### PR TITLE
feat: add project shell foundation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Copilot Review Instructions
+
+This repository is a local-first agent session and context management app.
+
+When reviewing pull requests, prioritize concrete regressions over style-only feedback:
+
+- Preserve the local-first model. Do not suggest cloud dependencies for core session reading, backup, or migration behavior.
+- Preserve existing session viewer behavior unless an active OpenSpec change explicitly changes it.
+- Treat `openspec/changes/` artifacts as normative for active changes and `openspec/specs/` as normative for accepted behavior.
+- For app shell or navigation work, verify URL deep links, global search session selection, source diagnostics, viewer modes, inspector/error center, and session backup behavior remain intact.
+- For session backup work, distinguish session source files, trajectories, transcripts, backup records, and backup bundles. Do not conflate these terms.
+- Do not ask placeholders to implement full future behavior unless the active spec requires it.
+- Treat product names and exploratory marketing terms as intentional unless they are inconsistent within the same pull request.
+- Call out state races, data-loss risk, security/privacy risk, missing tests, broken user flows, and stale documentation.
+- Prefer actionable comments with a specific failure mode, expected behavior, and suggested validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,14 @@ Do not duplicate the same fact across these files unless each copy serves a diff
 - Run targeted tests for the code you change when feasible.
 - If you touch parsing, attach, normalization, or diagnostics logic, prefer adding or updating unit tests in the same area.
 
