### PR TITLE
Add source diagnostics, CSRF token classification, and diagnostics UI

### DIFF
--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -15,14 +15,16 @@ export async function GET() {
   try {
     antigravity = await getAntigravityStatus();
   } catch (e) {
-    antigravity = { discovered: false, error: e instanceof Error ? e.message : String(e) };
+    const message = e instanceof Error ? e.message : String(e);
+    antigravity = { discovered: false, attachMethod: "legacy_discovery", error: message, lastError: message };
   }
 
   let windsurf: SourcesStatus["windsurf"];
   try {
     windsurf = await getWindsurfStatus(config);
   } catch (e) {
-    windsurf = { attached: false, error: e instanceof Error ? e.message : String(e) };
+    const message = e instanceof Error ? e.message : String(e);
+    windsurf = { attached: false, attachMethod: "log", error: message, lastError: message };
   }
 
   const status: SourcesStatus = { antigravity, windsurf };

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -178,6 +178,60 @@ function StatusPill(props: { label: string; tone: "ok" | "warn" | "bad"; title?:
   );
 }
 
+function formatSourceDiagnostics(status: SourcesStatus): string {
+  const ag = status.antigravity;
+  const ws = status.windsurf;
+  return [
+    "Antigravity",
+    `- discovered: ${ag.discovered}`,
+    `- attachMethod: ${ag.attachMethod ?? "unknown"}`,
+    `- path: ${ag.discoveryPath ?? "n/a"}`,
+    `- pid: ${ag.pid ?? "n/a"} (alive=${ag.pidAlive ?? false})`,
+    `- ports: http=${ag.httpPort ?? "n/a"}, https=${ag.httpsPort ?? "n/a"}`,
+    `- csrf: present=${ag.csrfTokenPresent ?? false}, source=${ag.csrfTokenSource ?? "none"}, required=${ag.tokenRequired ?? "unknown"}`,
+    `- heartbeatOk: ${ag.heartbeatOk ?? "unknown"}`,
+    `- lastError: ${ag.lastError ?? "none"}`,
+    `- recommendedAction: ${ag.recommendedAction ?? "none"}`,
+    "",
+    "Windsurf",
+    `- attached: ${ws.attached}`,
+    `- attachMethod: ${ws.attachMethod ?? "unknown"}`,
+    `- path: ${ws.logPath ?? "n/a"}`,
+    `- pid: ${ws.pid ?? "n/a"} (alive=${ws.pidAlive ?? false})`,
+    `- port: ${ws.port ?? "n/a"}`,
+    `- csrf: present=${ws.csrfTokenPresent ?? false}, source=${ws.csrfTokenSource ?? "none"}, required=${ws.tokenRequired ?? "unknown"}`,
+    `- heartbeatOk: ${ws.heartbeatOk ?? "unknown"}`,
+    `- lastError: ${ws.lastError ?? "none"}`,
+    `- recommendedAction: ${ws.recommendedAction ?? "none"}`
+  ].join("\n");
+}
+
+function SourceDiagnosticsPanel({ status }: { status: SourcesStatus | null }) {
+  const [copied, setCopied] = useState(false);
+  if (!status) return null;
+  const text = formatSourceDiagnostics(status);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <details className="mb-3 rounded-xl border border-border/70 p-3 text-xs">
+      <summary className="cursor-pointer text-sm font-medium">Connection diagnostics details</summary>
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <div className="text-muted">Copyable evidence chain for attach diagnostics</div>
+        <Button type="button" variant="outline" size="sm" onClick={copy}>{copied ? "Copied" : "Copy diagnostics"}</Button>
+      </div>
+      <pre className="mt-2 max-w-full overflow-x-auto whitespace-pre-wrap rounded-lg border border-border/60 bg-background/10 p-2">{text}</pre>
+    </details>
+  );
+}
+
 const bubbleBase =
   "group relative rounded-2xl border px-3 py-2 text-sm leading-relaxed backdrop-blur-sm shadow-[0_1px_0_0_rgba(255,255,255,0.03)_inset,0_12px_36px_rgba(0,0,0,0.28)]";
 