+## PR Review Workflow
+
+- For PR review triage and agent-assisted fixes, follow `docs/dev/pr-review-agent-workflow.md`.
+- Treat Copilot review comments as advisory input, not merge-blocking approval or requested changes.
+- Classify review feedback before editing: `must-fix`, `should-fix`, `product-decision`, or `ignore`.
+- Do not automatically change product names, scope boundaries, or placeholder commitments without user confirmation.
+- After pushing review fixes, request Copilot re-review manually or with `gh` when available; do not assume Copilot re-reviews automatically after new commits.
+
 ## Before Ending a Session
 
 When wrapping up work, verify documentation is current.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-04-11` — Project shell foundation
+  - Added a project-first shell with `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration` surfaces
+  - Preserved the existing session viewer under `Sessions`, including source diagnostics, URL deep links, search selection, and direct session backup
+  - Added bounded foundation placeholders for future asset, analysis, backup, and migration work without claiming unavailable inventory or analysis behavior
+
 - `2026-04-10` — Session Backup foundation
   - Added canonical `session-record/v1` and `session-backup/v1` schemas plus managed backup storage under `~/.agent-storage-manager/backups`
   - Added create/import/verify APIs for session backups, with schema/integrity validation and stable user-facing diagnostics

--- a/docs/design-system-baseline.md
+++ b/docs/design-system-baseline.md
@@ -1,0 +1,744 @@
+# Design System Baseline
+
+Updated: 2026-04-11
+
+This document defines the lightweight design-system baseline for the next phase
+of `agent-storage-manager`.
+
+It turns the approved visual direction into reusable design rules. It is not a
+complete component library, CSS token spec, implementation plan, or final brand
+identity.
+
+Primary references:
+
+- [visual-direction.md](./visual-direction.md)
+- [product-positioning-and-ia.md](./product-positioning-and-ia.md)
+- [content-contract-draft.md](./content-contract-draft.md)
+- [routed-context-handoff.md](./routed-context-handoff.md)
+- [cue-lifecycle-rules.md](./cue-lifecycle-rules.md)
+- [module-interaction-rules.md](./module-interaction-rules.md)
+- [glossary.md](./glossary.md)
+
+Figma reference:
+
+- [Agent Context Steward Low-Fi v1](https://www.figma.com/design/EWdC4ItqkJwd5NsOQBsI64)
+
+## 1. Status
+
+The approved visual baseline is:
+
+- base direction: `Steward Map`
+- supporting language: `Evidence Ledger`
+- avoided primary direction: `Workbench Console`
+
+This baseline exists to prevent the next phase from drifting into isolated
+screen design or premature implementation.
+
+Use it before:
+
+- producing additional high-fi pages
+- generating Figma Make prompts
+- proposing UI implementation tasks
+- creating production tokens or component APIs
+
+## 2. Product Principles
+
+### 2.1 Project-First
+
+The product's primary subject is the project.
+
+Design implication:
+
+- global page shells should orient around project identity, context health,
+  source presence, and routeable work
+- `Sessions`, `Assets`, `Analysis`, and `Backup / Migration` should feel like
+  project sub-areas, not separate products
+
+Avoid:
+
+- making the session transcript layout the default homepage pattern
+- treating backup or migration as the product's top-level subject
+
+### 2.2 Local-First
+
+The product should feel like a local developer tool that understands local
+agent context.
+
+Design implication:
+
+- source roots, local scope, provenance, and runtime attachment should be
+  visible where they affect trust or action
+- cloud or team collaboration patterns should not dominate the default UI
+
+Avoid:
+
+- cloud console aesthetics
+- enterprise admin dashboard patterns
+- collaboration-first cues unless a future feature explicitly requires them
+
+### 2.3 Context Governance
+
+The product is about understanding, governing, and migrating project-scoped
+agent context.
+
+Design implication:
+
+- cues, provenance, route targets, and validation state are first-class
+  interface concepts
+- object meaning should appear before actions
+- workflow actions should be bounded by selection, validation, and result
+
+Avoid:
+
+- generic command palettes as the main product surface
+- action-heavy pages without context or provenance
+- visual treatments that make all modules appear equally important
+
+## 3. Foundations
+
+### 3.1 Typography
+
+Typography should separate three jobs:
+
+- governance and page orientation
+- object and evidence reading
+- metadata and provenance
+
+Recommended roles:
+
+- `Display / Page Title`
+  - purpose: page subject and state framing
+  - tone: calm, confident, not marketing-heavy
+- `Section Heading`
+  - purpose: module identity and reading order
+  - tone: precise, structural
+- `Body`
+  - purpose: explanatory copy and object descriptions
+  - tone: readable, restrained
+- `Metadata Mono`
+  - purpose: scope, source, route, provenance, validation, and package facts
+  - tone: inspectable, technical, compact
+
+Rules:
+
+- use the mono role for facts, not paragraphs
+- avoid oversized dashboard numerals as the primary visual device
+- avoid terminal-style typography across the full page
+- keep status labels short enough to scan
+
+Implementation note:
+
+- final font families are not fixed here
+- future implementation should choose local or web-safe fonts only after
+  checking repository constraints and bundle impact
+
+### 3.2 Color Roles
+
+This baseline defines color roles, not exact token values.
+
+Required roles:
+
+- `background.base`
+  - quiet page foundation
+- `background.map`
+  - subtle project grid or route field
+- `surface.primary`
+  - main task region
+- `surface.secondary`
+  - supporting panels
+- `surface.ledger`
+  - provenance, validation, and audit blocks
+- `text.primary`
+  - main readable text
+- `text.secondary`
+  - supporting descriptions
+- `text.metadata`
+  - mono metadata labels
+- `border.structure`
+  - module and grid structure
+- `accent.route`
+  - active handoff or route continuity
+- `accent.provenance`
+  - source and trust information
+- `status.warning`
+  - non-blocking but important condition
+- `status.blocking`
+  - blocking or error condition
+- `status.pass`
+  - validation pass or safe state
+- `status.result`
+  - produced workflow output
+
+Rules:
+
+- status colors should be semantic and sparse
+- route and provenance colors should remain distinct
+- warning should be visible but not permanently alarming
+- blocking should be strong enough for action
+- success should support confidence without celebration
+
+Avoid:
+
+- default purple SaaS palette
+- full-page terminal green
+- using the same accent for route, provenance, and warning
+
+### 3.3 Spacing And Density
+
+The interface may be dense, but density must communicate priority.
+
+Density is acceptable in:
+
+- session evidence
+- asset metadata
+- provenance blocks
+- validation panels
+- route context
+
+Density should be constrained in:
+
+- `Project Overview`
+- quick actions
+- recent sessions
+- recent operations
+- completion cues
+
+Rules:
+
+- primary task areas can be tall and information-rich
+- secondary strips should stay compact
+- object details should section long content before they overflow
+- usage and object meaning should remain separate layers
+
+Avoid:
+
+- expanding secondary modules into full tables
+- hiding unresolved IA inside dense panels
+- making all panels equal height and weight by default
+
+### 3.4 Shape And Surface
+
+Surface hierarchy should clarify page role.
+
+Recommended surface types:
+
+- `Map Field`
+  - subtle project or route background
+  - useful for `Project Overview`, handoff, and workflow context
+- `Governance Panel`
+  - summary, routing, and attention surfaces
+  - useful for overview and analysis
+- `Ledger Panel`
+  - provenance, validation, source, and trust surfaces
+  - useful for assets and backup / migration
+- `Workbench Panel`
+  - evidence-reading surfaces
+  - useful for sessions only
+- `Workflow Panel`
+  - active workflow step, validation, result
+  - useful for backup / migration
+- `Compact Strip`
+  - origin cue, return cue, recent operations, completion cue
+
+Rules:
+
+- primary surface type should match the page role
+- ledger panels should not become generic cards
+- compact strips should not expand into hidden dashboards
+- workbench panels should not become the product-wide default
+
+## 4. Core Patterns
+
+### 4.1 Page Shell
+
+The page shell establishes the project-first frame.
+
+Must include:
+
+- project identity
+- top-level navigation
+- global search entry
+- source or attachment presence where relevant
+
+Should include:
+
+- compact active route or workflow cue when the page was entered through a
+  task-oriented handoff
+- page-level state only when it changes the user's next action
+
+Must not include:
+
+- detailed workflow internals on `Project Overview`
+- session transcript controls outside `Sessions`
+- operation history as a global primary element
+
+### 4.2 Top Navigation
+
+Top navigation should preserve the approved IA:
+
+- `Project Overview`
+- `Sessions`
+- `Assets`
+- `Analysis`
+- `Backup / Migration`
+
+Rules:
+
+- active page state should be clear but not oversized
+- labels should remain stable across pages
+- page-specific controls belong below the shell, not inside global navigation
+
+Avoid:
+
+- promoting asset subtypes to global nav
+- making `Global Assets` a top-level item
+- hiding `Backup / Migration` behind a generic tools label
+
+### 4.3 Route And Origin Cues
+
+Route and origin cues preserve task continuity.
+
+Required cue variants:
+
+- `Origin Cue`
+- `Continue Task Cue`
+- `Return To Origin Cue`
+- `Routed Object Cue`
+- `Workflow Entry Cue`
+
+Rules:
+
+- object-local routes use compact cues
+- page-defining issue or workflow routes may use stronger strips
+- return cues remain visible only while returning still helps
+- cues downgrade or disappear when the user changes task focus
+
+Placement:
+
+- page header for route reason
+- near selected object for object-local context
+- inside workflow body for workflow-critical state
+
+Avoid:
+
+- keeping stale origin cues during ordinary browsing
+- moving route meaning into an inspector only
+- using large banners for every route
+
+### 4.4 Metadata Labels
+
+Metadata labels make context assets inspectable.
+
+Common metadata:
+
+- scope
+- source
+- status
+- subtype
+- provenance
+- route
+- source root
+- session linkage
+- validation state
+- package or workflow id
+
+Rules:
+
+- metadata should be compact and scan-friendly
+- mono treatment is appropriate for stable factual labels
+- labels should carry meaning, not decoration
+
+Avoid:
+
+- long paragraphs in metadata style
+- duplicating the same fact in multiple adjacent panels
+- hiding trust-critical metadata behind hover-only UI
+
+### 4.5 Object Detail
+
+Object detail explains what the selected object is.
+
+Must answer:
+
+- object identity
+- subtype
+- scope
+- source
+- status
+- provenance or trust signal
+
+For session-derived assets, must also show:
+
+- origin session or session record
+- linkage state
+- whether provenance is retained
+
+Must not answer:
+
+- full project-wide issue interpretation
+- workflow execution state
+- unrelated object history
+
+Rules:
+
+- object meaning appears before object action
+- provenance belongs in object detail when trust affects reuse
+- usage belongs in a second layer after object meaning
+
+### 4.6 In-Effect / Usage
+
+`In-Effect / Usage` explains how an asset matters in the project.
+
+Must answer:
+
+- whether the asset is in effect
+- where it applies
+- what project behavior or workflow it affects
+- whether scope or override changes the result
+
+Rules:
+
+- it should read after object detail
+- it should not merge into provenance
+- it should not become an actions area
+
+Avoid:
+
+- placing in-effect state only in table rows
+- treating usage as a generic notes panel
+- making actions visually stronger than usage
+
+### 4.7 Workflow Bar
+
+The workflow bar preserves workflow-first behavior.
+
+Required structure for dense workflows:
+
+- line 1: workflow family
+- line 2: active workflow and current step
+
+Rules:
+
+- the bar identifies workflow context; it does not execute the workflow
+- workflow actions should live in the body near evidence and validation
+- workflow tabs are not a generic tools drawer
+
+Avoid:
+
+- putting primary CTAs in the workflow selector line
+- making operation history compete with active workflow
+- hiding current step in body-only text
+
+### 4.8 Validation Panel
+
+Validation panel is the decision surface for risky or portable operations.
+
+Must include:
+
+- validation state
+- warning state when present
+- blocking checks when present
+- follow-up actions
+- route targets when repair requires another page
+
+Rules:
+
+- warning and blocking information stays inside the validation body
+- primary CTA stays near the validation evidence
+- pass state should be clear but not dominant over warnings
+
+Avoid:
+
+- floating validation banners detached from workflow context
+- distributing CTA across header, bar, and history
+- turning validation into settings-style form layout
+
+### 4.9 Recent Operations
+
+Recent operations are secondary.
+
+Use as:
+
+- compact strip
+- low-priority history affordance
+- quick confirmation that recent activity exists
+
+Do not use as:
+
+- primary dashboard
+- workflow result substitute
+- operation management center
+
+Rules:
+
+- result state owns result detail
+- recent operations should not grow into a list by default
+- history can be expanded later only through an explicit secondary view
+
+### 4.10 Session Evidence Workbench
+
+`Sessions` may use more technical workbench texture than other pages.
+
+Allowed:
+
+- transcript / trajectory / markdown projection controls
+- event anchors
+- error center
+- source-aware session list
+- inspector for selected message or event
+
+Rules:
+
+- the page remains evidence-first
+- outbound actions are downstream from selected evidence
+- `Error Center` is about evidence inside sessions, not grouped project analysis
+
+Avoid:
+
+- making `Sessions` look like the whole product
+- making transcript controls appear in global shell
+- turning `Session Actions` into workflow steps
+
+## 5. Page Baselines
+
+### 5.1 `Project Overview`
+
+Primary visual mode:
+
+- `Steward Map`
+
+Required patterns:
+
+- page shell
+- attention surface
+- compact quick actions
+- secondary recent sessions
+- governance panels
+- route cues
+
+Must preserve:
+
+- summary and routing
+- project-first subject
+- issue-heavy attention center
+
+Must avoid:
+
+- findings workbench
+- session inventory
+- workflow execution surface
+
+### 5.2 `Assets`
+
+Primary visual mode:
+
+- `Steward Map` plus `Evidence Ledger`
+
+Required patterns:
+
+- subtype and scope control
+- asset inventory
+- object detail
+- provenance block
+- session linkage block
+- in-effect / usage layer
+- secondary asset actions
+
+Must preserve:
+
+- object-first understanding
+- visible provenance
+- usage after object meaning
+
+Must avoid:
+
+- generic admin table
+- hidden provenance
+- session replay surface
+- action-first layout
+
+### 5.3 `Backup / Migration`
+
+Primary visual mode:
+
+- workflow-first `Steward Map`
+
+Required patterns:
+
+- two-line workflow bar
+- workflow context summary
+- workflow steps
+- validation panel
+- result panel
+- compact recent operations
+
+Must preserve:
+
+- bounded operation
+- validation before execution
+- result inspection
+
+Must avoid:
+
+- tools drawer
+- settings page
+- operation history dashboard
+
+### 5.4 `Sessions`
+
+Primary visual mode:
+
+- evidence workbench inside `Steward Map` frame
+
+Required patterns:
+
+- session source bar
+- session list
+- session view
+- projection controls
+- optional error center
+- optional inspector
+- bounded session actions
+
+Must preserve:
+
+- readable evidence
+- source-aware diagnosis
+- session-specific action
+
+Must avoid:
+
+- becoming the homepage
+- hiding route reason in inspector
+- turning actions into workflow steps
+
+### 5.5 `Analysis`
+
+Primary visual mode:
+
+- interpretation surface inside `Steward Map` frame
+
+Required patterns:
+
+- context health summary
+- findings table
+- finding detail
+- recommended actions
+- route-to-action cues
+
+Must preserve:
+
+- problem explanation
+- action routing
+- selected finding continuity
+
+Must avoid:
+
+- asset inventory duplication
+- correction workflow body
+- passive findings warehouse
+
+## 6. State Baselines
+
+### 6.1 Normal
+
+Normal state should show the page's default role without route or issue
+overweight.
+
+Rules:
+
+- keep summary clear
+- keep primary module discoverable
+- keep secondary regions compact
+
+### 6.2 Routed-In
+
+Routed-in state should preserve why the user landed on the page.
+
+Rules:
+
+- show origin cue
+- preserve selected object or issue class
+- preserve return path while useful
+- avoid restating the source page
+
+### 6.3 Issue-Heavy
+
+Issue-heavy state should elevate the module responsible for action routing.
+
+Rules:
+
+- `Project Overview` elevates `Attention Needed`
+- `Sessions` elevates session-local failure evidence
+- `Analysis` elevates selected finding and recommended actions
+- `Assets` stays object-first unless the issue is object-local
+
+### 6.4 Workflow Validation
+
+Workflow validation state should center the validation decision.
+
+Rules:
+
+- workflow identity stays visible
+- validation evidence stays in the body
+- CTA stays near validation evidence
+- recent operations stay secondary
+
+### 6.5 Result
+
+Result state should center the produced output.
+
+Rules:
+
+- result panel is primary
+- completion cue is compact
+- warning remains near result if it affects trust
+- recent operations remain low-priority
+
+## 7. Implementation Readiness Boundary
+
+This baseline is enough to start planning implementation only after one more
+translation step:
+
+- map baseline patterns to existing app structure and current components
+- identify which UI can be migrated safely without breaking current session
+  viewer functionality
+- decide whether to implement a new shell first or page-by-page behind the
+  existing product
+
+This baseline is not enough to immediately implement:
+
+- a complete redesign
+- a reusable component library
+- finalized CSS tokens
+- responsive behavior
+- full page migration
+
+## 8. Open Design Risks
+
+The main open risks are:
+
+- real asset copy may exceed right detail capacity
+- validation panels may need grouping for multiple warnings or blockers
+- `Sessions` may require stronger workbench texture without pulling the whole
+  product back to session-first
+- responsive behavior has not been explored
+- final public naming is unresolved
+- existing UI migration strategy is not yet defined
+
+## 9. Recommended Next Step
+
+Recommended next step:
+
+- create an implementation-readiness review for migrating from current UI to
+  this baseline
+
+That review should answer:
+
+- which current UI elements can be preserved
+- which current UI elements should move into `Sessions`
+- which new shell or layout primitives are required
+- which page should be implemented first
+- what should remain behind Figma-only exploration for now
+
+Do not begin broad UI implementation before that review exists.

--- a/docs/dev/pr-review-agent-workflow.md
+++ b/docs/dev/pr-review-agent-workflow.md
@@ -67,6 +67,68 @@ CLI fallback:
 
 Codex should not mark GitHub conversations resolved or submit replies unless explicitly asked.
 
+## Resolving Conversations
+
+`Resolve conversation` marks a GitHub review thread as handled. It does not change code, approve a pull request, or prove that validation passed. It is a collaboration-state update that changes what reviewers see as still needing attention.
+
+Codex may recommend resolving a thread when:
+
+- the comment was classified as `must-fix` or `should-fix`, the fix was pushed, and relevant validation passed;
+- the comment is stale or false positive, with a concrete explanation;
+- the comment is a duplicate of another handled thread.
+
+Codex must not resolve a thread when:
+
+- it is a `product-decision` and the human maintainer has not confirmed the decision;
+- the response is only an opinion without validation or evidence;
+- the comment concerns security, privacy, data loss, local paths, tokens, backups, or migration integrity and no concrete fix has been verified.
+
+Default policy:
+
+- Codex should list the threads it recommends resolving and wait for explicit human authorization before calling GitHub's resolve mutation.
+
+## Suggested Changesets
+
+GitHub review comments may include a suggested changeset with a `Commit suggestion` button. That button applies the reviewer-provided patch directly to the PR branch as a commit.
+
+Use it only for small, mechanical, low-risk changes:
+
+- typos;
+- markdown table formatting;
+- comment wording;
+- obvious import cleanup;
+- single-line documentation fixes.
+
+Do not use it for:
+
+- React state or effect changes;
+- URL/deep-link behavior;
+- session backup, migration, parser, source attach, or diagnostics logic;
+- OpenSpec behavior changes;
+- any change requiring new tests or multi-file edits.
+
+Preferred policy:
+
+- Let Codex implement logic changes locally, run validation, and push a normal commit.
+- If a human uses `Commit suggestion` for a trivial fix, Codex should pull the branch afterward and run at least the relevant lightweight validation before merge.
+
+## Automation Level
+
+Recommended automation is semi-automatic:
+
+| Step | Automation level |
+| ---- | ---------------- |
+| Fetch review comments and thread state | Automatic via `gh pr view` and `gh api graphql` |
+| Classify comments | Codex-assisted, human confirmation for ambiguous items |
+| Apply fixes | Codex-assisted after scope confirmation |
+| Run validation | Automatic/local |
+| Push fix commit | Automatic after validation |
+| Request Copilot re-review | Automatic via `gh pr edit <number> --add-reviewer copilot-pull-request-reviewer` when supported |
+| Resolve conversations | Manual authorization, then automatic via GitHub GraphQL |
+| Merge PR | Human decision |
+
+Do not implement this with Git hooks. Hooks run on local commit/push boundaries, while review state lives in GitHub and requires network access, permissions, PR context, and product-scope judgment.
+
 ## Suggested Codex Prompt
 
 Use this prompt in the control thread or a focused PR-fix thread:

--- a/docs/dev/pr-review-agent-workflow.md
+++ b/docs/dev/pr-review-agent-workflow.md
@@ -1,0 +1,101 @@
+# PR Review Agent Workflow
+
+This document defines the recommended human + agent workflow for pull request review in this repository.
+
+## Goals
+
+- Keep Copilot useful without turning it into a merge blocker.
+- Let Codex triage and fix actionable review feedback with low manual overhead.
+- Preserve the repository's OpenSpec, local-first, and documentation discipline.
+- Avoid noisy automation that pushes code or resolves comments without human intent.
+
+## Roles
+
+| Role | Responsibility |
+| ---- | -------------- |
+| Human maintainer | Owns scope decisions, product naming, merge timing, and final acceptance. |
+| Copilot code review | Provides automatic review comments and low-cost second-pass feedback. |
+| Codex control thread | Triage comments, cluster actionable work, implement approved fixes, run validation, and update PR status. |
+| QA agent | Performs browser QA for UI flows that need real runtime verification. |
+| GitHub PR | Serves as the execution boundary for the current change. |
+
+## Copilot Setup
+
+Recommended repository setup:
+
+- Keep automatic Copilot review enabled for new pull requests, including draft PRs if available.
+- Do not treat Copilot as a required approval gate. Copilot code review submits comment reviews, not approvals or requested changes.
+- Keep `.github/copilot-instructions.md` short and repository-specific. Copilot PR review only reads the first 4,000 characters of each instruction file.
+- Use `.github/instructions/**/*.instructions.md` later only when a path-specific rule is consistently needed.
+- Do not rely on Copilot instructions added in the current PR to affect that same PR. Copilot uses instructions from the base branch.
+
+Not recommended:
+
+- Do not use Git hooks to call GitHub review APIs. Hooks run at the wrong layer, can block local commits/pushes on network failures, and cannot reliably understand PR state.
+- Do not require Copilot review as a branch protection approval.
+- Do not auto-apply Copilot suggestions without triage.
+
+## Standard Flow
+
+1. Open a draft PR once the local branch has a coherent, validated slice.
+2. Let automatic Copilot review run, or manually request Copilot review if automation did not trigger.
+3. Codex reads PR review comments with thread-aware GitHub access.
+4. Codex classifies each comment:
+   - `must-fix`: correctness, data-loss, security, privacy, build, or spec violation.
+   - `should-fix`: real UX/performance/maintainability issue with low regression risk.
+   - `product-decision`: naming, scope, visual taste, or roadmap choice requiring human confirmation.
+   - `ignore`: stale, duplicate, low-confidence, or contrary to the active spec.
+5. Human confirms any `product-decision` or ambiguous `should-fix` item.
+6. Codex implements approved fixes only, with changes traceable to review comments.
+7. Codex runs targeted tests, `pnpm exec tsc --noEmit`, `pnpm build`, and OpenSpec validation when an OpenSpec change is active.
+8. Codex pushes the fix commit to the PR branch.
+9. Human or Codex requests Copilot re-review manually.
+10. Merge only after local/CI validation, QA evidence when needed, and human acceptance.
+
+## Re-Review Trigger
+
+GitHub currently does not automatically request a Copilot re-review after new commits are pushed to a PR that Copilot already reviewed.
+
+Preferred trigger:
+
+- Use the GitHub UI: open the Reviewers menu and request Copilot again.
+
+CLI fallback:
+
+- Try `gh pr edit <number> --add-reviewer copilot-pull-request-reviewer`.
+- If GitHub rejects the bot reviewer name, use the UI.
+
+Codex should not mark GitHub conversations resolved or submit replies unless explicitly asked.
+
+## Suggested Codex Prompt
+
+Use this prompt in the control thread or a focused PR-fix thread:
+
+```text
+Please triage PR review feedback for PR #<number>.
+
+Use the repository workflow in docs/dev/pr-review-agent-workflow.md.
+
+Tasks:
+1. Fetch review comments and unresolved review threads.
+2. Cluster comments into must-fix / should-fix / product-decision / ignore.
+3. Do not modify code until product-decision or ambiguous items are called out.
+4. Fix all confirmed must-fix and should-fix items.
+5. Run targeted tests, pnpm exec tsc --noEmit, pnpm build, and OpenSpec validation if applicable.
+6. Push the fix commit.
+7. Tell me whether Copilot re-review should be requested manually or whether you were able to request it via gh.
+```
+
+## Scope Rules
+
+- Review fixes should stay within the PR's active scope.
+- Naming comments about experimental product/marketing terms are product decisions, not automatic fixes.
+- Placeholder surfaces should remain bounded unless the active spec requires full implementation.
+- For shell/navigation changes, preserve session URL deep links, global search selection, diagnostics, viewer modes, inspector/error center, and direct session backup.
+- For local storage/session changes, treat tokens, paths, ports, and exported diagnostics as sensitive.
+
+## When To Use A New Branch
+
+- If the fix directly addresses comments on the current PR, commit to the PR branch.
+- If the work is a follow-up feature or redesign beyond the PR scope, open a new branch after the current PR merges.
+- If the follow-up depends on the unmerged PR, branch from the PR branch and treat it as stacked work.

--- a/docs/implementation-readiness-review.md
+++ b/docs/implementation-readiness-review.md
@@ -1,0 +1,605 @@
+# Implementation Readiness Review
+
+Updated: 2026-04-11
+
+This document reviews whether the current codebase is ready to move from the
+approved UX and visual direction into implementation planning.
+
+It is not an implementation plan. It defines the migration boundary and the next
+safe planning target.
+
+Primary references:
+
+- [product-positioning-and-ia.md](./product-positioning-and-ia.md)
+- [visual-direction.md](./visual-direction.md)
+- [design-system-baseline.md](./design-system-baseline.md)
+- [content-contract-draft.md](./content-contract-draft.md)
+- [session-backup-migration-ux.md](./session-backup-migration-ux.md)
+- [glossary.md](./glossary.md)
+
+Code references:
+
+- [src/app/page.tsx](../src/app/page.tsx)
+- [src/components/HomeClient.tsx](../src/components/HomeClient.tsx)
+- [src/components/GlobalSearch.tsx](../src/components/GlobalSearch.tsx)
+- [src/components/SettingsClient.tsx](../src/components/SettingsClient.tsx)
+- [src/app/globals.css](../src/app/globals.css)
+- [src/lib/urlState.ts](../src/lib/urlState.ts)
+- [src/lib/sessionRecord.ts](../src/lib/sessionRecord.ts)
+- [src/lib/sessionRecordMapper.ts](../src/lib/sessionRecordMapper.ts)
+- [src/lib/server/sessionBackupService.ts](../src/lib/server/sessionBackupService.ts)
+
+## 1. Status
+
+The current app is implementation-ready for a scoped migration plan, but not
+for a broad redesign.
+
+The current shipped UI is still effectively:
+
+- a local-first session viewer
+- a source diagnostics surface
+- a trajectory / transcript / markdown workbench
+- a session backup entry point
+
+The next product direction is:
+
+- project-first
+- local-first
+- multi-agent
+- focused on agent context governance
+
+This creates a controlled migration problem:
+
+- preserve the current viewer capability
+- move that capability into the future `Sessions` page
+- introduce a project-first shell and page model without breaking current
+  session reading
+
+## 2. Current UI Inventory
+
+### 2.1 App Entry
+
+Current entry:
+
+- `src/app/page.tsx` renders `HomeClient`
+
+Implication:
+
+- the current homepage is the session viewer
+- the future homepage should be `Project Overview`
+- `HomeClient` should not remain the long-term root product shape
+
+### 2.2 Main Client Component
+
+Current main UI:
+
+- `src/components/HomeClient.tsx`
+
+It currently owns:
+
+- config and source status loading
+- Antigravity / Windsurf / Codex source selection
+- session list loading
+- session selection
+- global search selection handling
+- URL deep-link restoration and sync
+- transcript / trajectory / compact view state
+- trajectory filtering
+- execution-group collapse state
+- inspector state
+- error center state
+- session backup action and feedback
+- diagnostics export link
+- large portions of session rendering
+
+Implication:
+
+- `HomeClient` is a working product surface, but it combines app shell,
+  source bar, session list, viewer, inspector, and backup entry behavior.
+- It is too coupled to become the future `Project Overview`.
+- It is a good source of behavior for the future `Sessions` page.
+
+### 2.3 Existing Components
+
+Current reusable components:
+
+- `GlobalSearch`
+- `JsonViewer`
+- shadcn-style primitives:
+  - `Badge`
+  - `Button`
+  - `Card`
+  - `Input`
+  - `Select`
+  - `Switch`
+
+Implication:
+
+- the codebase has enough primitives for a first shell and page skeleton.
+- it does not yet have product-specific primitives such as route cues,
+  provenance blocks, workflow bars, validation panels, or object detail panels.
+
+### 2.4 Current Styling
+
+Current styling:
+
+- Tailwind v4
+- global CSS variables for dark background, panel, muted, text, border, accent,
+  danger
+- current visual language is dark, session-workbench oriented, and cyan-accented
+
+Implication:
+
+- some current styles are useful for `Sessions`.
+- the future project-first shell needs a broader token model aligned with
+  [design-system-baseline.md](./design-system-baseline.md).
+- replacing global CSS immediately would be risky because the current viewer
+  depends on many existing utility combinations.
+
+### 2.5 Existing URL State
+
+Current URL state:
+
+- source
+- session id
+- root id
+- view
+- trajectory filters
+- expanded groups
+- selected row
+- inspector mode
+- include cleared
+
+Implication:
+
+- the existing URL model is session-viewer-specific.
+- it should be preserved for `Sessions`.
+- future project-level routing requires a separate, higher-level route state
+  model for page, object context, issue context, workflow context, and return
+  context.
+
+### 2.6 Existing Backup Capability
+
+Current backup capability includes:
+
+- session record model
+- session record mapper
+- session backup service and store
+- session backup API routes
+- UI action to create session backup
+
+Implication:
+
+- foundation exists for `Backup / Migration`.
+- current UI exposes backup as a session action, not a bounded workflow page.
+- first implementation should not remove the current session backup affordance
+  until a workflow entry surface exists.
+
+## 3. Preserve / Move / Replace
+
+### 3.1 Preserve
+
+Preserve these behaviors:
+
+- local-first source reading
+- Antigravity / Windsurf / Codex source status
+- session list and source-root disambiguation
+- global search selection
+- URL deep-link restoration for selected sessions
+- trajectory / transcript / compact views
+- execution group collapse and virtualization
+- error center and inspector
+- diagnostic JSON export
+- existing session backup creation path
+
+Reason:
+
+- these are the current product's strongest working capabilities
+- they become the foundation of the future `Sessions` page
+
+### 3.2 Move Into `Sessions`
+
+Move or reinterpret these current UI regions as future `Sessions` page modules:
+
+- source tabs -> `Session Source Bar`
+- conversation list -> `Session List`
+- viewer card -> `Session View`
+- view mode controls -> `Projection Controls`
+- error button and error inspector -> `Error Center`
+- inspector side panel -> `Session Inspector`
+- backup action -> `Session Actions`
+- diagnostic JSON export -> diagnostic action inside session detail/actions
+
+Reason:
+
+- this preserves capability while preventing the session viewer from remaining
+  the product homepage.
+
+### 3.3 Replace Or Reframe
+
+Replace or reframe these current concepts:
+
+- `Agent Storage Manager` product title
+  - replace with a project-first product frame once naming is decided enough for
+    internal UI
+- source-first top row
+  - reframe as project shell source presence, not the whole product header
+- single root page
+  - replace with page-level IA: `Project Overview`, `Sessions`, `Assets`,
+    `Analysis`, `Backup / Migration`
+- immediate backup button as primary page action
+  - reframe as session action that can route into `Backup / Migration`
+    workflow
+
+### 3.4 Do Not Remove Yet
+
+Do not remove these before replacement surfaces exist:
+
+- current `HomeClient`
+- URL deep-link behavior
+- backup button
+- diagnostic export
+- source diagnostics panel
+- transcript / trajectory / markdown views
+
+Reason:
+
+- removing them before a `Sessions` page exists would regress the current
+  shipped capability.
+
+## 4. Required New Product Primitives
+
+Before broad page implementation, define these primitives at the design and code
+boundary.
+
+### 4.1 App Shell
+
+Purpose:
+
+- establish project-first navigation and source presence
+
+Needed for:
+
+- all future top-level pages
+
+Minimum responsibilities:
+
+- project identity
+- top-level nav
+- global search slot
+- source presence status
+- optional route or workflow cue slot
+
+Should not own:
+
+- session selection
+- workflow execution state
+- asset subtype state
+
+### 4.2 Route Cue
+
+Purpose:
+
+- preserve origin, issue, return, and continue-task context across page jumps
+
+Needed for:
+
+- `Assets / routed-in from Sessions`
+- `Analysis / routed-in from Overview`
+- `Backup / Migration / validation`
+
+Minimum variants:
+
+- origin
+- return
+- continue task
+- issue
+- workflow entry
+
+### 4.3 Metadata Label
+
+Purpose:
+
+- display scope, source, subtype, status, provenance, root, route, and
+  validation facts consistently
+
+Needed for:
+
+- `Assets`
+- `Sessions`
+- `Backup / Migration`
+- `Analysis`
+
+### 4.4 Object Detail Panel
+
+Purpose:
+
+- explain selected object meaning without becoming a full page state manager
+
+Needed for:
+
+- `Assets`
+- possibly `Analysis` finding detail
+
+Must support:
+
+- identity
+- subtype
+- scope
+- source
+- status
+- provenance
+- session linkage
+
+### 4.5 Provenance Block
+
+Purpose:
+
+- show where an object came from and whether that source remains trustworthy
+
+Needed for:
+
+- session-derived assets
+- backup packages
+- validation results
+
+### 4.6 Workflow Bar
+
+Purpose:
+
+- keep `Backup / Migration` workflow-first
+
+Minimum structure:
+
+- workflow family line
+- active workflow and current step line
+
+### 4.7 Validation Panel
+
+Purpose:
+
+- concentrate validation state, warnings, blocking checks, and decision actions
+
+Needed for:
+
+- session backup validation
+- import validation
+- migration preview
+- project bundle
+
+## 5. Recommended First Implementation Slice
+
+Recommended first slice:
+
+- create the future app shell and preserve the current viewer as the `Sessions`
+  content surface
+
+This should be implemented as a migration scaffold, not a redesign of every
+page.
+
+### 5.1 Why Shell First
+
+Shell first is recommended because:
+
+- it changes the product subject from session-first to project-first
+- it creates a home for future pages without breaking current viewer behavior
+- it lets the current `HomeClient` move under `Sessions` gradually
+- it makes global navigation and route state explicit before page-specific
+  redesign
+
+### 5.2 First Slice Scope
+
+The first implementation slice should include:
+
+- new app shell frame
+- top-level navigation labels
+- `Project Overview` placeholder or minimal summary shell
+- `Sessions` route or tab containing existing viewer behavior
+- current `HomeClient` behavior preserved inside the `Sessions` surface
+- source status preserved in the shell or sessions source bar
+- global search preserved
+
+It should not include:
+
+- full high-fi implementation
+- complete `Assets`
+- complete `Analysis`
+- complete `Backup / Migration`
+- finalized design tokens
+- responsive redesign
+- removal of current viewer logic
+
+### 5.3 First Slice Success Criteria
+
+The slice succeeds if:
+
+- the app no longer reads as session-first at the top level
+- the existing session viewer still works
+- deep links to selected sessions still work or have a clear compatibility
+  plan
+- source diagnostics and attachment status remain accessible
+- no backup or diagnostic export capability is lost
+- the code has a clear place to add `Assets`, `Analysis`, and
+  `Backup / Migration`
+
+## 6. Alternative Implementation Slices Considered
+
+### 6.1 Implement `Project Overview` First
+
+Pros:
+
+- most directly validates product repositioning
+- aligns with approved high-fi trial
+
+Cons:
+
+- current code has no real project overview data model yet
+- risks creating static UI before data boundaries exist
+- does not solve where current viewer lives
+
+Decision:
+
+- not first
+- should follow shell scaffold
+
+### 6.2 Implement `Assets` First
+
+Pros:
+
+- validates context asset model
+- uses strong visual direction from `Evidence Ledger`
+
+Cons:
+
+- asset inventory and provenance data model are not fully implemented
+- may require more backend work before UI is meaningful
+
+Decision:
+
+- not first
+- should wait for asset source and object model planning
+
+### 6.3 Implement `Backup / Migration` First
+
+Pros:
+
+- session backup foundation exists
+- validation workflow has clear UX
+
+Cons:
+
+- current backup UI is a direct session action, not a page workflow
+- page may look isolated without shell and route context
+- project bundle and import workflows need more product decisions
+
+Decision:
+
+- not first
+- should follow shell scaffold and possibly a focused OpenSpec change
+
+### 6.4 Refactor `HomeClient` First
+
+Pros:
+
+- reduces complexity before UI changes
+- may make later work safer
+
+Cons:
+
+- refactor-only work does not advance product repositioning
+- high risk of spending effort without visible migration progress
+
+Decision:
+
+- do not start with a broad refactor
+- extract only when needed by the shell or `Sessions` migration
+
+## 7. Technical Risks
+
+### 7.1 `HomeClient` Coupling
+
+Risk:
+
+- `HomeClient` combines data loading, URL state, rendering, inspector, search
+  selection, and backup action.
+
+Mitigation:
+
+- first wrap rather than rewrite
+- extract session viewer modules only when a concrete migration slice requires
+  it
+- avoid changing URL state and rendering structure in the same commit
+
+### 7.2 URL Compatibility
+
+Risk:
+
+- existing URLs encode session viewer state against the root page.
+
+Mitigation:
+
+- preserve current URL parameters during first shell scaffold
+- document whether future session URLs should become `/sessions?...` or remain
+  query-driven during transition
+- add tests before changing `urlState.ts`
+
+### 7.3 Styling Drift
+
+Risk:
+
+- current dark workbench styling conflicts with the new `Steward Map` baseline.
+
+Mitigation:
+
+- keep existing session workbench styling initially
+- introduce new baseline styles as additive shell/page primitives
+- avoid replacing global CSS variables until page migration proves stable
+
+### 7.4 Data Model Gaps
+
+Risk:
+
+- `Project Overview`, `Assets`, and `Analysis` need data that the current UI
+  does not yet model as first-class project context.
+
+Mitigation:
+
+- use shell scaffold before building data-rich pages
+- plan project context aggregation separately
+- avoid fake permanent UI that cannot be backed by local data
+
+### 7.5 Backup Workflow Boundary
+
+Risk:
+
+- current backup action is direct; future `Backup / Migration` is a bounded
+  workflow page.
+
+Mitigation:
+
+- preserve direct session backup action initially
+- later route it into workflow context only when validation and result surfaces
+  exist
+- do not remove current API or action until workflow replacement is tested
+
+## 8. Open Questions Before Implementation Plan
+
+These questions should be answered in an OpenSpec proposal or implementation
+plan:
+
+- should future navigation use routes like `/sessions` and `/assets`, or a
+  single app route with internal page state?
+- how should existing deep links migrate?
+- what is the minimum project identity model?
+- what source status belongs in global shell versus `Sessions` source bar?
+- should `HomeClient` be renamed or wrapped first?
+- what is the first safe test boundary for shell migration?
+- does `Project Overview` initially show real data, a limited summary, or a
+  guided placeholder?
+
+## 9. Recommended Next Step
+
+Recommended next step:
+
+- create an OpenSpec change for a shell-first migration scaffold
+
+Suggested change id:
+
+- `project-shell-foundation`
+
+Suggested scope:
+
+- introduce a project-first app shell
+- add top-level page structure
+- preserve current session viewer under `Sessions`
+- keep current session backup and diagnostics behavior working
+- do not implement full `Assets`, `Analysis`, or `Backup / Migration`
+
+Why OpenSpec:
+
+- this changes product behavior and navigation
+- it touches the main app shell
+- it must preserve current viewer behavior
+- it needs explicit compatibility criteria for URL state and session backup
+
+Do not start broad implementation before that change exists.

--- a/docs/viewer/project-shell-foundation-qa.md
+++ b/docs/viewer/project-shell-foundation-qa.md
@@ -1,0 +1,110 @@
+# Project Shell Foundation QA Report
+
+**Branch**: `feat/project-shell-foundation`  
+**Date**: 2026-04-11  
+**QA Method**: `agent-browser` on local dev server, plus manual regression retest  
+**Overall Status**: ✅ **PASS**
+
+---
+
+## Scope
+
+This report covers browser QA for the project shell foundation changes, including:
+
+- `Project Overview`
+- `Sessions`
+- `Assets`
+- `Analysis`
+- `Backup / Migration`
+- deep-link behavior
+- global search behavior
+
+---
+
+## Environment
+
+| Item | Status | Details |
+| ---- | ------ | ------- |
+| Branch | ✅ | `feat/project-shell-foundation` |
+| Dev server | ✅ | `http://localhost:3000` |
+| Browser automation | ✅ | `agent-browser` |
+| Browser noise | ⚠️ | Ignored `kiro-cli` runtime panic noise and relied on actual page results |
+
+---
+
+## Results
+
+### Basic shell
+
+| Check | Status | Notes |
+| ---- | ------ | ----- |
+| Default landing page is `Project Overview` | ✅ | Verified in browser |
+| Top-level navigation is visible | ✅ | `Project Overview`, `Sessions`, `Assets`, `Analysis`, `Backup / Migration` |
+| Global search entry is visible | ✅ | `Open global search` |
+| Settings entry is visible | ✅ | `Settings` |
+| Blank screen / hydration issue observed | ✅ | No blocking issue observed during QA |
+
+### Placeholder surfaces
+
+| Surface | Status | Notes |
+| ------- | ------ | ----- |
+| `Assets` | ✅ | Shows `foundation placeholder` and preserved-path guidance |
+| `Analysis` | ✅ | Shows `foundation placeholder` and preserved-path guidance |
+| `Backup / Migration` | ✅ | Shows `foundation placeholder` and preserved-path guidance |
+| Return path to `Sessions` | ✅ | `Return to Sessions` present on placeholder screens |
+
+### Sessions containment
+
+| Check | Status | Notes |
+| ---- | ------ | ----- |
+| Existing session list remains available | ✅ | Verified in browser |
+| Source pills remain available | ✅ | `Antigravity`, `Windsurf`, `Codex` |
+| `Refresh` remains available | ✅ | Verified |
+| `Settings` remains available inside Sessions | ✅ | Verified |
+| Existing viewer remains available | ✅ | Selected session loaded successfully |
+| Existing viewer tabs remain available | ✅ | `Transcript`, `Trajectory`, `Chat` |
+| Existing session backup action remains available | ✅ | `Back Up Session` visible |
+| Error entry remains available | ✅ | `errors 1` visible in selected session |
+
+### Deep-link behavior
+
+| Check | Status | Notes |
+| ---- | ------ | ----- |
+| Opening a URL with `source` and `id` lands in `Sessions` | ✅ | Verified with real deep link |
+| Selected session viewer restores from URL | ✅ | `Transcript`, `Trajectory`, `Chat` visible after open |
+| Deep-link flow stays functional inside project shell | ✅ | Verified in browser |
+
+### Global search behavior
+
+| Check | Status | Notes |
+| ---- | ------ | ----- |
+| Shell-level global search opens | ✅ | Search dialog/input appears |
+| Search returns indexed results | ✅ | Example query `Macro` returned results |
+| Clicking a result opens the expected session in `Sessions` | ✅ | Manual retest passed after fix, including reopening from `Project Overview` across source changes |
+
+### Layout sanity check
+
+| Check | Status | Notes |
+| ---- | ------ | ----- |
+| Desktop layout sanity | ✅ | Overview CTA set visible |
+| Narrow viewport sanity | ✅ | Top nav and CTA buttons still visible |
+
+---
+
+## Main finding
+
+No blocking regression remains in the validated scope.
+
+---
+
+## Conclusion
+
+The project shell foundation is largely working as intended:
+
+- shell navigation works
+- placeholder boundaries are clear
+- existing `Sessions` viewer functionality is preserved
+- deep-link behavior works
+- global search result selection now restores the expected target session
+
+## Final Status: ✅ PASS

--- a/docs/visual-direction.md
+++ b/docs/visual-direction.md
@@ -1,0 +1,514 @@
+# Visual Direction
+
+Updated: 2026-04-11
+
+This document records the current visual-direction decision for the next phase of
+`agent-storage-manager`.
+
+It is intentionally a direction baseline, not a final design system or
+implementation specification.
+
+Primary references:
+
+- [product-positioning-and-ia.md](./product-positioning-and-ia.md)
+- [low-fi-wireframes-phase-1-detailed.md](./low-fi-wireframes-phase-1-detailed.md)
+- [low-fi-wireframes-phase-2-sessions-analysis.md](./low-fi-wireframes-phase-2-sessions-analysis.md)
+- [routed-context-handoff.md](./routed-context-handoff.md)
+- [cue-lifecycle-rules.md](./cue-lifecycle-rules.md)
+- [glossary.md](./glossary.md)
+
+Figma reference:
+
+- [Agent Context Steward Low-Fi v1](https://www.figma.com/design/EWdC4ItqkJwd5NsOQBsI64)
+
+## 1. Status
+
+The current product direction has moved beyond a session-first viewer.
+
+The visual direction must support the working product definition from
+[product-positioning-and-ia.md](./product-positioning-and-ia.md):
+
+> A local-first product for understanding, governing, and migrating
+> project-scoped agent context.
+
+The visual exploration has passed three high-fi trial checks:
+
+- `Project Overview / issue-heavy`
+- `Assets / routed-in from Sessions`
+- `Backup / Migration / validation`
+
+The exploration should now stop generating additional high-fi trials until this
+direction is turned into a lightweight design-system baseline.
+
+## 2. Direction Decision
+
+### 2.1 Base Direction: `Steward Map`
+
+`Steward Map` is the base visual direction.
+
+It should make the product feel like:
+
+- a project-first context stewardship surface
+- a mapped dependency and routing environment
+- a calm governance tool for local agent context
+- a developer-facing product without becoming terminal-first
+
+It should emphasize:
+
+- project structure
+- issue routing
+- context handoff
+- lifecycle cues
+- governance state
+- continuity between sessions, assets, findings, and workflows
+
+It should not feel like:
+
+- a generic SaaS dashboard
+- a project-management board
+- a cloud admin console
+- a session transcript viewer with a new header
+
+### 2.2 Supporting Language: `Evidence Ledger`
+
+`Evidence Ledger` is the supporting visual language.
+
+It should be used where trust, source, and object understanding matter most:
+
+- asset provenance
+- session-derived evidence
+- chain of custody
+- validation records
+- source roots
+- backup and migration package state
+
+It should emphasize:
+
+- provenance
+- auditability
+- scoped metadata
+- source-aware labels
+- trust state
+- object identity
+
+It should not dominate the whole product.
+
+If overused, it can make the product feel like a document archive or compliance
+ledger instead of a working context product.
+
+### 2.3 Avoided Primary Direction: `Workbench Console`
+
+`Workbench Console` should not become the primary visual direction.
+
+It may inform local texture inside `Sessions` or specific developer-heavy
+inspection surfaces, but it should not lead the overall product.
+
+Reason:
+
+- it risks pulling the product back toward session-first or terminal-first
+  identity
+- it can make `Sessions` feel like the hidden homepage
+- it may overemphasize execution logs at the expense of project-level context
+  governance
+
+## 3. Trial Results
+
+### 3.1 `Project Overview / issue-heavy`
+
+Figma page:
+
+- `High-Fi Trial - Steward Map Overview`
+
+Result:
+
+- passed
+
+What it validated:
+
+- `Project Overview` can become a project-level stewardship surface rather than
+  a session viewer homepage.
+- `Attention Needed` can be the primary center of gravity without turning into
+  `Analysis`.
+- `Recent Sessions` can remain secondary evidence rather than reclaiming the
+  page subject.
+- `Quick Actions` can stay routing-first instead of becoming a workflow surface.
+
+Visual conclusions:
+
+- map grid, route nodes, destination pills, and governance panels support the
+  project-first subject.
+- small `Evidence Ledger` cues such as source-aware labels and chain-of-custody
+  language help make the governance surface more concrete.
+
+Risk:
+
+- the stewardship tone can become too managerial if later pages do not preserve
+  enough developer-tool texture.
+
+### 3.2 `Assets / routed-in from Sessions`
+
+Figma page:
+
+- `High-Fi Trial - Evidence Ledger Assets`
+
+Result:
+
+- passed
+
+What it validated:
+
+- `Assets` can stay object-first while preserving routed session context.
+- `Asset Inventory` can remain the driving module without becoming a generic
+  admin table.
+- right detail can answer "what is this object?"
+- second-layer usage can answer "how does it matter in this project?"
+- provenance and session linkage can be prominent without turning the page back
+  into `Sessions`.
+
+Visual conclusions:
+
+- `Steward Map` should frame project continuity, subtype, scope, and route
+  context.
+- `Evidence Ledger` should carry provenance, trust columns, metadata labels,
+  and session linkage.
+
+Risk:
+
+- information density is close to the upper bound. Real data may require
+  sectioning, truncation, or progressive disclosure in the right detail panel.
+
+### 3.3 `Backup / Migration / validation`
+
+Figma page:
+
+- `High-Fi Trial - Workflow Validation`
+
+Result:
+
+- passed
+
+What it validated:
+
+- `Backup / Migration` can remain workflow-first while using the same visual
+  system.
+- the two-line workflow bar can make workflow family, active workflow, and
+  current step clear.
+- `Validation Panel` can remain the dominant decision surface.
+- warning, blocking checks, and CTA hierarchy can live inside the validation
+  panel instead of dispersing into header, history, or tools areas.
+- `Recent Operations` can remain a low-priority strip.
+
+Visual conclusions:
+
+- `Steward Map` should carry workflow continuity, origin cue, step path, and
+  project route context.
+- `Evidence Ledger` should carry validation, source, provenance, and trust
+  wording.
+
+Risk:
+
+- complex validation states with multiple warnings or blocking checks may make
+  the validation panel too tall. Later design should define grouping or
+  disclosure rules before implementation.
+
+## 4. Lightweight Design-System Seed
+
+This section defines a seed for future design-system work. It is not yet a
+component spec.
+
+### 4.1 Typography Direction
+
+Use typography to separate governance, object evidence, and metadata.
+
+Recommended direction:
+
+- a strong, readable sans face for page titles, module headings, and navigation
+- a technical mono face for metadata, scope, source, provenance, route, and
+  validation labels
+- restrained weight contrast rather than oversized dashboard numerals
+
+Typography should communicate:
+
+- calm control
+- local developer tool precision
+- inspectable evidence
+
+Avoid:
+
+- terminal-only typography across the whole product
+- generic dashboard display type
+- excessive monospace text in narrative areas
+
+### 4.2 Palette Direction
+
+Use a calm base palette with semantic cue colors.
+
+Recommended roles:
+
+- base surface: quiet, low-glare, local-workbench neutral
+- map/grid lines: subtle structure, not decoration
+- route/accent: used for active handoff and navigation continuity
+- provenance/trust: distinct but restrained
+- warning: visible and warm, not alarmist
+- blocking/error: strong enough for action, not permanently dominant
+- success/pass: supportive, not celebratory
+
+Avoid:
+
+- default purple SaaS palette
+- harsh terminal-green-on-black as the global identity
+- high-saturation status colors everywhere
+
+### 4.3 Surface Direction
+
+Surfaces should clarify hierarchy and role.
+
+Use:
+
+- map-like page backgrounds for project continuity
+- structured panels for governance and routing
+- ledger-like cards for provenance, trust, and validation details
+- compact strips for origin, return, and continuation cues
+- strong primary panels only where the current task is decided
+
+Avoid:
+
+- turning every module into equal cards
+- using side inspectors as the only place where task meaning appears
+- making history or recent operations visually compete with active workflow
+
+### 4.4 Cue Language
+
+Cues are part of the product's core UX, not decoration.
+
+Use cue treatments for:
+
+- origin
+- continue task
+- return to origin
+- issue
+- provenance
+- in-effect
+- validation
+- warning
+- result
+- completion
+
+Visual priority should follow [cue-lifecycle-rules.md](./cue-lifecycle-rules.md):
+
+- page-defining issue or workflow continuity may become banner-level
+- object-local routed context should stay compact
+- workflow-critical validation and warning cues should stay inside the workflow
+  body
+- completion cues should downgrade quickly once they no longer change the next
+  action
+
+### 4.5 Navigation Direction
+
+Navigation should reinforce the project-first IA.
+
+Use:
+
+- stable top-level navigation for `Project Overview`, `Sessions`, `Assets`,
+  `Analysis`, and `Backup / Migration`
+- local subnavigation for asset subtype, scope, workflow family, and projection
+  mode
+- route pills or compact strips for temporary task continuity
+
+Avoid:
+
+- making `Sessions` visually look like the real homepage
+- making `Backup / Migration` look like a utilities drawer
+- exposing too many workflow internals on `Project Overview`
+
+### 4.6 Density Direction
+
+The product is allowed to be information-dense, but density must be purposeful.
+
+High density is acceptable for:
+
+- provenance
+- validation
+- session evidence
+- object metadata
+- route context
+
+Density must be constrained for:
+
+- homepage summary
+- quick actions
+- recent sessions
+- recent operations
+- completion cues
+
+If real data increases density, prefer:
+
+- grouping
+- truncation with reveal
+- progressive disclosure
+- split between object meaning and project usage
+
+Avoid:
+
+- expanding every secondary region into a full table
+- letting detail panels become unbounded text containers
+- using density to hide unresolved IA decisions
+
+## 5. Page-Specific Guidance
+
+### 5.1 `Project Overview`
+
+Primary direction:
+
+- `Steward Map`
+
+The page should feel like:
+
+- project health and routing
+- governance summary
+- mapped attention surface
+
+Key constraints:
+
+- `Attention Needed` is primary in issue-heavy state
+- `Recent Sessions` stays secondary
+- `Quick Actions` stays routing-first
+- no detailed finding triage
+- no session workbench behavior
+
+### 5.2 `Assets`
+
+Primary direction:
+
+- `Steward Map` plus strong `Evidence Ledger`
+
+The page should feel like:
+
+- object understanding
+- provenance inspection
+- scope and in-effect confirmation
+
+Key constraints:
+
+- inventory drives selection
+- detail explains the selected object
+- in-effect / usage is a second layer
+- provenance and session linkage are visible
+- actions remain secondary
+
+### 5.3 `Backup / Migration`
+
+Primary direction:
+
+- workflow-first `Steward Map` with `Evidence Ledger` validation language
+
+The page should feel like:
+
+- bounded operation
+- explicit validation
+- inspectable result
+
+Key constraints:
+
+- workflow identity is always visible
+- validation and warnings live inside the workflow body
+- CTA is concentrated near validation or result evidence
+- recent operations stay low-priority
+- no tools drawer behavior
+
+### 5.4 `Sessions`
+
+Primary direction:
+
+- `Steward Map` frame with limited `Workbench Console` texture
+
+The page should feel like:
+
+- evidence workbench
+- readable session history
+- source-aware diagnosis
+
+Key constraints:
+
+- it must not become the product homepage
+- transcript or trajectory reading remains primary within the page
+- error center is evidence-oriented, not grouped project analysis
+- outbound actions remain bounded and downstream from evidence
+
+### 5.5 `Analysis`
+
+Primary direction:
+
+- `Steward Map` interpretation surface with restrained evidence cues
+
+The page should feel like:
+
+- issue interpretation
+- action routing
+- selected problem explanation
+
+Key constraints:
+
+- findings table drives issue selection
+- finding detail explains why it matters
+- recommended actions route outward
+- no correction workflow body
+- no asset inventory duplication
+
+## 6. Readiness Gate
+
+Before implementation planning, the next step should be a lightweight
+design-system baseline.
+
+That baseline should define:
+
+- page shell
+- top navigation
+- route / origin / return cue treatments
+- metadata label style
+- surface hierarchy
+- issue / warning / validation / result states
+- object detail and provenance blocks
+- workflow bar and validation panel patterns
+
+It should not yet define:
+
+- a complete component library
+- exhaustive variants
+- production CSS tokens
+- final brand identity
+- public marketing name
+
+Implementation should wait until at least one representative page can be mapped
+from the visual baseline into code without breaking existing local-first viewer
+functionality.
+
+## 7. Open Risks
+
+The main remaining risks are:
+
+- information density may exceed the right detail panel's capacity on real
+  assets
+- validation states may need grouping rules for multiple warnings or blocking
+  checks
+- `Sessions` still needs careful treatment so technical texture does not pull
+  the product back into session-first identity
+- final naming is unresolved, so brand expression should remain product-role
+  driven rather than name-driven
+- implementation may need to coexist with current UI before a full redesign is
+  safe
+
+## 8. Recommended Next Step
+
+Recommended next step:
+
+- create a lightweight design-system baseline from this document and the three
+  high-fi trials
+
+Do not continue generating more high-fi pages until the baseline exists.
+
+Reason:
+
+- the visual direction has enough evidence to converge
+- more pages without a baseline will create inconsistent local patterns
+- implementation planning needs reusable rules, not more isolated mockups

--- a/openspec/changes/project-shell-foundation/.openspec.yaml
+++ b/openspec/changes/project-shell-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/project-shell-foundation/design.md
+++ b/openspec/changes/project-shell-foundation/design.md
@@ -1,0 +1,180 @@
+## Context
+
+The current app opens at `src/app/page.tsx` and renders `HomeClient`, which is a
+working session viewer and diagnostics surface. `HomeClient` currently combines
+app shell, source selection, session list, viewer, inspector, URL sync, global
+search selection, diagnostics export, and session backup entry behavior.
+
+The approved product direction is project-first rather than session-first. The
+approved visual baseline is `Steward Map` with `Evidence Ledger` as supporting
+language. The implementation readiness review recommends a shell-first scaffold
+that preserves the existing viewer under the future `Sessions` area instead of
+rewriting all pages at once.
+
+Key constraints:
+
+- Preserve local-first source reading.
+- Preserve existing session viewer functionality.
+- Preserve current URL deep-link behavior until an explicit migration replaces
+  it.
+- Preserve current session backup and diagnostics affordances.
+- Do not implement full `Assets`, `Analysis`, or `Backup / Migration` in this
+  foundation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce a project-first app shell with stable top-level navigation.
+- Establish `Project Overview` as the landing subject.
+- Keep the existing session viewer available under `Sessions`.
+- Preserve current session deep links, global search selection, source status,
+  diagnostics export, and direct session backup behavior.
+- Create a safe structure where future `Assets`, `Analysis`, and
+  `Backup / Migration` pages can be added without keeping the root page
+  session-first.
+
+**Non-Goals:**
+
+- Do not build the full final visual design.
+- Do not create a complete component library or finalized production tokens.
+- Do not implement full `Assets`, `Analysis`, or `Backup / Migration`.
+- Do not redesign trajectory rendering, transcript rendering, or inspector
+  behavior.
+- Do not remove or replace the current session backup API.
+- Do not change session record or backup package schemas.
+
+## Decisions
+
+### Decision 1: Add a shell scaffold before page rewrites
+
+Introduce a project-first shell that owns top-level navigation and page framing,
+then place the existing viewer behavior under the `Sessions` surface.
+
+Rationale:
+
+- It changes the app's top-level subject without risking current viewer
+  behavior.
+- It creates a stable place for future pages.
+- It keeps implementation scope small enough to validate with existing tests.
+
+Alternative considered:
+
+- Implement `Project Overview` first as a rich page.
+- Rejected because current code does not yet have a first-class project context
+  aggregation model, and a rich static overview would create UI ahead of data.
+
+### Decision 2: Wrap before extracting `HomeClient`
+
+The first implementation should wrap or contain existing `HomeClient` behavior
+instead of immediately splitting it into many components.
+
+Rationale:
+
+- `HomeClient` is highly coupled but functional.
+- Broad refactor before shell migration would spend effort without validating
+  the product repositioning.
+- Extraction can happen incrementally once the new shell creates real seams.
+
+Alternative considered:
+
+- Refactor `HomeClient` first.
+- Rejected because it increases regression risk without changing the product
+  subject.
+
+### Decision 3: Preserve existing session URL semantics during the foundation
+
+The foundation should not change `src/lib/urlState.ts` semantics unless required
+for a compatibility shim.
+
+Rationale:
+
+- Existing session URLs encode selected source, session id, root id, view,
+  filters, expanded groups, selected row, and inspector state.
+- Breaking deep links would regress one of the current product strengths.
+
+Alternative considered:
+
+- Move immediately to route paths like `/sessions?...`.
+- Deferred because route migration needs explicit compatibility criteria and
+  tests.
+
+### Decision 4: Use placeholders only where data boundaries are not ready
+
+`Project Overview`, `Assets`, `Analysis`, and `Backup / Migration` can exist as
+top-level destinations in the scaffold, but only `Sessions` should carry the
+full existing working surface in this change.
+
+Rationale:
+
+- The shell can establish IA before all data models exist.
+- Placeholder pages can communicate role and next step without pretending to be
+  complete.
+
+Alternative considered:
+
+- Hide unavailable pages.
+- Rejected because the goal of the foundation is to establish the project-first
+  IA and migration target.
+
+### Decision 5: Keep backup as a session action initially
+
+The existing direct session backup action should remain available in `Sessions`
+until `Backup / Migration` has real workflow validation and result surfaces.
+
+Rationale:
+
+- Session backup functionality already exists.
+- Moving it into a nonfunctional workflow page would reduce capability.
+
+Alternative considered:
+
+- Remove direct backup and route to a placeholder `Backup / Migration`.
+- Rejected because placeholders must not break working preservation behavior.
+
+## Risks / Trade-offs
+
+- [Risk] The shell may look like a redesign while still containing the old
+  viewer.
+  - Mitigation: treat this change as a scaffold; only apply additive baseline
+    styling needed for shell and navigation.
+- [Risk] Existing session deep links may be overwritten during shell routing.
+  - Mitigation: preserve current query-driven session state and add tests before
+    changing URL behavior.
+- [Risk] `HomeClient` remains large after the first slice.
+  - Mitigation: accept this temporarily; extract only after the shell boundary
+    proves useful.
+- [Risk] Placeholder pages may be mistaken for implemented features.
+  - Mitigation: label them as foundation surfaces and keep actions disabled or
+    clearly routed to existing working surfaces.
+- [Risk] Source diagnostics may become hidden in the new shell.
+  - Mitigation: preserve diagnostics access either in shell source presence or
+    the `Sessions` source bar.
+
+## Migration Plan
+
+1. Introduce shell and page-selection structure around the existing root app.
+2. Add stable top-level navigation labels.
+3. Place existing viewer behavior under `Sessions`.
+4. Add a minimal `Project Overview` foundation surface.
+5. Add placeholder surfaces for `Assets`, `Analysis`, and `Backup / Migration`
+   that communicate role without claiming full behavior.
+6. Verify existing session reading, search selection, URL restoration,
+   diagnostics export, and session backup still work.
+
+Rollback strategy:
+
+- Keep current `HomeClient` behavior intact.
+- If shell routing regresses core viewer behavior, temporarily route the root
+  page back to the existing viewer while preserving the new components for
+  later rework.
+
+## Open Questions
+
+- Should later page navigation become path-based (`/sessions`, `/assets`) or
+  remain internal page state under the root route?
+- What is the minimum real project identity model for `Project Overview`?
+- Which source status details belong in the global shell versus the `Sessions`
+  source bar?
+- When should direct session backup route into the future
+  `Backup / Migration` workflow?

--- a/openspec/changes/project-shell-foundation/proposal.md
+++ b/openspec/changes/project-shell-foundation/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The product direction has shifted from a session-first viewer to a project-first
+local agent context steward, but the current app still opens directly into the
+session viewer. We need a shell-first migration scaffold that changes the
+product subject without regressing the existing local session reading,
+diagnostics, deep-link, and backup capabilities.
+
+## What Changes
+
+- Introduce a project-first app shell with stable top-level navigation for:
+  `Project Overview`, `Sessions`, `Assets`, `Analysis`, and
+  `Backup / Migration`.
+- Preserve the existing session viewer behavior inside the `Sessions` surface
+  during the first migration slice.
+- Add a minimal `Project Overview` surface or placeholder that establishes the
+  project-first landing role without pretending to implement full analysis or
+  asset inventory.
+- Keep source status, global search, diagnostics access, URL deep-link behavior,
+  and direct session backup behavior working during the scaffold phase.
+- Establish clear non-goals for this change: no complete redesign, no full
+  `Assets`, no full `Analysis`, no full `Backup / Migration`, no final design
+  system implementation, and no removal of current viewer functionality.
+- No breaking changes are intended.
+
+## Capabilities
+
+### New Capabilities
+
+- `project-shell`: Defines the project-first app shell, top-level page
+  structure, session viewer containment, and migration compatibility
+  requirements.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected UI entry points:
+  - `src/app/page.tsx`
+  - `src/components/HomeClient.tsx`
+  - new shell/page components to be introduced during implementation
+- Affected shared UI:
+  - `src/components/GlobalSearch.tsx`
+  - shadcn-style primitives under `src/components/ui/`
+  - `src/app/globals.css` only through additive styling, not broad replacement
+- Affected state and compatibility areas:
+  - session URL state in `src/lib/urlState.ts`
+  - current source status and diagnostics flows
+  - current session backup entry action
+- No backend storage format, session record model, or backup package schema
+  change is required for this foundation.

--- a/openspec/changes/project-shell-foundation/specs/project-shell/spec.md
+++ b/openspec/changes/project-shell-foundation/specs/project-shell/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Project-first app shell
+The system SHALL provide a project-first app shell that frames the product around
+project-scoped agent context rather than around the session viewer.
+
+#### Scenario: Shell shows project-first navigation
+- **WHEN** the user opens the app
+- **THEN** the app shows top-level navigation for `Project Overview`,
+  `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`
+
+#### Scenario: Root page is not the raw session viewer
+- **WHEN** the user opens the app without a session deep link
+- **THEN** the app presents `Project Overview` as the landing subject instead of
+  immediately presenting the session list and viewer as the whole product
+
+### Requirement: Current session viewer containment
+The system SHALL preserve the existing session viewer behavior inside the
+`Sessions` surface during the shell foundation.
+
+#### Scenario: Sessions surface contains existing viewer capability
+- **WHEN** the user navigates to `Sessions`
+- **THEN** the user can browse sources, select sessions, and view session
+  content using the existing compact, transcript, or trajectory views supported
+  by the selected source
+
+#### Scenario: Session inspector remains available
+- **WHEN** the user selects an inspectable session row or opens error
+  inspection from the `Sessions` surface
+- **THEN** the existing inspector behavior remains available
+
+### Requirement: Source status and diagnostics preservation
+The system SHALL preserve source status and diagnostics access during the shell
+foundation.
+
+#### Scenario: Source presence remains visible
+- **WHEN** source status has loaded
+- **THEN** the app exposes Antigravity, Windsurf, and Codex source presence or
+  attachment state from either the shell or the `Sessions` source area
+
+#### Scenario: Diagnostics remain accessible
+- **WHEN** source diagnostics are available
+- **THEN** the user can still access diagnostic details and copyable evidence
+  without leaving the current local app workflow
+
+### Requirement: Search selection preservation
+The system SHALL preserve the existing global search session-selection behavior.
+
+#### Scenario: Search result opens session
+- **WHEN** the user selects a session result from global search
+- **THEN** the app navigates to or reveals the `Sessions` surface and selects
+  the matching session
+
+#### Scenario: Cross-source search result opens session
+- **WHEN** the selected search result belongs to a different source than the
+  currently active source
+- **THEN** the app switches to the target source and loads the selected session
+  without clearing the pending selection
+
+### Requirement: Session URL compatibility
+The system SHALL preserve existing session deep-link behavior during the shell
+foundation.
+
+#### Scenario: Existing session URL restores viewer state
+- **WHEN** the app loads with existing query parameters for source, session id,
+  root id, view, filters, expanded groups, selected row, or inspector state
+- **THEN** the `Sessions` surface restores the matching viewer state as it did
+  before the shell foundation
+
+#### Scenario: Session interactions keep URL state valid
+- **WHEN** the user changes selected session, view, trajectory filters, expanded
+  groups, selected row, inspector mode, or WindSurf cleared-step visibility
+- **THEN** the URL state remains valid for restoring the same session viewer
+  state
+
+### Requirement: Session backup compatibility
+The system SHALL preserve direct session backup behavior during the shell
+foundation.
+
+#### Scenario: User creates session backup from Sessions
+- **WHEN** the user has selected a session in the `Sessions` surface and invokes
+  the session backup action
+- **THEN** the system creates a session backup through the existing session
+  backup API behavior
+
+#### Scenario: Source copy option remains bounded
+- **WHEN** the selected source supports source-copy backup
+- **THEN** the user can still opt into source copy for that session backup
+
+### Requirement: Placeholder surfaces do not claim full behavior
+The system SHALL expose foundation surfaces for future top-level pages without
+claiming unimplemented full behavior.
+
+#### Scenario: Assets placeholder is bounded
+- **WHEN** the user navigates to `Assets` before full asset inventory is
+  implemented
+- **THEN** the app communicates the intended assets role without presenting a
+  fake complete rules, memory, skills, or commands inventory
+
+#### Scenario: Analysis placeholder is bounded
+- **WHEN** the user navigates to `Analysis` before full findings behavior is
+  implemented
+- **THEN** the app communicates the intended interpretation and routing role
+  without presenting fake findings or corrective workflow behavior
+
+#### Scenario: Backup Migration placeholder is bounded
+- **WHEN** the user navigates to `Backup / Migration` before full workflow
+  behavior is implemented
+- **THEN** the app communicates the intended workflow role without replacing the
+  existing working session backup action
+
+### Requirement: Additive styling boundary
+The system SHALL introduce shell-foundation styling additively without broadly
+replacing current viewer styling.
+
+#### Scenario: Viewer styling remains functional
+- **WHEN** the user uses the `Sessions` surface after the shell foundation
+- **THEN** transcript, trajectory, inspector, and diagnostic content remain
+  readable and usable
+
+#### Scenario: Shell styling follows baseline roles
+- **WHEN** shell-specific UI is rendered
+- **THEN** it uses design roles aligned with the design-system baseline such as
+  page shell, route cue, metadata label, compact strip, or primary surface
+  without requiring a complete production token system

--- a/openspec/changes/project-shell-foundation/tasks.md
+++ b/openspec/changes/project-shell-foundation/tasks.md
@@ -1,0 +1,38 @@
+## 1. Shell Structure
+
+- [ ] 1.1 Add a project-first shell component with top-level navigation labels for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`.
+- [ ] 1.2 Add page-selection state or routing glue for switching between the foundation surfaces without removing the existing viewer behavior.
+- [ ] 1.3 Update the root page to render the shell scaffold instead of exposing the raw session viewer as the whole product.
+
+## 2. Sessions Containment
+
+- [ ] 2.1 Move or wrap the existing `HomeClient` viewer behavior under the `Sessions` surface.
+- [ ] 2.2 Preserve source selection, session list, compact/transcript/trajectory views, inspector, error center, diagnostics export, and session backup action in `Sessions`.
+- [ ] 2.3 Preserve global search selection so selecting a session result reveals `Sessions` and loads the selected session.
+
+## 3. Foundation Surfaces
+
+- [ ] 3.1 Add a minimal `Project Overview` foundation surface that communicates project-first role without fake full analysis or inventory data.
+- [ ] 3.2 Add bounded placeholder surfaces for `Assets`, `Analysis`, and `Backup / Migration`.
+- [ ] 3.3 Ensure placeholders communicate intended role and do not replace current working session backup or diagnostics behavior.
+
+## 4. Compatibility
+
+- [ ] 4.1 Preserve existing session URL deep-link restoration for source, session id, root id, view, filters, expanded groups, selected row, inspector, and include-cleared state.
+- [ ] 4.2 Preserve URL sync for session viewer interactions after the shell scaffold is introduced.
+- [ ] 4.3 Preserve source diagnostics visibility and copyable diagnostics evidence.
+- [ ] 4.4 Preserve direct session backup behavior, including source-copy opt-in where supported.
+
+## 5. Styling Boundary
+
+- [ ] 5.1 Add shell-foundation styles additively using roles from `docs/design-system-baseline.md`.
+- [ ] 5.2 Keep existing transcript, trajectory, inspector, and diagnostic content readable and usable.
+- [ ] 5.3 Avoid broad global CSS replacement or complete visual redesign in this change.
+
+## 6. Tests And Validation
+
+- [ ] 6.1 Add or update targeted tests for shell navigation and `Sessions` containment.
+- [ ] 6.2 Add or update targeted tests for preserving global search session selection through the shell.
+- [ ] 6.3 Add or update targeted tests for URL restoration and URL sync compatibility.
+- [ ] 6.4 Run targeted tests for affected UI and URL-state behavior.
+- [ ] 6.5 Run `openspec validate project-shell-foundation --strict`.

--- a/openspec/changes/project-shell-foundation/tasks.md
+++ b/openspec/changes/project-shell-foundation/tasks.md
@@ -1,38 +1,38 @@
 ## 1. Shell Structure
 
-- [ ] 1.1 Add a project-first shell component with top-level navigation labels for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`.
-- [ ] 1.2 Add page-selection state or routing glue for switching between the foundation surfaces without removing the existing viewer behavior.
-- [ ] 1.3 Update the root page to render the shell scaffold instead of exposing the raw session viewer as the whole product.
+- [x] 1.1 Add a project-first shell component with top-level navigation labels for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`.
+- [x] 1.2 Add page-selection state or routing glue for switching between the foundation surfaces without removing the existing viewer behavior.
+- [x] 1.3 Update the root page to render the shell scaffold instead of exposing the raw session viewer as the whole product.
 
 ## 2. Sessions Containment
 
-- [ ] 2.1 Move or wrap the existing `HomeClient` viewer behavior under the `Sessions` surface.
-- [ ] 2.2 Preserve source selection, session list, compact/transcript/trajectory views, inspector, error center, diagnostics export, and session backup action in `Sessions`.
-- [ ] 2.3 Preserve global search selection so selecting a session result reveals `Sessions` and loads the selected session.
+- [x] 2.1 Move or wrap the existing `HomeClient` viewer behavior under the `Sessions` surface.
+- [x] 2.2 Preserve source selection, session list, compact/transcript/trajectory views, inspector, error center, diagnostics export, and session backup action in `Sessions`.
+- [x] 2.3 Preserve global search selection so selecting a session result reveals `Sessions` and loads the selected session.
 
 ## 3. Foundation Surfaces
 
-- [ ] 3.1 Add a minimal `Project Overview` foundation surface that communicates project-first role without fake full analysis or inventory data.
-- [ ] 3.2 Add bounded placeholder surfaces for `Assets`, `Analysis`, and `Backup / Migration`.
-- [ ] 3.3 Ensure placeholders communicate intended role and do not replace current working session backup or diagnostics behavior.
+- [x] 3.1 Add a minimal `Project Overview` foundation surface that communicates project-first role without fake full analysis or inventory data.
+- [x] 3.2 Add bounded placeholder surfaces for `Assets`, `Analysis`, and `Backup / Migration`.
+- [x] 3.3 Ensure placeholders communicate intended role and do not replace current working session backup or diagnostics behavior.
 
 ## 4. Compatibility
 
-- [ ] 4.1 Preserve existing session URL deep-link restoration for source, session id, root id, view, filters, expanded groups, selected row, inspector, and include-cleared state.
-- [ ] 4.2 Preserve URL sync for session viewer interactions after the shell scaffold is introduced.
-- [ ] 4.3 Preserve source diagnostics visibility and copyable diagnostics evidence.
-- [ ] 4.4 Preserve direct session backup behavior, including source-copy opt-in where supported.
+- [x] 4.1 Preserve existing session URL deep-link restoration for source, session id, root id, view, filters, expanded groups, selected row, inspector, and include-cleared state.
+- [x] 4.2 Preserve URL sync for session viewer interactions after the shell scaffold is introduced.
+- [x] 4.3 Preserve source diagnostics visibility and copyable diagnostics evidence.
+- [x] 4.4 Preserve direct session backup behavior, including source-copy opt-in where supported.
 
 ## 5. Styling Boundary
 
-- [ ] 5.1 Add shell-foundation styles additively using roles from `docs/design-system-baseline.md`.
-- [ ] 5.2 Keep existing transcript, trajectory, inspector, and diagnostic content readable and usable.
-- [ ] 5.3 Avoid broad global CSS replacement or complete visual redesign in this change.
+- [x] 5.1 Add shell-foundation styles additively using roles from `docs/design-system-baseline.md`.
+- [x] 5.2 Keep existing transcript, trajectory, inspector, and diagnostic content readable and usable.
+- [x] 5.3 Avoid broad global CSS replacement or complete visual redesign in this change.
 
 ## 6. Tests And Validation
 
-- [ ] 6.1 Add or update targeted tests for shell navigation and `Sessions` containment.
-- [ ] 6.2 Add or update targeted tests for preserving global search session selection through the shell.
-- [ ] 6.3 Add or update targeted tests for URL restoration and URL sync compatibility.
-- [ ] 6.4 Run targeted tests for affected UI and URL-state behavior.
-- [ ] 6.5 Run `openspec validate project-shell-foundation --strict`.
+- [x] 6.1 Add or update targeted tests for shell navigation and `Sessions` containment.
+- [x] 6.2 Add or update targeted tests for preserving global search session selection through the shell.
+- [x] 6.3 Add or update targeted tests for URL restoration and URL sync compatibility.
+- [x] 6.4 Run targeted tests for affected UI and URL-state behavior.
+- [x] 6.5 Run `openspec validate project-shell-foundation --strict`.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-import HomeClient from "@/components/HomeClient";
+import ProjectShellClient from "@/components/ProjectShellClient";
 
 export default function Page() {
-  return <HomeClient />;
+  return <ProjectShellClient />;
 }
-

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -70,7 +70,41 @@ export function resolveInitialSource(input: {
   externalSelectionSource?: Source;
   defaultSource: Source;
 }): Source {
-  return input.urlSource ?? input.externalSelectionSource ?? input.defaultSource;
+  return input.externalSelectionSource ?? input.urlSource ?? input.defaultSource;
+}
+
+export function shouldResetViewerSelectionOnSourceChange(input: {
+  source: Source;
+  crossSourceSelection?: Source | null;
+  urlId?: string;
+  urlSource?: Source;
+  externalSelectionRequestId?: number | null;
+  pendingExternalSelectionRequestId?: number | null;
+}): boolean {
+  if (
+    input.externalSelectionRequestId != null
+    && input.pendingExternalSelectionRequestId === input.externalSelectionRequestId
+  ) {
+    return false;
+  }
+
+  if (input.crossSourceSelection === input.source) {
+    return false;
+  }
+
+  if (input.urlId && input.urlSource === input.source) {
+    return false;
+  }
+
+  return true;
+}
+
+export function shouldDeferSearchSelectionLoad(input: {
+  currentSource: Source;
+  nextSource: Source;
+  itemCount: number;
+}): boolean {
+  return input.nextSource !== input.currentSource || input.itemCount === 0;
 }
 
 function formatBytes(bytes: number) {
@@ -1426,6 +1460,8 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
   const crossSourceSelectionRef = useRef<Source | null>(null);
   const externalSelectionRequestRef = useRef<number | null>(null);
   const externalSelectionSourceRef = useRef<Source | undefined>(externalSelection?.source);
+  const pendingExternalSelectionRequestRef = useRef<number | null>(null);
+  const pendingSearchSelectionRef = useRef<Pick<HomeClientExternalSelection, "sessionId" | "source" | "rootId"> | null>(null);
 
   // URL deep-link: parsed once on mount. The useState lazy initializer guarantees
   // parseUrlState only runs on the first render; the ref gives mutable access
@@ -1903,6 +1939,11 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
       setAntigravityView("markdown");
       setWindsurfView("chat");
       setCollapsedExecutionGroups({});
+      if (shouldDeferSearchSelectionLoad({ currentSource: source, nextSource: sessionSource, itemCount: items.length })) {
+        pendingSearchSelectionRef.current = { sessionId, source: sessionSource, rootId };
+        return;
+      }
+      pendingSearchSelectionRef.current = null;
       loadConversation(sessionSource, sessionId, 0, sessionSource === "windsurf" ? "chat" : undefined, {
         rootId: match?.rootId ?? rootId
       }).catch(
@@ -1917,6 +1958,10 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
     if (!externalSelection) return;
     if (externalSelectionRequestRef.current === externalSelection.requestId) return;
     externalSelectionRequestRef.current = externalSelection.requestId;
+    pendingExternalSelectionRequestRef.current = externalSelection.requestId;
+    urlInitRef.current = {};
+    urlRestoringRef.current = false;
+    restorationInitiatedRef.current = false;
     handleGlobalSearchSelect(externalSelection.sessionId, externalSelection.source, externalSelection.rootId);
   }, [externalSelection, handleGlobalSearchSelect]);
 
@@ -2119,23 +2164,28 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
 
   useEffect(() => {
     loadList(source).catch(() => {});
-    // If this source change was triggered by a cross-source GlobalSearch selection
-    // (handleGlobalSearchSelect sets crossSourceSelectionRef), skip the reset so
-    // the pending session selection survives the source-change cycle.
     const crossSourceSelection = crossSourceSelectionRef.current;
-    if (crossSourceSelection) {
+    const urlInit = urlInitRef.current;
+
+    if (!shouldResetViewerSelectionOnSourceChange({
+      source,
+      crossSourceSelection,
+      urlId: urlInit.id ?? undefined,
+      urlSource: urlInit.source ?? undefined,
+      externalSelectionRequestId: externalSelection?.requestId ?? null,
+      pendingExternalSelectionRequestId: pendingExternalSelectionRequestRef.current,
+    })) {
       if (crossSourceSelection === source) {
         crossSourceSelectionRef.current = null;
-        return;
       }
-      // Stale ref for a different source; clear it so it cannot affect future switches.
-      crossSourceSelectionRef.current = null;
+      if (pendingExternalSelectionRequestRef.current === (externalSelection?.requestId ?? null)) {
+        pendingExternalSelectionRequestRef.current = null;
+      }
+      return;
     }
-    // URL deep-link: skip the reset only when the source change is the initial
-    // one driven by refreshConfigAndStatus setting the URL's target source.
-    // If the user actively switches to a different source, run the normal reset.
-    const urlInit = urlInitRef.current;
-    if (urlInit.id && source === urlInit.source) return;
+
+    crossSourceSelectionRef.current = null;
+    pendingExternalSelectionRequestRef.current = null;
 
     setSelectedKey(null);
     setSelectedId(null);
@@ -2144,7 +2194,7 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
     setAntigravityView("markdown");
     setWindsurfView("chat");
     setCollapsedExecutionGroups({});
-  }, [source]);
+  }, [source, externalSelection?.requestId]);
 
   // When items reloads (e.g. after a source-switch triggered by GlobalSearch),
   // re-derive selectedKey from selectedId so the conversation list highlights
@@ -2162,6 +2212,32 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
     const expectedKey = toSelectionKey(match.rootId, match.id);
     setSelectedKey((prev) => (prev === expectedKey ? prev : expectedKey));
   }, [items, selectedId, selectedKey]);
+
+  useEffect(() => {
+    const pendingSelection = pendingSearchSelectionRef.current;
+    if (!pendingSelection) return;
+    if (pendingSelection.source !== source) return;
+    if (loadingList || items.length === 0) return;
+
+    const match = items.find((it) => {
+      if (it.id !== pendingSelection.sessionId) return false;
+      return pendingSelection.rootId ? it.rootId === pendingSelection.rootId : true;
+    }) ?? items.find((it) => it.id === pendingSelection.sessionId);
+
+    const effectiveRootId = match?.rootId ?? pendingSelection.rootId;
+    const key = toSelectionKey(effectiveRootId, pendingSelection.sessionId);
+    setSelectedKey(key);
+    setSelectedId(pendingSelection.sessionId);
+    pendingSearchSelectionRef.current = null;
+
+    loadConversation(
+      pendingSelection.source,
+      pendingSelection.sessionId,
+      0,
+      pendingSelection.source === "windsurf" ? "chat" : undefined,
+      { rootId: effectiveRootId }
+    ).catch((e) => setError(e instanceof Error ? e.message : String(e)));
+  }, [items, loadingList, source, loadConversation]);
 
   useEffect(() => {
     if (content?.kind !== "trajectory") return;

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -53,6 +53,26 @@ type SessionBackupFeedback =
       hint?: string;
     };
 
+export type HomeClientExternalSelection = {
+  requestId: number;
+  sessionId: string;
+  source: Source;
+  rootId?: string;
+};
+
+export type HomeClientProps = {
+  chrome?: "full" | "embedded";
+  externalSelection?: HomeClientExternalSelection | null;
+};
+
+export function resolveInitialSource(input: {
+  urlSource?: Source;
+  externalSelectionSource?: Source;
+  defaultSource: Source;
+}): Source {
+  return input.urlSource ?? input.externalSelectionSource ?? input.defaultSource;
+}
+
 function formatBytes(bytes: number) {
   const units = ["B", "KB", "MB", "GB"];
   let value = bytes;
@@ -1359,7 +1379,7 @@ function fromSelectionKey(key: string | null): { rootId?: string; id: string } |
   }
 }
 
-export default function HomeClient() {
+export default function HomeClient({ chrome = "full", externalSelection = null }: HomeClientProps = {}) {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [status, setStatus] = useState<SourcesStatus | null>(null);
   const [source, setSource] = useState<Source>("antigravity");
@@ -1404,6 +1424,8 @@ export default function HomeClient() {
   // The useEffect([source]) reset checks this ref so it doesn't wipe the pending
   // session selection that the callback already queued.
   const crossSourceSelectionRef = useRef<Source | null>(null);
+  const externalSelectionRequestRef = useRef<number | null>(null);
+  const externalSelectionSourceRef = useRef<Source | undefined>(externalSelection?.source);
 
   // URL deep-link: parsed once on mount. The useState lazy initializer guarantees
   // parseUrlState only runs on the first render; the ref gives mutable access
@@ -1891,6 +1913,14 @@ export default function HomeClient() {
   );
 
   useEffect(() => {
+    externalSelectionSourceRef.current = externalSelection?.source;
+    if (!externalSelection) return;
+    if (externalSelectionRequestRef.current === externalSelection.requestId) return;
+    externalSelectionRequestRef.current = externalSelection.requestId;
+    handleGlobalSearchSelect(externalSelection.sessionId, externalSelection.source, externalSelection.rootId);
+  }, [externalSelection, handleGlobalSearchSelect]);
+
+  useEffect(() => {
     if (!pendingTrajectoryJumpEventId) return;
     if (content?.kind !== "trajectory") return;
 
@@ -1964,7 +1994,11 @@ export default function HomeClient() {
     // On manual refresh, preserve the user's current source selection.
     if (isFirstLoad) {
       const urlInit = urlInitRef.current;
-      const initSource = urlInit.source ?? cfgJson.config.ui.defaultSource;
+      const initSource = resolveInitialSource({
+        urlSource: urlInit.source ?? undefined,
+        externalSelectionSource: externalSelectionSourceRef.current,
+        defaultSource: cfgJson.config.ui.defaultSource,
+      });
       setSource(initSource);
     }
 
@@ -2374,13 +2408,13 @@ export default function HomeClient() {
     <div className="mx-auto max-w-[1200px] p-4">
       <div className="mb-4 flex items-center justify-between gap-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <div className="text-lg font-semibold">Agent Storage Manager</div>
+          <div className="text-lg font-semibold">{chrome === "full" ? "Agent Storage Manager" : "Sessions"}</div>
           {antigravityPill}
           {windsurfPill}
           {codexPill}
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <GlobalSearch onSelect={handleGlobalSearchSelect} />
+          {chrome === "full" ? <GlobalSearch onSelect={handleGlobalSearchSelect} /> : null}
           <Button variant="outline" size="sm" onClick={() => refreshConfigAndStatus()}>
             Refresh
           </Button>

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -2172,13 +2172,13 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
       crossSourceSelection,
       urlId: urlInit.id ?? undefined,
       urlSource: urlInit.source ?? undefined,
-      externalSelectionRequestId: externalSelection?.requestId ?? null,
+      externalSelectionRequestId: externalSelectionRequestRef.current,
       pendingExternalSelectionRequestId: pendingExternalSelectionRequestRef.current,
     })) {
       if (crossSourceSelection === source) {
         crossSourceSelectionRef.current = null;
       }
-      if (pendingExternalSelectionRequestRef.current === (externalSelection?.requestId ?? null)) {
+      if (pendingExternalSelectionRequestRef.current === externalSelectionRequestRef.current) {
         pendingExternalSelectionRequestRef.current = null;
       }
       return;
@@ -2194,7 +2194,7 @@ export default function HomeClient({ chrome = "full", externalSelection = null }
     setAntigravityView("markdown");
     setWindsurfView("chat");
     setCollapsedExecutionGroups({});
-  }, [source, externalSelection?.requestId]);
+  }, [source]);
 
   // When items reloads (e.g. after a source-switch triggered by GlobalSearch),
   // re-derive selectedKey from selectedId so the conversation list highlights

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import Link from "next/link";
+import React, { useCallback, useEffect, useState } from "react";
+
+import HomeClient, { type HomeClientExternalSelection } from "@/components/HomeClient";
+import { GlobalSearch } from "@/components/GlobalSearch";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { Source } from "@/lib/types";
+
+export type ProjectShellPage = "overview" | "sessions" | "assets" | "analysis" | "backup";
+
+type ProjectShellNavItem = {
+  id: ProjectShellPage;
+  label: string;
+  eyebrow: string;
+};
+
+const NAV_ITEMS: ProjectShellNavItem[] = [
+  { id: "overview", label: "Project Overview", eyebrow: "govern" },
+  { id: "sessions", label: "Sessions", eyebrow: "evidence" },
+  { id: "assets", label: "Assets", eyebrow: "context" },
+  { id: "analysis", label: "Analysis", eyebrow: "insight" },
+  { id: "backup", label: "Backup / Migration", eyebrow: "workflow" },
+];
+
+export function resolveInitialProjectShellPage(search: string): ProjectShellPage {
+  const params = new URLSearchParams(search);
+  return params.has("id") || params.has("source") ? "sessions" : "overview";
+}
+
+export function buildExternalSessionSelection(input: {
+  requestId: number;
+  sessionId: string;
+  source: Source;
+  rootId?: string;
+}): HomeClientExternalSelection {
+  return {
+    requestId: input.requestId,
+    sessionId: input.sessionId,
+    source: input.source,
+    ...(input.rootId ? { rootId: input.rootId } : {}),
+  };
+}
+
+function ProjectOverviewSurface({ onNavigate }: { onNavigate(page: ProjectShellPage): void }) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+      <div className="space-y-4">
+        <Card className="p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Badge variant="ok">Project-first</Badge>
+            <Badge variant="default">local context</Badge>
+          </div>
+          <h2 className="text-xl font-semibold">Project context command surface</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">
+            This foundation view frames the app around a local project and routes into evidence, context assets,
+            analysis, and backup workflows. It intentionally avoids inventing aggregate findings before the underlying
+            data contracts exist.
+          </p>
+        </Card>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card className="p-4">
+            <div className="text-xs uppercase tracking-[0.2em] text-muted">Attention Needed</div>
+            <h3 className="mt-2 font-semibold">Diagnostics and unresolved context issues stay routed</h3>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Use the Sessions page for current source diagnostics and session evidence. Future analysis summaries will
+              appear here only after they can route to a concrete object or workflow.
+            </p>
+            <Button className="mt-4" size="sm" onClick={() => onNavigate("sessions")}>
+              Review Sessions
+            </Button>
+          </Card>
+
+          <Card className="p-4">
+            <div className="text-xs uppercase tracking-[0.2em] text-muted">Recent Evidence</div>
+            <h3 className="mt-2 font-semibold">Session viewer remains the active evidence workbench</h3>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              Existing transcript, trajectory, inspector, error center, diagnostics, and direct session backup behavior
+              are preserved under Sessions while the project shell is introduced.
+            </p>
+            <Button className="mt-4" variant="outline" size="sm" onClick={() => onNavigate("sessions")}>
+              Open Evidence Workbench
+            </Button>
+          </Card>
+        </div>
+      </div>
+
+      <Card className="p-4">
+        <div className="text-xs uppercase tracking-[0.2em] text-muted">Quick Routes</div>
+        <div className="mt-4 space-y-2">
+          <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => onNavigate("assets")}>
+            Inspect context assets
+          </Button>
+          <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => onNavigate("analysis")}>
+            Review analysis
+          </Button>
+          <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => onNavigate("backup")}>
+            Start backup / migration
+          </Button>
+        </div>
+        <p className="mt-4 text-xs leading-5 text-muted">
+          These routes are bounded placeholders in this change. Working session backup remains available from a selected
+          session.
+        </p>
+      </Card>
+    </div>
+  );
+}
+
+function PlaceholderSurface(props: {
+  title: string;
+  label: string;
+  body: string;
+  preservedPath: string;
+  onNavigateSessions: () => void;
+}) {
+  return (
+    <Card className="p-5">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Badge variant="default">{props.label}</Badge>
+        <Badge variant="warn">foundation placeholder</Badge>
+      </div>
+      <h2 className="text-xl font-semibold">{props.title}</h2>
+      <p className="mt-3 max-w-3xl text-sm leading-6 text-muted">{props.body}</p>
+      <div className="mt-5 rounded-lg border border-border/70 bg-background/35 p-4 text-sm text-muted">
+        Current working path: {props.preservedPath}
+      </div>
+      <Button className="mt-5" variant="outline" size="sm" onClick={props.onNavigateSessions}>
+        Return to Sessions
+      </Button>
+    </Card>
+  );
+}
+
+export default function ProjectShellClient() {
+  const [activePage, setActivePage] = useState<ProjectShellPage>("overview");
+  const [externalSelection, setExternalSelection] = useState<HomeClientExternalSelection | null>(null);
+
+  useEffect(() => {
+    setActivePage(resolveInitialProjectShellPage(window.location.search));
+  }, []);
+
+  const handleSearchSelect = useCallback((sessionId: string, source: Source, rootId?: string) => {
+    setActivePage("sessions");
+    setExternalSelection((prev) =>
+      buildExternalSessionSelection({
+        requestId: (prev?.requestId ?? 0) + 1,
+        sessionId,
+        source,
+        rootId,
+      })
+    );
+  }, []);
+
+  const activeNav = NAV_ITEMS.find((item) => item.id === activePage) ?? NAV_ITEMS[0]!;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4 p-4">
+        <header className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="text-xl font-semibold">Agent Context Insightor</h1>
+                <Badge variant="ok">local-first</Badge>
+                <Badge variant="default">project shell</Badge>
+              </div>
+              <p className="mt-1 text-sm text-muted">
+                Project view for agent sessions, context assets, analysis, and backup workflows.
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-wrap items-center gap-2">
+              <GlobalSearch onSelect={handleSearchSelect} />
+              <Button asChild variant="outline" size="sm">
+                <Link href="/settings">Settings</Link>
+              </Button>
+            </div>
+          </div>
+
+          <nav className="mt-4 flex gap-2 overflow-x-auto pb-1" aria-label="Project sections">
+            {NAV_ITEMS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setActivePage(item.id)}
+                className={cn(
+                  "min-w-fit rounded-xl border px-3 py-2 text-left transition-colors",
+                  item.id === activePage
+                    ? "border-accent/70 bg-accent/15 text-foreground"
+                    : "border-border/60 bg-background/30 text-muted hover:border-accent/40 hover:text-foreground"
+                )}
+                aria-current={item.id === activePage ? "page" : undefined}
+              >
+                <div className="text-[10px] uppercase tracking-[0.18em] opacity-75">{item.eyebrow}</div>
+                <div className="text-sm font-medium">{item.label}</div>
+              </button>
+            ))}
+          </nav>
+        </header>
+
+        <main className="min-w-0">
+          {activePage !== "sessions" ? (
+            <div className="mb-3 flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-card/50 px-4 py-3">
+              <div>
+                <div className="text-xs uppercase tracking-[0.2em] text-muted">Current Surface</div>
+                <div className="font-semibold">{activeNav.label}</div>
+              </div>
+              <Badge variant="default">{activeNav.eyebrow}</Badge>
+            </div>
+          ) : null}
+
+          {activePage === "overview" ? <ProjectOverviewSurface onNavigate={setActivePage} /> : null}
+          {activePage === "sessions" ? (
+            <HomeClient chrome="embedded" externalSelection={externalSelection} />
+          ) : null}
+          {activePage === "assets" ? (
+            <PlaceholderSurface
+              title="Assets"
+              label="context inventory"
+              body="Rules, memory, skills, and commands will be organized here by scope, source, status, provenance, and in-effect usage. This placeholder does not claim inventory completeness yet."
+              preservedPath="Use Sessions for source evidence and session-level extraction until asset contracts are implemented."
+              onNavigateSessions={() => setActivePage("sessions")}
+            />
+          ) : null}
+          {activePage === "analysis" ? (
+            <PlaceholderSurface
+              title="Analysis"
+              label="interpretation"
+              body="Analysis will summarize context issues and route each finding to a concrete object or workflow. This placeholder avoids creating a findings inventory before analysis contracts exist."
+              preservedPath="Use Sessions inspector and error center for current evidence-driven investigation."
+              onNavigateSessions={() => setActivePage("sessions")}
+            />
+          ) : null}
+          {activePage === "backup" ? (
+            <PlaceholderSurface
+              title="Backup / Migration"
+              label="restricted workflow"
+              body="Project-level backup and migration workflows will live here once bundle and migration contracts are implemented. Existing direct session backup remains inside selected Sessions."
+              preservedPath="Open a session and use its Backup Session action for current supported backup behavior."
+              onNavigateSessions={() => setActivePage("sessions")}
+            />
+          ) : null}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/tests/homeClient.test.ts
+++ b/tests/homeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildSessionBackupRequest, resolveRestoredSelection, supportsSessionSourceCopy } from "@/components/HomeClient";
+import { buildSessionBackupRequest, resolveInitialSource, resolveRestoredSelection, supportsSessionSourceCopy } from "@/components/HomeClient";
 import type { ConversationListItem } from "@/lib/types";
 
 function makeItem(overrides: Partial<ConversationListItem>): ConversationListItem {
@@ -45,6 +45,35 @@ describe("resolveRestoredSelection", () => {
 
     expect(result.effectiveRootId).toBeUndefined();
     expect(result.selectedKey).toBe(JSON.stringify({ rootId: "unknown", id: "session-1" }));
+  });
+});
+
+describe("resolveInitialSource", () => {
+  it("prefers URL source over external search selection and default source", () => {
+    expect(
+      resolveInitialSource({
+        urlSource: "codex",
+        externalSelectionSource: "windsurf",
+        defaultSource: "antigravity",
+      })
+    ).toBe("codex");
+  });
+
+  it("prefers external search selection over default source", () => {
+    expect(
+      resolveInitialSource({
+        externalSelectionSource: "codex",
+        defaultSource: "antigravity",
+      })
+    ).toBe("codex");
+  });
+
+  it("falls back to default source when no URL or external selection exists", () => {
+    expect(
+      resolveInitialSource({
+        defaultSource: "windsurf",
+      })
+    ).toBe("windsurf");
   });
 });
 

--- a/tests/homeClient.test.ts
+++ b/tests/homeClient.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { buildSessionBackupRequest, resolveInitialSource, resolveRestoredSelection, supportsSessionSourceCopy } from "@/components/HomeClient";
+import {
+  buildSessionBackupRequest,
+  resolveInitialSource,
+  resolveRestoredSelection,
+  shouldDeferSearchSelectionLoad,
+  shouldResetViewerSelectionOnSourceChange,
+  supportsSessionSourceCopy,
+} from "@/components/HomeClient";
 import type { ConversationListItem } from "@/lib/types";
 
 function makeItem(overrides: Partial<ConversationListItem>): ConversationListItem {
@@ -49,14 +56,14 @@ describe("resolveRestoredSelection", () => {
 });
 
 describe("resolveInitialSource", () => {
-  it("prefers URL source over external search selection and default source", () => {
+  it("prefers external search selection over URL source and default source", () => {
     expect(
       resolveInitialSource({
         urlSource: "codex",
         externalSelectionSource: "windsurf",
         defaultSource: "antigravity",
       })
-    ).toBe("codex");
+    ).toBe("windsurf");
   });
 
   it("prefers external search selection over default source", () => {
@@ -74,6 +81,79 @@ describe("resolveInitialSource", () => {
         defaultSource: "windsurf",
       })
     ).toBe("windsurf");
+  });
+});
+
+describe("shouldResetViewerSelectionOnSourceChange", () => {
+  it("keeps a freshly requested external selection during the initial sessions mount", () => {
+    expect(
+      shouldResetViewerSelectionOnSourceChange({
+        source: "antigravity",
+        externalSelectionRequestId: 7,
+        pendingExternalSelectionRequestId: 7,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps the pending selection across a cross-source switch", () => {
+    expect(
+      shouldResetViewerSelectionOnSourceChange({
+        source: "codex",
+        crossSourceSelection: "codex",
+      })
+    ).toBe(false);
+  });
+
+  it("does not reset while restoring the currently addressed URL session", () => {
+    expect(
+      shouldResetViewerSelectionOnSourceChange({
+        source: "windsurf",
+        urlId: "session-9",
+        urlSource: "windsurf",
+      })
+    ).toBe(false);
+  });
+
+  it("resets normally when there is no pending external selection or matching URL restore", () => {
+    expect(
+      shouldResetViewerSelectionOnSourceChange({
+        source: "antigravity",
+        urlId: "session-9",
+        urlSource: "codex",
+      })
+    ).toBe(true);
+  });
+});
+
+describe("shouldDeferSearchSelectionLoad", () => {
+  it("defers loading when the search result targets a different source", () => {
+    expect(
+      shouldDeferSearchSelectionLoad({
+        currentSource: "antigravity",
+        nextSource: "codex",
+        itemCount: 200,
+      })
+    ).toBe(true);
+  });
+
+  it("defers loading on a fresh mount before the conversation list is ready", () => {
+    expect(
+      shouldDeferSearchSelectionLoad({
+        currentSource: "antigravity",
+        nextSource: "antigravity",
+        itemCount: 0,
+      })
+    ).toBe(true);
+  });
+
+  it("loads immediately when the target source already matches and items exist", () => {
+    expect(
+      shouldDeferSearchSelectionLoad({
+        currentSource: "codex",
+        nextSource: "codex",
+        itemCount: 12,
+      })
+    ).toBe(false);
   });
 });
 

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { buildExternalSessionSelection, resolveInitialProjectShellPage } from "@/components/ProjectShellClient";
+
+describe("resolveInitialProjectShellPage", () => {
+  it("opens project overview for a root URL", () => {
+    expect(resolveInitialProjectShellPage("")).toBe("overview");
+  });
+
+  it("opens sessions when a session deep link is present", () => {
+    expect(resolveInitialProjectShellPage("?source=codex&id=session-1&rootId=root-a")).toBe("sessions");
+  });
+
+  it("opens sessions when a source-scoped URL is present", () => {
+    expect(resolveInitialProjectShellPage("?source=windsurf")).toBe("sessions");
+  });
+});
+
+describe("buildExternalSessionSelection", () => {
+  it("keeps the global search selection payload explicit", () => {
+    expect(
+      buildExternalSessionSelection({
+        requestId: 3,
+        sessionId: "session-1",
+        source: "codex",
+        rootId: "root-a",
+      })
+    ).toEqual({
+      requestId: 3,
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-a",
+    });
+  });
+
+  it("omits absent root ids", () => {
+    expect(
+      buildExternalSessionSelection({
+        requestId: 4,
+        sessionId: "session-2",
+        source: "antigravity",
+      })
+    ).toEqual({
+      requestId: 4,
+      sessionId: "session-2",
+      source: "antigravity",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first project-first shell foundation for Agent Storage Manager:

- introduces top-level surfaces for Project Overview, Sessions, Assets, Analysis, and Backup / Migration
- wraps the existing session viewer under Sessions without removing source diagnostics, deep links, viewer modes, inspector/error center, or direct session backup
- adds bounded placeholders for future Assets, Analysis, and Backup / Migration surfaces
- fixes shell-level global search so selecting a result from Project Overview opens the expected target session in Sessions
- records OpenSpec task completion, changelog entry, and browser QA report

## Validation

- `pnpm test tests/projectShellClient.test.ts tests/homeClient.test.ts tests/urlState.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `openspec validate project-shell-foundation --strict`
- Browser QA report: `docs/viewer/project-shell-foundation-qa.md`

Note: `openspec validate` succeeds, but the CLI still emits non-blocking PostHog telemetry DNS noise in this local environment.