@@ -1556,6 +1610,8 @@ export default function HomeClient() {
           </Button>
         </div>
       </div>
+
+      <SourceDiagnosticsPanel status={status} />
 
       <Card className="mb-3 p-3">
         <div className="flex flex-wrap items-center gap-2">

--- a/src/lib/parse/tokenSource.ts
+++ b/src/lib/parse/tokenSource.ts
@@ -1,0 +1,16 @@
+export type CsrfTokenSource = "ps_args" | "override" | "discovery_file" | "none";
+
+export function classifyCsrfTokenSource(params: {
+  tokenFromPs?: string | null;
+  overrideToken?: string | null;
+  discoveryToken?: string | null;
+}): { token: string | null; source: CsrfTokenSource } {
+  const tokenFromPs = params.tokenFromPs?.trim() || "";
+  const overrideToken = params.overrideToken?.trim() || "";
+  const discoveryToken = params.discoveryToken?.trim() || "";
+
+  if (tokenFromPs) return { token: tokenFromPs, source: "ps_args" };
+  if (overrideToken) return { token: overrideToken, source: "override" };
+  if (discoveryToken) return { token: discoveryToken, source: "discovery_file" };
+  return { token: null, source: "none" };
+}

--- a/src/lib/server/antigravity.ts
+++ b/src/lib/server/antigravity.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { extractCsrfTokenFromCommand } from "@/lib/parse/commandLine";
+import { classifyCsrfTokenSource } from "@/lib/parse/tokenSource";
 import { extractLatestAntigravityStartInfoFromLog } from "@/lib/parse/antigravityLog";
 import { normalizeAntigravityTrajectoryToEvents } from "@/lib/parse/antigravitySteps";
 import type { SourcesStatus } from "@/lib/types";
@@ -141,6 +142,8 @@ async function tryResolveAntigravityFromLogFile(logPath: string): Promise<{
   httpPort?: number;
   httpsPort?: number;
   csrfToken: string;
+  csrfTokenSource: "ps_args" | "none";
+  tokenRequired: boolean;
   baseUrl: string;
   dispatcher?: unknown;
   heartbeatOk: boolean;
@@ -152,41 +155,48 @@ async function tryResolveAntigravityFromLogFile(logPath: string): Promise<{
 
   const cmd = await readProcessCommandLine(startInfo.pid);
   const tokenFromPs = cmd ? extractCsrfTokenFromCommand(cmd) : null;
-  const csrfToken = tokenFromPs ?? "";
+  const tokenInfo = classifyCsrfTokenSource({ tokenFromPs });
+  const csrfToken = tokenInfo.token ?? "";
 
   const httpBaseUrl = startInfo.httpPort ? `http://127.0.0.1:${startInfo.httpPort}` : null;
   const httpsBaseUrl = startInfo.httpsPort ? `https://127.0.0.1:${startInfo.httpsPort}` : null;
 
   // Prefer HTTP to avoid TLS complexity.
   if (httpBaseUrl) {
-    const ok =
-      (csrfToken ? await probeAntigravityHeartbeat({ baseUrl: httpBaseUrl, csrfToken }) : false) ||
-      (await probeAntigravityHeartbeat({ baseUrl: httpBaseUrl }));
+    const okWithToken = csrfToken ? await probeAntigravityHeartbeat({ baseUrl: httpBaseUrl, csrfToken }) : false;
+    const okWithoutToken = await probeAntigravityHeartbeat({ baseUrl: httpBaseUrl });
+    const heartbeatOk = okWithToken || okWithoutToken;
     return {
       logPath,
       pid: startInfo.pid,
       httpPort: startInfo.httpPort,
       httpsPort: startInfo.httpsPort,
       csrfToken,
+      csrfTokenSource: tokenInfo.source === "ps_args" ? "ps_args" : "none",
+      tokenRequired: heartbeatOk ? !okWithoutToken : !csrfToken,
       baseUrl: httpBaseUrl,
-      heartbeatOk: ok
+      heartbeatOk
     };
   }
 
   if (httpsBaseUrl) {
     const dispatcher = await getInsecureLocalhostDispatcher();
-    const ok =
-      (csrfToken ? await probeAntigravityHeartbeat({ baseUrl: httpsBaseUrl, csrfToken, dispatcher: dispatcher ?? undefined }) : false) ||
-      (await probeAntigravityHeartbeat({ baseUrl: httpsBaseUrl, dispatcher: dispatcher ?? undefined }));
+    const okWithToken = csrfToken
+      ? await probeAntigravityHeartbeat({ baseUrl: httpsBaseUrl, csrfToken, dispatcher: dispatcher ?? undefined })
+      : false;
+    const okWithoutToken = await probeAntigravityHeartbeat({ baseUrl: httpsBaseUrl, dispatcher: dispatcher ?? undefined });
+    const heartbeatOk = okWithToken || okWithoutToken;
     return {
       logPath,
       pid: startInfo.pid,
       httpPort: startInfo.httpPort,
       httpsPort: startInfo.httpsPort,
       csrfToken,
+      csrfTokenSource: tokenInfo.source === "ps_args" ? "ps_args" : "none",
+      tokenRequired: heartbeatOk ? !okWithoutToken : !csrfToken,
       baseUrl: httpsBaseUrl,
       dispatcher: dispatcher ?? undefined,
-      heartbeatOk: ok
+      heartbeatOk
     };
   }
 
@@ -251,18 +261,32 @@ export async function getAntigravityStatus(): Promise<SourcesStatus["antigravity
     | Awaited<ReturnType<typeof tryResolveAntigravityFromLogFile>>
     | null = null;
   let bestLogError: string | undefined;
+  let bestLogPid: number | undefined;
+  let bestLogPidAlive = false;
 
   for (const c of logCandidates) {
     try {
+      const logText = await fs.readFile(c.p, "utf-8").catch(() => "");
+      const startInfo = extractLatestAntigravityStartInfoFromLog(logText);
+      if (startInfo) {
+        bestLogPid = startInfo.pid;
+        bestLogPidAlive = isProcessAlive(startInfo.pid);
+      }
       const res = await tryResolveAntigravityFromLogFile(c.p);
       if (!bestLogResult) bestLogResult = res;
       if (res.heartbeatOk) {
         return {
           discovered: true,
+          attachMethod: "log",
           discoveryPath: res.logPath,
+          pid: res.pid,
+          pidAlive: true,
           httpPort: res.httpPort,
           httpsPort: res.httpsPort,
           csrfTokenPresent: Boolean(res.csrfToken),
+          csrfTokenSource: res.csrfTokenSource,
+          tokenRequired: res.tokenRequired,
+          heartbeatOk: true,
           reachable: true
         };
       }
@@ -271,32 +295,51 @@ export async function getAntigravityStatus(): Promise<SourcesStatus["antigravity
     }
   }
 
-  if (bestLogResult) {
-    const tokenHint = bestLogResult.csrfToken
+  if (bestLogResult || logCandidates.length > 0) {
+    const recommendedAction = !bestLogPidAlive
+      ? "Keep Antigravity open and start a session to relaunch the language server."
+      : "Keep Antigravity running and start/restart a session, then refresh.";
+    const tokenHint = bestLogResult?.csrfToken
       ? "Token present but Heartbeat failed."
-      : "Missing CSRF token or Heartbeat failed. Ensure we can read LS process args; if not, we may need a token override.";
+      : "Token missing from process args (or Heartbeat failed).";
     return {
       discovered: true,
-      discoveryPath: bestLogResult.logPath,
-      httpPort: bestLogResult.httpPort,
-      httpsPort: bestLogResult.httpsPort,
-      csrfTokenPresent: Boolean(bestLogResult.csrfToken),
+      attachMethod: "log",
+      discoveryPath: bestLogResult?.logPath ?? logCandidates[0]?.p,
+      pid: bestLogResult?.pid ?? bestLogPid,
+      pidAlive: bestLogPidAlive,
+      httpPort: bestLogResult?.httpPort,
+      httpsPort: bestLogResult?.httpsPort,
+      csrfTokenPresent: Boolean(bestLogResult?.csrfToken),
+      csrfTokenSource: bestLogResult?.csrfTokenSource ?? "none",
+      tokenRequired: bestLogResult?.tokenRequired ?? true,
+      heartbeatOk: false,
       reachable: false,
-      error: `${tokenHint}${bestLogError ? ` (${bestLogError})` : ""}`
+      recommendedAction,
+      lastError: bestLogError,
+      error: `${tokenHint} ${recommendedAction}${bestLogError ? ` (${bestLogError})` : ""}`
     };
   }
 
   // Fallback to legacy discovery file mechanism.
   const found = await findLatestAntigravityDiscovery();
-  if (!found) return { discovered: false, error: "No Antigravity log or discovery file found." };
+  if (!found) {
+    const recommendedAction = "Open Antigravity and start a session so logs/discovery are generated.";
+    return {
+      discovered: false,
+      attachMethod: "legacy_discovery",
+      csrfTokenSource: "none",
+      recommendedAction,
+      lastError: "No Antigravity log or discovery file found.",
+      error: `No Antigravity log or discovery file found. ${recommendedAction}`
+    };
+  }
 
   const { discoveryPath, discovery } = found;
   const httpBaseUrl = discovery.httpPort ? `http://127.0.0.1:${discovery.httpPort}` : null;
   const httpsBaseUrl = discovery.httpsPort ? `https://127.0.0.1:${discovery.httpsPort}` : null;
 
   let reachable = false;
-  let lastError: string | undefined;
-
   if (httpBaseUrl) reachable = await probeAntigravityHeartbeat({ baseUrl: httpBaseUrl, csrfToken: discovery.csrfToken });
   if (!reachable && httpsBaseUrl) {
     const dispatcher = await getInsecureLocalhostDispatcher();
@@ -307,20 +350,34 @@ export async function getAntigravityStatus(): Promise<SourcesStatus["antigravity
     });
   }
 
+  const pidAlive = isProcessAlive(discovery.pid);
+  const tokenRequired = reachable ? Boolean(discovery.csrfToken) : true;
+  const recommendedAction = !pidAlive
+    ? "Keep Antigravity open and start a session to relaunch the language server."
+    : "Keep Antigravity running and start/restart a session, then refresh.";
+
+  let lastError: string | undefined;
   if (!reachable) {
-    lastError = !isProcessAlive(discovery.pid)
-      ? "Antigravity discovery is stale (language server pid not running). Keep Antigravity open and start a session to relaunch the daemon."
+    lastError = !pidAlive
+      ? "Antigravity discovery is stale (language server pid not running)."
       : "Antigravity discovery found but language server not reachable.";
   }
 
   return {
     discovered: true,
+    attachMethod: "legacy_discovery",
     discoveryPath,
+    pid: discovery.pid,
+    pidAlive,
     httpPort: discovery.httpPort,
     httpsPort: discovery.httpsPort,
     csrfTokenPresent: Boolean(discovery.csrfToken),
+    csrfTokenSource: classifyCsrfTokenSource({ discoveryToken: discovery.csrfToken }).source,
+    tokenRequired,
+    heartbeatOk: reachable,
     reachable,
-    ...(lastError ? { error: lastError } : {})
+    recommendedAction,
+    ...(lastError ? { lastError, error: `${lastError} ${recommendedAction}` } : {})
   };
 }
 

--- a/src/lib/server/windsurf.ts
+++ b/src/lib/server/windsurf.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 
 import type { AppConfig, ChatMessage, SourcesStatus, TrajectoryEvent, TrajectorySummary } from "@/lib/types";
 import { extractCsrfTokenFromCommand } from "@/lib/parse/commandLine";
+import { classifyCsrfTokenSource } from "@/lib/parse/tokenSource";
 import { summarizeTrajectoryEvents } from "@/lib/parse/trajectory";
 import { extractLatestWindsurfStartInfoFromLog } from "@/lib/parse/windsurfLog";
 import { normalizeWindsurfStepsToMessages, normalizeWindsurfStepsToTrajectoryEvents } from "@/lib/parse/windsurfSteps";
@@ -160,46 +161,98 @@ async function resolveWindsurfConnection(config: AppConfig): Promise<WindsurfCon
 export async function getWindsurfStatus(config: AppConfig): Promise<SourcesStatus["windsurf"]> {
   const logPath = await findLatestWindsurfLogFile();
   if (!logPath) {
-    return { attached: false, error: "Windsurf log not found. Open Windsurf and start a Cascade session." };
+    const recommendedAction = "Open Windsurf and start a Cascade session.";
+    return {
+      attached: false,
+      attachMethod: "log",
+      csrfTokenSource: "none",
+      recommendedAction,
+      lastError: "Windsurf log not found.",
+      error: `Windsurf log not found. ${recommendedAction}`
+    };
   }
 
   const logText = await fs.readFile(logPath, "utf-8").catch(() => "");
   const startInfo = extractLatestWindsurfStartInfoFromLog(logText);
   if (!startInfo) {
-    return { attached: false, logPath, error: "Failed to parse pid/port from Windsurf.log." };
-  }
-  if (!isProcessAlive(startInfo.pid)) {
+    const recommendedAction = "Start a Cascade session in Windsurf so pid/port are logged.";
     return {
       attached: false,
+      attachMethod: "log",
+      logPath,
+      csrfTokenSource: "none",
+      recommendedAction,
+      lastError: "Failed to parse pid/port from Windsurf.log.",
+      error: `Failed to parse pid/port from Windsurf.log. ${recommendedAction}`
+    };
+  }
+
+  const pidAlive = isProcessAlive(startInfo.pid);
+  if (!pidAlive) {
+    const recommendedAction = "Keep Windsurf open and start a Cascade session to relaunch the language server.";
+    return {
+      attached: false,
+      attachMethod: "log",
       logPath,
       pid: startInfo.pid,
+      pidAlive,
       port: startInfo.port,
-      error: "Windsurf language server is not running. Keep Windsurf open and start a Cascade session."
+      csrfTokenSource: "none",
+      recommendedAction,
+      lastError: "Windsurf language server is not running.",
+      error: `Windsurf language server is not running. ${recommendedAction}`
     };
   }
 
   const cmd = await readProcessCommandLine(startInfo.pid);
   const tokenFromPs = cmd ? extractCsrfTokenFromCommand(cmd) : null;
-  const csrfToken = tokenFromPs ?? (config.windsurf.csrfTokenOverride?.trim() || null);
-  let attached = Boolean(startInfo.port) && Boolean(csrfToken);
-  let error: string | undefined;
+  const overrideToken = config.windsurf.csrfTokenOverride?.trim() || null;
+  const tokenInfo = classifyCsrfTokenSource({ tokenFromPs, overrideToken });
+  const csrfToken = tokenInfo.token;
+  const csrfTokenSource = tokenInfo.source === "discovery_file" ? "none" : tokenInfo.source;
 
-  if (!csrfToken) {
-    const baseUrl = `http://127.0.0.1:${startInfo.port}`;
-    const ok = await probeWindsurfHeartbeat({ baseUrl });
-    attached = ok;
-    error = ok
-      ? "Attached without CSRF token (probe succeeded). Some environments may require a token; set override if RPC fails."
-      : "Missing Windsurf CSRF token. Keep Windsurf running and ensure we can read the LS process args, or set a token override in Settings.";
+  const baseUrl = `http://127.0.0.1:${startInfo.port}`;
+  let heartbeatWithToken = false;
+  let heartbeatWithoutToken = false;
+
+  if (csrfToken) heartbeatWithToken = await probeWindsurfHeartbeat({ baseUrl, csrfToken });
+  heartbeatWithoutToken = await probeWindsurfHeartbeat({ baseUrl });
+
+  const heartbeatOk = heartbeatWithToken || heartbeatWithoutToken;
+  const attached = heartbeatOk;
+  const tokenRequired = heartbeatOk ? !heartbeatWithoutToken : !csrfToken;
+
+  let lastError: string | undefined;
+  if (!attached) {
+    lastError = csrfToken
+      ? "Windsurf heartbeat probe failed with and without CSRF token."
+      : "Missing Windsurf CSRF token and heartbeat probe failed without token.";
   }
+
+  const recommendedAction = attached
+    ? "Connection healthy."
+    : tokenRequired
+      ? "Set Windsurf CSRF token override in Settings if process args are unreadable."
+      : "Keep Windsurf open and start/restart a Cascade session, then refresh.";
 
   return {
     attached,
+    attachMethod: "log",
     logPath,
     pid: startInfo.pid,
+    pidAlive,
     port: startInfo.port,
     csrfTokenPresent: Boolean(csrfToken),
-    ...(error ? { error } : {})
+    csrfTokenSource,
+    tokenRequired,
+    heartbeatOk,
+    recommendedAction,
+    ...(lastError
+      ? {
+          lastError,
+          error: `${lastError} ${recommendedAction}`
+        }
+      : {})
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,19 +36,34 @@ export type ConversationListItem = ConversationFile & {
 export type SourcesStatus = {
   antigravity: {
     discovered: boolean;
+    attachMethod?: "log" | "legacy_discovery";
     discoveryPath?: string;
+    pid?: number;
+    pidAlive?: boolean;
     httpPort?: number;
     httpsPort?: number;
     csrfTokenPresent?: boolean;
+    csrfTokenSource?: "ps_args" | "override" | "discovery_file" | "none";
+    tokenRequired?: boolean;
+    heartbeatOk?: boolean;
+    lastError?: string;
+    recommendedAction?: string;
     reachable?: boolean;
     error?: string;
   };
   windsurf: {
     attached: boolean;
+    attachMethod?: "log";
     logPath?: string;
     pid?: number;
+    pidAlive?: boolean;
     port?: number;
     csrfTokenPresent?: boolean;
+    csrfTokenSource?: "ps_args" | "override" | "none";
+    tokenRequired?: boolean;
+    heartbeatOk?: boolean;
+    lastError?: string;
+    recommendedAction?: string;
     error?: string;
   };
 };

--- a/tests/tokenSource.test.ts
+++ b/tests/tokenSource.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyCsrfTokenSource } from "../src/lib/parse/tokenSource";
+
+describe("classifyCsrfTokenSource", () => {
+  it("prefers process args token", () => {
+    expect(
+      classifyCsrfTokenSource({
+        tokenFromPs: "ps-token",
+        overrideToken: "override-token",
+        discoveryToken: "discovery-token"
+      })
+    ).toEqual({ token: "ps-token", source: "ps_args" });
+  });
+
+  it("falls back to override token", () => {
+    expect(
+      classifyCsrfTokenSource({
+        tokenFromPs: null,
+        overrideToken: "override-token",
+        discoveryToken: "discovery-token"
+      })
+    ).toEqual({ token: "override-token", source: "override" });
+  });
+
+  it("falls back to discovery token", () => {
+    expect(
+      classifyCsrfTokenSource({
+        tokenFromPs: null,
+        overrideToken: "",
+        discoveryToken: "discovery-token"
+      })
+    ).toEqual({ token: "discovery-token", source: "discovery_file" });
+  });
+
+  it("returns none when no token exists", () => {
+    expect(classifyCsrfTokenSource({ tokenFromPs: "", overrideToken: "", discoveryToken: null })).toEqual({
+      token: null,
+      source: "none"
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve diagnostics and UX for discovering/attaching to local language servers (Antigravity/Windsurf) by surfacing richer metadata and actionable recommendations.
- Make CSRF token origin detection explicit so attach logic and messaging can handle process args, overrides, and discovery files consistently.
- Provide an easy copyable diagnostics panel in the UI for debugging attach/connection issues.

### Description

- Add a new `classifyCsrfTokenSource` helper in `src/lib/parse/tokenSource.ts` to determine token origin (`ps_args`/`override`/`discovery_file`/`none`).
- Enhance Antigravity and Windsurf server code (`src/lib/server/antigravity.ts`, `src/lib/server/windsurf.ts`) to probe heartbeat with and without CSRF tokens, compute `tokenRequired`, `heartbeatOk`, `csrfTokenSource`, and surface `attachMethod`, `pid`, `pidAlive`, `recommendedAction`, and `lastError` where relevant.
- Expand the `SourcesStatus` type in `src/lib/types.ts` to include the new diagnostic fields and token source enums.
- Update the API route `src/app/api/sources/route.ts` to return the richer error/status payloads even on exceptions.
- Add a frontend diagnostics panel and formatting in `src/components/HomeClient.tsx` (`formatSourceDiagnostics` and `SourceDiagnosticsPanel`) with a copy-to-clipboard button and inline presentation of the collected diagnostics.
- Add unit tests for the token classifier at `tests/tokenSource.test.ts`.

### Testing

- Ran unit tests with `vitest` for `tests/tokenSource.test.ts`, and they passed.
- Exercised the modified status endpoints and UI locally to verify the new diagnostics render and the copy button copies the formatted diagnostics string (manual verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72ac9d0d0832a959e45e0400dffd7)