### PR TITLE
feat: add analysis foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Do not duplicate the same fact across these files unless each copy serves a diff
 - Treat Copilot review comments as advisory input, not merge-blocking approval or requested changes.
 - Classify review feedback before editing: `must-fix`, `should-fix`, `product-decision`, or `ignore`.
 - Do not automatically change product names, scope boundaries, or placeholder commitments without user confirmation.
-- After pushing review fixes, request Copilot re-review manually or with `gh` when available; do not assume Copilot re-reviews automatically after new commits.
+- After pushing review fixes, request Copilot re-review manually or with `gh pr edit <number> --add-reviewer copilot-pull-request-reviewer` when available; do not assume Copilot re-reviews automatically after new commits.
 - Keep review-fix commits separate from process/documentation workflow changes when practical.
 - External QA reports should preserve original findings. If a blocker is fixed and retested, add a clear re-test result instead of deleting the original failure record.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ This file records shipped, merged changes for Agent Storage Manager.
   - Added local asset seed data, normalization helpers, subtype/scope/source/status filtering, selected asset detail, provenance, and in-effect/usage cues
   - Added routed handoff paths into `Assets` from Sessions, Project Overview, and Analysis without carrying full transcript or trajectory state
 
+- `2026-04-12` — Analysis foundation
+  - Replaced the `Analysis` placeholder with a bounded interpretation-and-routing surface for local context findings
+  - Added local analysis seed data, normalization helpers, issue/severity/object/status filtering, health summary, finding detail, evidence context, and route-only recommended actions
+  - Added routed handoff paths into `Analysis` from Assets, Project Overview, and Sessions without claiming complete automated analysis or inline remediation
+
 - `2026-04-10` — Session Backup foundation
   - Added canonical `session-record/v1` and `session-backup/v1` schemas plus managed backup storage under `~/.agent-storage-manager/backups`
   - Added create/import/verify APIs for session backups, with schema/integrity validation and stable user-facing diagnostics

--- a/README.md
+++ b/README.md
@@ -62,11 +62,16 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - top-level surfaces for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`
   - `Sessions` contains the existing viewer, source diagnostics, URL deep links, search selection, and direct session backup behavior
   - `Assets` provides a bounded reusable context assets foundation for rules, memory, skills, commands, and unknown asset fragments
-  - `Analysis` and `Backup / Migration` remain bounded foundation surfaces until their full workflows are implemented
+  - `Analysis` provides a bounded interpretation-and-routing foundation for local context findings
+  - `Backup / Migration` remains a bounded foundation surface until full project-level workflows are implemented
 - Assets foundation:
   - local-first reusable context asset model with subtype, scope, source, status, provenance, optional body summary, and in-effect/usage metadata
   - subtype/scope/source/status filtering with asset summary, inventory, selected detail, provenance, and in-effect/usage regions
   - routed handoff into `Assets` from Sessions, Project Overview, and Analysis without carrying full transcript or trajectory state
+- Analysis foundation:
+  - local-first analysis finding model with issue class, severity, status, affected object, evidence references, route targets, and preservation warnings
+  - context health summary, findings inventory, selected finding detail, evidence context, and route-only recommended actions
+  - routed handoff into `Analysis` from Assets, Project Overview, and Sessions without claiming complete automated project analysis or inline remediation
 - Scan and list session files (default directories + custom roots from Settings)
   - Antigravity / Windsurf: `.pb` session files (flat directory)
   - Codex CLI: `.jsonl` session files (nested `YYYY/MM/DD/` directory structure)

--- a/docs/viewer/analysis-foundation-qa-prompt.md
+++ b/docs/viewer/analysis-foundation-qa-prompt.md
@@ -1,0 +1,70 @@
+# Analysis Foundation QA Prompt
+
+Use this prompt with an external QA agent that can operate the local app through a browser.
+
+```text
+You are QA-ing the `analysis-foundation` implementation for the local-first Agent Storage Manager project.
+
+Repository: /Users/tr/Workspace/agent-storage-manager
+Branch under test: feat/analysis-foundation
+
+Goal:
+Verify that the new Analysis foundation behaves as a bounded interpretation-and-routing surface. It should show local context findings, explain why they matter, and route users to owning pages without claiming complete automated analysis, automatic fixes, asset editing, session mutation, or backup execution inside Analysis.
+
+Setup:
+1. Run `pnpm install` if dependencies are missing.
+2. Start the app with `pnpm dev`.
+3. Open the local dev URL, usually `http://localhost:3000`.
+4. If the session list is empty, focus QA on the project shell, Assets, Analysis, and visible seeded/foundation states. Do not require real Antigravity/Windsurf/Codex sessions unless available locally.
+
+Primary smoke checks:
+1. Open `Project Overview`.
+2. Confirm the top-level nav includes `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`.
+3. Open `Analysis` from the top-level nav.
+4. Confirm the Analysis page is no longer a placeholder.
+5. Confirm it shows:
+   - Analysis header
+   - Context Health Summary
+   - Findings Inventory
+   - Finding Detail
+   - Recommended Actions
+6. Confirm copy clearly says this is bounded foundation behavior and does not claim automatic remediation.
+
+Analysis state checks:
+1. In normal top-level Analysis browsing, confirm seeded findings appear.
+2. Select at least one finding and confirm the selected row is visibly active.
+3. Confirm the detail panel shows title, issue class, severity/status/object context, why it matters, evidence context when available, and route-only actions.
+4. Confirm high-severity or preservation-sensitive findings show a warning/issue-heavy cue.
+5. Change filters until no findings match. Confirm an empty state appears and no fake findings are shown.
+6. Confirm changing filters or object focus clears/downgrades routed context cues when applicable.
+
+Routed handoff checks:
+1. From `Project Overview`, use a route into Analysis if present, such as `Review Analysis`.
+2. Confirm Analysis shows a compact routed cue from overview and applies the relevant issue context.
+3. From `Assets`, select or route to an issue-related asset and use `Review in Analysis` or equivalent.
+4. Confirm Analysis shows a compact routed cue from assets, preserves affected asset context, and does not embed the full Assets inventory.
+5. From `Sessions`, if a selected session is available, use `Review in Analysis`.
+6. Confirm Analysis shows a compact routed cue from sessions and does not carry transcript/trajectory reading mode into Analysis.
+
+Outbound route checks:
+1. From a selected Analysis finding with an Assets route, click the route.
+2. Confirm the app opens `Assets` with routed context, selected or filtered affected asset when available, and compact origin cue from Analysis.
+3. From a selected Analysis finding with a Sessions route, click the route.
+4. Confirm the app opens `Sessions` and attempts to select the referenced session without polluting URL state after leaving Sessions.
+5. From a selected Analysis finding with a Backup / Migration route, click the route.
+6. Confirm the app opens `Backup / Migration` with a routed cue, but does not execute backup or migration inline.
+
+Regression checks:
+1. Assets page still renders its asset foundation correctly.
+2. Existing direct session backup button remains under `Sessions`, not under Analysis.
+3. Top-level navigation to Analysis without routed context clears old routed cues.
+4. Top-level navigation away from Sessions clears session viewer URL params as before.
+
+Report format:
+- Verdict: Pass / Fail / Pass with concerns
+- Environment: browser, OS, local URL
+- Blocking issues: list exact steps, expected result, actual result, screenshots if possible
+- Non-blocking concerns: wording, layout, confusing state transitions
+- Regression notes: anything broken in Sessions, Assets, or Backup / Migration
+- Suggested follow-up tests
+```

--- a/docs/viewer/analysis-foundation-qa-prompt.md
+++ b/docs/viewer/analysis-foundation-qa-prompt.md
@@ -5,17 +5,18 @@ Use this prompt with an external QA agent that can operate the local app through
 ```text
 You are QA-ing the `analysis-foundation` implementation for the local-first Agent Storage Manager project.
 
-Repository: /Users/tr/Workspace/agent-storage-manager
+Repository: <repo-path>
 Branch under test: feat/analysis-foundation
 
 Goal:
 Verify that the new Analysis foundation behaves as a bounded interpretation-and-routing surface. It should show local context findings, explain why they matter, and route users to owning pages without claiming complete automated analysis, automatic fixes, asset editing, session mutation, or backup execution inside Analysis.
 
 Setup:
-1. Run `pnpm install` if dependencies are missing.
-2. Start the app with `pnpm dev`.
-3. Open the local dev URL, usually `http://localhost:3000`.
-4. If the session list is empty, focus QA on the project shell, Assets, Analysis, and visible seeded/foundation states. Do not require real Antigravity/Windsurf/Codex sessions unless available locally.
+1. Use the QA agent's local checkout path for `<repo-path>`.
+2. Run `pnpm install` if dependencies are missing.
+3. Start the app with `pnpm dev`.
+4. Open the local dev URL, usually `http://localhost:3000`.
+5. If the session list is empty, focus QA on the project shell, Assets, Analysis, and visible seeded/foundation states. Do not require real Antigravity/Windsurf/Codex sessions unless available locally.
 
 Primary smoke checks:
 1. Open `Project Overview`.

--- a/openspec/changes/analysis-foundation/tasks.md
+++ b/openspec/changes/analysis-foundation/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Analysis Model
 
-- [ ] 1.1 Define bounded analysis finding, handoff, filter, summary, and route target types.
-- [ ] 1.2 Add deterministic local seed findings covering normal, selected, issue-heavy, routed-in, empty, and stale handoff states.
-- [ ] 1.3 Add helper functions for normalization, filtering, summary derivation, selected finding resolution, and handoff-to-filter mapping.
+- [x] 1.1 Define bounded analysis finding, handoff, filter, summary, and route target types.
+- [x] 1.2 Add deterministic local seed findings covering normal, selected, issue-heavy, routed-in, empty, and stale handoff states.
+- [x] 1.3 Add helper functions for normalization, filtering, summary derivation, selected finding resolution, and handoff-to-filter mapping.
 
 ## 2. Analysis Surface
 
-- [ ] 2.1 Replace the Analysis placeholder with a bounded Analysis foundation component.
-- [ ] 2.2 Render the Analysis header, context health summary, findings inventory, selected finding detail, and recommended actions.
-- [ ] 2.3 Render explicit empty, loading, normal, selected, issue-heavy, routed-in, and stale handoff states.
-- [ ] 2.4 Keep placeholder/bounded copy clear so the surface does not imply complete automated analysis.
+- [x] 2.1 Replace the Analysis placeholder with a bounded Analysis foundation component.
+- [x] 2.2 Render the Analysis header, context health summary, findings inventory, selected finding detail, and recommended actions.
+- [x] 2.3 Render explicit empty, loading, normal, selected, issue-heavy, routed-in, and stale handoff states.
+- [x] 2.4 Keep placeholder/bounded copy clear so the surface does not imply complete automated analysis.
 
 ## 3. Routed Handoff
 
-- [ ] 3.1 Add shell-level handoff builders for `Assets -> Analysis`, `Project Overview -> Analysis`, and `Sessions -> Analysis`.
-- [ ] 3.2 Wire Analysis outbound routes to `Sessions`, `Assets`, and `Backup / Migration` without executing destination workflows inline.
-- [ ] 3.3 Preserve compact origin, issue, continue-task, and preservation warning cues according to existing cue lifecycle rules.
-- [ ] 3.4 Ensure normal top-level navigation clears stale Analysis handoff context.
+- [x] 3.1 Add shell-level handoff builders for `Assets -> Analysis`, `Project Overview -> Analysis`, and `Sessions -> Analysis`.
+- [x] 3.2 Wire Analysis outbound routes to `Sessions`, `Assets`, and `Backup / Migration` without executing destination workflows inline.
+- [x] 3.3 Preserve compact origin, issue, continue-task, and preservation warning cues according to existing cue lifecycle rules.
+- [x] 3.4 Ensure normal top-level navigation clears stale Analysis handoff context.
 
 ## 4. Tests and QA
 
-- [ ] 4.1 Add unit tests for analysis finding normalization, filters, summaries, and selected finding resolution.
-- [ ] 4.2 Add component tests for normal, empty, selected, issue-heavy, routed-in, and stale handoff Analysis states.
-- [ ] 4.3 Add shell tests for route builders and cross-page navigation from Analysis to destination surfaces.
-- [ ] 4.4 Prepare an external QA prompt covering Analysis foundation smoke flows and routed handoff flows.
+- [x] 4.1 Add unit tests for analysis finding normalization, filters, summaries, and selected finding resolution.
+- [x] 4.2 Add component tests for normal, empty, selected, issue-heavy, routed-in, and stale handoff Analysis states.
+- [x] 4.3 Add shell tests for route builders and cross-page navigation from Analysis to destination surfaces.
+- [x] 4.4 Prepare an external QA prompt covering Analysis foundation smoke flows and routed handoff flows.
 
 ## 5. Documentation and Validation
 
-- [ ] 5.1 Update README and CHANGELOG when implementation ships.
-- [ ] 5.2 Run targeted tests for analysis helpers, Analysis component, and project shell routing.
-- [ ] 5.3 Run `pnpm test`, `pnpm build`, and `openspec validate analysis-foundation --strict`.
+- [x] 5.1 Update README and CHANGELOG when implementation ships.
+- [x] 5.2 Run targeted tests for analysis helpers, Analysis component, and project shell routing.
+- [x] 5.3 Run `pnpm test`, `pnpm build`, and `openspec validate analysis-foundation --strict`.

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -1,0 +1,552 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Select } from "@/components/ui/select";
+import {
+  ANALYSIS_FINDING_STATUSES,
+  ANALYSIS_ISSUE_CLASSES,
+  ANALYSIS_OBJECT_TYPES,
+  ANALYSIS_SEVERITIES,
+  applyAnalysisFilters,
+  buildAssetsHandoffFromAnalysisRoute,
+  buildFiltersFromAnalysisHandoff,
+  createAnalysisFindingSeeds,
+  createDefaultAnalysisFilters,
+  deriveAnalysisSurfaceState,
+  formatAnalysisFindingStatusLabel,
+  formatAnalysisIssueClassLabel,
+  formatAnalysisObjectTypeLabel,
+  formatAnalysisSeverityLabel,
+  resolveAnalysisFindingSelection,
+  summarizeAnalysisFindings,
+  type AnalysisFinding,
+  type AnalysisFindingStatus,
+  type AnalysisFilters,
+  type AnalysisHandoff,
+  type AnalysisIssueClass,
+  type AnalysisObjectType,
+  type AnalysisRoute,
+  type AnalysisSeverity,
+} from "@/lib/analysisFindings";
+import type { AssetsHandoff } from "@/lib/contextAssets";
+import type { Source } from "@/lib/types";
+
+export type AnalysisFoundationProps = {
+  handoff: AnalysisHandoff | null;
+  onOpenAssets(handoff: AssetsHandoff): void;
+  onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string }): void;
+  onOpenOverview(): void;
+  onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
+  loadingDelayMs?: number;
+};
+
+const LOADING_DELAY_MS = 120;
+
+function FilterSelect<T extends string>(props: {
+  label: string;
+  value: T | "all";
+  options: readonly T[];
+  onChange(value: T | "all"): void;
+  formatLabel(value: T | "all"): string;
+}) {
+  return (
+    <label className="grid gap-1 text-xs text-muted">
+      <span className="uppercase tracking-[0.18em]">{props.label}</span>
+      <Select value={props.value} onChange={(event) => props.onChange(event.target.value as T | "all")}>
+        <option value="all">All</option>
+        {props.options.map((option) => (
+          <option key={option} value={option}>
+            {props.formatLabel(option)}
+          </option>
+        ))}
+      </Select>
+    </label>
+  );
+}
+
+function renderSeverityBadge(severity: AnalysisSeverity) {
+  if (severity === "high") return <Badge variant="warn">High</Badge>;
+  if (severity === "unknown") return <Badge variant="default">Unknown</Badge>;
+  return <Badge variant={severity === "low" ? "ok" : "default"}>{formatAnalysisSeverityLabel(severity)}</Badge>;
+}
+
+function CueStrip(props: {
+  handoff: AnalysisHandoff | null;
+  staleSelection: boolean;
+  filteredCount: number;
+}) {
+  if (!props.handoff) return null;
+
+  return (
+    <Card className="border-accent/30 bg-accent/8 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="default">routed analysis</Badge>
+            <Badge variant="ok">from {props.handoff.origin}</Badge>
+            {props.handoff.issueClass ? <Badge variant="warn">{formatAnalysisIssueClassLabel(props.handoff.issueClass)}</Badge> : null}
+          </div>
+          <div className="text-sm font-medium">{props.handoff.subtitle}</div>
+          <div className="text-xs leading-5 text-muted">
+            {props.staleSelection
+              ? "The original finding could not be selected. Any still-valid issue or object filters are preserved so the routed task can degrade safely."
+              : props.filteredCount === 0
+                ? "No findings currently match the routed context. Filters stay visible so you can adjust without losing the original task framing."
+                : props.handoff.continueLabel ?? "Continue interpreting the routed issue context here."}
+          </div>
+        </div>
+        {props.handoff.returnLabel ? <Badge variant="default">{props.handoff.returnLabel}</Badge> : null}
+      </div>
+    </Card>
+  );
+}
+
+function RouteButton(props: {
+  finding: AnalysisFinding;
+  route: AnalysisRoute;
+  onOpenAssets(handoff: AssetsHandoff): void;
+  onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string }): void;
+  onOpenOverview(): void;
+  onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
+}) {
+  if (props.route.target === "assets" && props.route.assetId) {
+    return (
+      <Button size="sm" variant="outline" onClick={() => props.onOpenAssets(buildAssetsHandoffFromAnalysisRoute(props.route, props.finding))}>
+        {props.route.label}
+      </Button>
+    );
+  }
+
+  if (props.route.target === "sessions" && props.route.sessionId && props.route.source) {
+    return (
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() =>
+          props.onOpenSession({
+            sessionId: props.route.sessionId!,
+            source: props.route.source!,
+            rootId: props.route.rootId,
+          })
+        }
+      >
+        {props.route.label}
+      </Button>
+    );
+  }
+
+  if (props.route.target === "backup") {
+    return (
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() =>
+          props.onOpenBackup({
+            findingId: props.finding.id,
+            title: props.finding.title,
+            preservationWarning: props.route.preservationWarning ?? props.finding.preservationWarning,
+            routeLabel: props.route.label,
+          })
+        }
+      >
+        {props.route.label}
+      </Button>
+    );
+  }
+
+  if (props.route.target === "overview") {
+    return (
+      <Button size="sm" variant="outline" onClick={props.onOpenOverview}>
+        {props.route.label}
+      </Button>
+    );
+  }
+
+  return (
+    <Badge variant="default">
+      {props.route.label}: unavailable route context
+    </Badge>
+  );
+}
+
+export function AnalysisFoundation({
+  handoff,
+  onOpenAssets,
+  onOpenBackup,
+  onOpenOverview,
+  onOpenSession,
+  loadingDelayMs = LOADING_DELAY_MS,
+}: AnalysisFoundationProps) {
+  const findings = useMemo(() => createAnalysisFindingSeeds(), []);
+  const initialFilters = buildFiltersFromAnalysisHandoff(handoff, createDefaultAnalysisFilters());
+  const initialFilteredFindings = applyAnalysisFilters(findings, initialFilters);
+  const initialSelectedFinding = resolveAnalysisFindingSelection(initialFilteredFindings, handoff);
+  const [filters, setFilters] = useState<AnalysisFilters>(() => initialFilters);
+  const [selectedFindingId, setSelectedFindingId] = useState<string | null>(initialSelectedFinding?.id ?? null);
+  const [activeHandoff, setActiveHandoff] = useState<AnalysisHandoff | null>(handoff);
+  const [staleSelection, setStaleSelection] = useState(Boolean(handoff?.findingId || handoff?.assetId || handoff?.sessionId) && !initialSelectedFinding);
+  const [isLoading, setIsLoading] = useState(loadingDelayMs > 0);
+  const loadingTimeoutRef = useRef<number | null>(null);
+
+  const clearLoadingTimeout = useCallback(() => {
+    if (loadingTimeoutRef.current === null) return;
+    window.clearTimeout(loadingTimeoutRef.current);
+    loadingTimeoutRef.current = null;
+  }, []);
+
+  const scheduleLoadingComplete = useCallback((callback: () => void) => {
+    clearLoadingTimeout();
+    if (loadingDelayMs <= 0) {
+      callback();
+      return;
+    }
+    loadingTimeoutRef.current = window.setTimeout(() => {
+      loadingTimeoutRef.current = null;
+      callback();
+    }, loadingDelayMs);
+  }, [clearLoadingTimeout, loadingDelayMs]);
+
+  useEffect(() => {
+    const nextFilters = buildFiltersFromAnalysisHandoff(handoff, createDefaultAnalysisFilters());
+    setFilters(nextFilters);
+    setActiveHandoff(handoff);
+    setIsLoading(true);
+
+    scheduleLoadingComplete(() => {
+      const filtered = applyAnalysisFilters(findings, nextFilters);
+      const selected = resolveAnalysisFindingSelection(filtered, handoff);
+      setSelectedFindingId(selected?.id ?? null);
+      setStaleSelection(Boolean(handoff?.findingId || handoff?.assetId || handoff?.sessionId) && !selected);
+      setIsLoading(false);
+    });
+
+    return clearLoadingTimeout;
+  }, [clearLoadingTimeout, findings, handoff, scheduleLoadingComplete]);
+
+  const filteredFindings = useMemo(() => applyAnalysisFilters(findings, filters), [filters, findings]);
+  const selectedFinding = useMemo(
+    () => filteredFindings.find((finding) => finding.id === selectedFindingId) ?? null,
+    [filteredFindings, selectedFindingId]
+  );
+  const summary = useMemo(() => summarizeAnalysisFindings(filteredFindings), [filteredFindings]);
+  const surfaceState = deriveAnalysisSurfaceState({
+    isLoading,
+    filteredFindings,
+    selectedFindingId,
+  });
+
+  function acknowledgeRoutedContext() {
+    if (!activeHandoff) return;
+    setActiveHandoff(null);
+  }
+
+  function updateFilter<K extends keyof AnalysisFilters>(key: K, value: AnalysisFilters[K]) {
+    acknowledgeRoutedContext();
+    setFilters((current) => ({ ...current, [key]: value }));
+    setSelectedFindingId(null);
+    setStaleSelection(false);
+    setIsLoading(true);
+    scheduleLoadingComplete(() => setIsLoading(false));
+  }
+
+  function handleSelectFinding(finding: AnalysisFinding) {
+    if (finding.id !== selectedFindingId) {
+      acknowledgeRoutedContext();
+    }
+    setSelectedFindingId(finding.id);
+  }
+
+  return (
+    <div className="space-y-4">
+      <CueStrip handoff={activeHandoff} staleSelection={staleSelection} filteredCount={filteredFindings.length} />
+
+      <Card className="p-4">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="default">interpretation and routing</Badge>
+              {surfaceState === "issue-heavy" ? <Badge variant="warn">issue-heavy state</Badge> : null}
+              {surfaceState === "empty" ? <Badge variant="default">empty state</Badge> : null}
+              {surfaceState === "loading" ? <Badge variant="default">loading</Badge> : null}
+              {activeHandoff ? <Badge variant="ok">routed-in</Badge> : null}
+            </div>
+            <h2 className="text-xl font-semibold">Analysis</h2>
+            <p className="max-w-3xl text-sm leading-6 text-muted">
+              Interpret local context issues, preserve evidence boundaries, and route each finding to the owning surface. This foundation does not claim automatic fixes, asset editing, session mutation, or backup execution.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <FilterSelect
+              label="Issue class"
+              value={filters.issueClass}
+              options={ANALYSIS_ISSUE_CLASSES}
+              onChange={(value) => updateFilter("issueClass", value as AnalysisIssueClass | "all")}
+              formatLabel={(value) => (value === "all" ? "All" : formatAnalysisIssueClassLabel(value as AnalysisIssueClass))}
+            />
+            <FilterSelect
+              label="Severity"
+              value={filters.severity}
+              options={ANALYSIS_SEVERITIES}
+              onChange={(value) => updateFilter("severity", value as AnalysisSeverity | "all")}
+              formatLabel={(value) => (value === "all" ? "All" : formatAnalysisSeverityLabel(value as AnalysisSeverity))}
+            />
+            <FilterSelect
+              label="Object"
+              value={filters.objectType}
+              options={ANALYSIS_OBJECT_TYPES}
+              onChange={(value) => updateFilter("objectType", value as AnalysisObjectType | "all")}
+              formatLabel={(value) => (value === "all" ? "All" : formatAnalysisObjectTypeLabel(value as AnalysisObjectType))}
+            />
+            <FilterSelect
+              label="Status"
+              value={filters.status}
+              options={ANALYSIS_FINDING_STATUSES}
+              onChange={(value) => updateFilter("status", value as AnalysisFindingStatus | "all")}
+              formatLabel={(value) => (value === "all" ? "All" : formatAnalysisFindingStatusLabel(value as AnalysisFindingStatus))}
+            />
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.85fr)]">
+        <div className="space-y-4">
+          <Card className="p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-[0.18em] text-muted">Context Health Summary</div>
+                <div className="mt-2 text-2xl font-semibold">{summary.total}</div>
+                <div className="text-sm text-muted">matching findings in the current context</div>
+              </div>
+              <div className="grid gap-2 text-sm text-muted sm:grid-cols-2">
+                <div className="rounded-xl border border-border/60 bg-background/15 px-3 py-2">
+                  <div className="text-xs uppercase tracking-[0.18em]">High severity</div>
+                  <div className="mt-1 font-semibold text-foreground">{summary.highSeverity}</div>
+                </div>
+                <div className="rounded-xl border border-border/60 bg-background/15 px-3 py-2">
+                  <div className="text-xs uppercase tracking-[0.18em]">Preservation</div>
+                  <div className="mt-1 font-semibold text-foreground">{summary.preservationSensitive}</div>
+                </div>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {ANALYSIS_ISSUE_CLASSES.map((issueClass) => (
+                <Badge key={issueClass} variant={summary.issueClassCounts[issueClass] > 0 ? "ok" : "default"}>
+                  {formatAnalysisIssueClassLabel(issueClass)} {summary.issueClassCounts[issueClass]}
+                </Badge>
+              ))}
+            </div>
+            {surfaceState === "issue-heavy" ? (
+              <div className="mt-4 rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-3 text-sm leading-6 text-muted">
+                High-severity or preservation-sensitive context is present. Use the selected finding detail and recommended routes to move work to Sessions, Assets, or Backup / Migration without executing remediation here.
+              </div>
+            ) : null}
+          </Card>
+
+          <Card className="p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-[0.18em] text-muted">Findings Inventory</div>
+                <div className="text-sm text-muted">Findings are local seed interpretations for routing validation, not complete automated analysis.</div>
+              </div>
+              {selectedFinding ? <Badge variant="default">selected finding active</Badge> : null}
+            </div>
+
+            {surfaceState === "loading" ? (
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div key={index} className="rounded-xl border border-border/60 bg-background/12 px-3 py-4 text-sm text-muted">
+                    Loading analysis findings…
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {surfaceState === "empty" ? (
+              <div className="rounded-xl border border-dashed border-border/60 bg-background/10 px-4 py-5">
+                <div className="text-sm font-medium text-foreground">No findings match the current issue and object context.</div>
+                <div className="mt-2 text-sm leading-6 text-muted">
+                  Keep the active context visible, then change filters, inspect sessions for evidence, or review reusable assets before escalating into workflow surfaces.
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Button size="sm" variant="outline" onClick={() => updateFilter("issueClass", "all")}>
+                    Clear issue filter
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => updateFilter("status", "all")}>
+                    Include resolved / unknown
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            {surfaceState !== "loading" && surfaceState !== "empty" ? (
+              <div className="space-y-3">
+                {filteredFindings.map((finding) => {
+                  const selected = finding.id === selectedFindingId;
+                  return (
+                    <button
+                      key={finding.id}
+                      type="button"
+                      onClick={() => handleSelectFinding(finding)}
+                      aria-pressed={selected}
+                      aria-label={`${selected ? "Selected finding" : "Select finding"}: ${finding.title}`}
+                      className={[
+                        "w-full rounded-xl border px-4 py-3 text-left transition-colors",
+                        selected
+                          ? "border-accent/55 bg-accent/10"
+                          : "border-border/60 bg-background/10 hover:border-accent/35 hover:bg-background/16",
+                      ].join(" ")}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <div className="font-medium text-foreground">{finding.title}</div>
+                            <Badge variant="default">{formatAnalysisIssueClassLabel(finding.issueClass)}</Badge>
+                            {renderSeverityBadge(finding.severity)}
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted">
+                            <span>{formatAnalysisObjectTypeLabel(finding.affectedObjectType)}</span>
+                            <span>{finding.affectedObjectLabel}</span>
+                            <span>{formatAnalysisFindingStatusLabel(finding.status)}</span>
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 flex-wrap gap-2">
+                          {finding.preservationWarning ? <Badge variant="warn">preserve first</Badge> : null}
+                          {finding.routes.length > 0 ? <Badge variant="ok">{finding.routes.length} routes</Badge> : <Badge variant="default">no route</Badge>}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <Card className="p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-[0.18em] text-muted">Finding Detail</div>
+                <div className="text-sm text-muted">Explain the problem before offering outbound action routes.</div>
+              </div>
+              {selectedFinding ? renderSeverityBadge(selectedFinding.severity) : null}
+            </div>
+
+            {selectedFinding ? (
+              <div className="space-y-4">
+                <div>
+                  <div className="text-lg font-semibold">{selectedFinding.title}</div>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Badge variant="default">{formatAnalysisIssueClassLabel(selectedFinding.issueClass)}</Badge>
+                    <Badge variant="default">{formatAnalysisObjectTypeLabel(selectedFinding.affectedObjectType)}</Badge>
+                    <Badge variant="default">{formatAnalysisFindingStatusLabel(selectedFinding.status)}</Badge>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm leading-6 text-muted">
+                  {selectedFinding.whyItMatters}
+                </div>
+
+                {selectedFinding.preservationWarning ? (
+                  <div className="rounded-xl border border-amber-400/35 bg-amber-400/10 px-3 py-3 text-sm leading-6 text-muted">
+                    <span className="font-medium text-foreground">Preservation warning:</span> {selectedFinding.preservationWarning}
+                  </div>
+                ) : null}
+
+                <div className="space-y-2 rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                  <div className="text-xs uppercase tracking-[0.18em] text-muted">Evidence Context</div>
+                  {selectedFinding.evidence.length > 0 ? (
+                    <div className="space-y-2">
+                      {selectedFinding.evidence.map((evidence, index) => (
+                        <div key={`${evidence.label}-${index}`} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border/50 bg-background/15 px-3 py-2">
+                          <div>
+                            <div className="font-medium text-foreground">{evidence.label}</div>
+                            <div className="text-xs text-muted">{evidence.target}</div>
+                          </div>
+                          {evidence.target === "session" && evidence.sessionId && evidence.source ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                onOpenSession({
+                                  sessionId: evidence.sessionId!,
+                                  source: evidence.source!,
+                                  rootId: evidence.rootId,
+                                })
+                              }
+                            >
+                              Open evidence
+                            </Button>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-muted">Evidence reference unavailable.</div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-border/60 bg-background/10 px-4 py-6 text-sm text-muted">
+                Select a finding to inspect issue class, severity, affected object, evidence, and bounded outbound routes.
+              </div>
+            )}
+          </Card>
+
+          <Card className="p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-[0.18em] text-muted">Recommended Actions</div>
+                <div className="text-sm text-muted">Actions route to owning pages; Analysis does not execute fixes inline.</div>
+              </div>
+              {selectedFinding?.routes.length ? <Badge variant="ok">route-only</Badge> : null}
+            </div>
+
+            {selectedFinding ? (
+              selectedFinding.routes.length > 0 ? (
+                <div className="space-y-3">
+                  {selectedFinding.routes.map((route, index) => (
+                    <div key={`${route.target}-${index}`} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <div className="font-medium">{route.label}</div>
+                            <Badge variant="default">{route.target}</Badge>
+                            {route.preservationWarning ? <Badge variant="warn">preserve first</Badge> : null}
+                          </div>
+                          <div className="mt-2 text-sm leading-6 text-muted">{route.reason}</div>
+                        </div>
+                        <RouteButton
+                          finding={selectedFinding}
+                          route={route}
+                          onOpenAssets={onOpenAssets}
+                          onOpenBackup={onOpenBackup}
+                          onOpenOverview={onOpenOverview}
+                          onOpenSession={onOpenSession}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-xl border border-dashed border-border/60 bg-background/10 px-4 py-5 text-sm text-muted">
+                  No outbound route is available yet. Keep this finding as interpretation only until a concrete owner surface exists.
+                </div>
+              )
+            ) : (
+              <div className="rounded-xl border border-dashed border-border/60 bg-background/10 px-4 py-5 text-sm text-muted">
+                Select a finding to show route-only actions to Sessions, Assets, or Backup / Migration.
+              </div>
+            )}
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AnalysisFoundation;

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -22,6 +22,7 @@ import {
   formatAnalysisObjectTypeLabel,
   formatAnalysisSeverityLabel,
   resolveAnalysisFindingSelection,
+  resolveAnalysisSessionRootId,
   summarizeAnalysisFindings,
   type AnalysisFinding,
   type AnalysisFindingStatus,
@@ -108,6 +109,7 @@ function CueStrip(props: {
 function RouteButton(props: {
   finding: AnalysisFinding;
   route: AnalysisRoute;
+  handoff: AnalysisHandoff | null;
   onOpenAssets(handoff: AssetsHandoff): void;
   onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string }): void;
   onOpenOverview(): void;
@@ -130,7 +132,12 @@ function RouteButton(props: {
           props.onOpenSession({
             sessionId: props.route.sessionId!,
             source: props.route.source!,
-            rootId: props.route.rootId,
+            rootId: resolveAnalysisSessionRootId({
+              handoff: props.handoff,
+              sessionId: props.route.sessionId!,
+              source: props.route.source!,
+              explicitRootId: props.route.rootId,
+            }),
           })
         }
       >
@@ -475,7 +482,12 @@ export function AnalysisFoundation({
                                 onOpenSession({
                                   sessionId: evidence.sessionId!,
                                   source: evidence.source!,
-                                  rootId: evidence.rootId,
+                                  rootId: resolveAnalysisSessionRootId({
+                                    handoff: activeHandoff,
+                                    sessionId: evidence.sessionId!,
+                                    source: evidence.source!,
+                                    explicitRootId: evidence.rootId,
+                                  }),
                                 })
                               }
                             >
@@ -527,6 +539,7 @@ export function AnalysisFoundation({
                           onOpenBackup={onOpenBackup}
                           onOpenOverview={onOpenOverview}
                           onOpenSession={onOpenSession}
+                          handoff={activeHandoff}
                         />
                       </div>
                     </div>

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -51,13 +51,10 @@ export function resolveAnalysisNavigationHandoff(handoff: AnalysisHandoff | null
   return handoff?.sessionId && handoff.source ? handoff : null;
 }
 
-export function clearAnalysisRoutedCueState(input: {
-  activeHandoff: AnalysisHandoff | null;
-  navigationHandoff: AnalysisHandoff | null;
-}) {
+export function clearAnalysisRoutedCueState(navigationHandoff: AnalysisHandoff | null) {
   return {
     activeHandoff: null,
-    navigationHandoff: input.navigationHandoff,
+    navigationHandoff,
   };
 }
 
@@ -264,10 +261,7 @@ export function AnalysisFoundation({
 
   function acknowledgeRoutedContext() {
     if (!activeHandoff) return;
-    const nextState = clearAnalysisRoutedCueState({
-      activeHandoff,
-      navigationHandoff,
-    });
+    const nextState = clearAnalysisRoutedCueState(navigationHandoff);
     setActiveHandoff(nextState.activeHandoff);
     setNavigationHandoff(nextState.navigationHandoff);
   }

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -94,7 +94,7 @@ function CueStrip(props: {
           <div className="text-sm font-medium">{props.handoff.subtitle}</div>
           <div className="text-xs leading-5 text-muted">
             {props.staleSelection
-              ? "The original finding could not be selected. Any still-valid issue or object filters are preserved so the routed task can degrade safely."
+              ? "The original routed context could not be selected. Any still-valid issue or object filters are preserved so the routed task can degrade safely."
               : props.filteredCount === 0
                 ? "No findings currently match the routed context. Filters stay visible so you can adjust without losing the original task framing."
                 : props.handoff.continueLabel ?? "Continue interpreting the routed issue context here."}

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -47,6 +47,20 @@ export type AnalysisFoundationProps = {
 
 const LOADING_DELAY_MS = 120;
 
+export function resolveAnalysisNavigationHandoff(handoff: AnalysisHandoff | null): AnalysisHandoff | null {
+  return handoff?.sessionId && handoff.source ? handoff : null;
+}
+
+export function clearAnalysisRoutedCueState(input: {
+  activeHandoff: AnalysisHandoff | null;
+  navigationHandoff: AnalysisHandoff | null;
+}) {
+  return {
+    activeHandoff: null,
+    navigationHandoff: input.navigationHandoff,
+  };
+}
+
 function FilterSelect<T extends string>(props: {
   label: string;
   value: T | "all";
@@ -109,7 +123,7 @@ function CueStrip(props: {
 function RouteButton(props: {
   finding: AnalysisFinding;
   route: AnalysisRoute;
-  handoff: AnalysisHandoff | null;
+  navigationHandoff: AnalysisHandoff | null;
   onOpenAssets(handoff: AssetsHandoff): void;
   onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string }): void;
   onOpenOverview(): void;
@@ -133,7 +147,7 @@ function RouteButton(props: {
             sessionId: props.route.sessionId!,
             source: props.route.source!,
             rootId: resolveAnalysisSessionRootId({
-              handoff: props.handoff,
+              handoff: props.navigationHandoff,
               sessionId: props.route.sessionId!,
               source: props.route.source!,
               explicitRootId: props.route.rootId,
@@ -195,6 +209,7 @@ export function AnalysisFoundation({
   const [filters, setFilters] = useState<AnalysisFilters>(() => initialFilters);
   const [selectedFindingId, setSelectedFindingId] = useState<string | null>(initialSelectedFinding?.id ?? null);
   const [activeHandoff, setActiveHandoff] = useState<AnalysisHandoff | null>(handoff);
+  const [navigationHandoff, setNavigationHandoff] = useState<AnalysisHandoff | null>(() => resolveAnalysisNavigationHandoff(handoff));
   const [staleSelection, setStaleSelection] = useState(Boolean(handoff?.findingId || handoff?.assetId || handoff?.sessionId) && !initialSelectedFinding);
   const [isLoading, setIsLoading] = useState(loadingDelayMs > 0);
   const loadingTimeoutRef = useRef<number | null>(null);
@@ -221,6 +236,7 @@ export function AnalysisFoundation({
     const nextFilters = buildFiltersFromAnalysisHandoff(handoff, createDefaultAnalysisFilters());
     setFilters(nextFilters);
     setActiveHandoff(handoff);
+    setNavigationHandoff(resolveAnalysisNavigationHandoff(handoff));
     setIsLoading(true);
 
     scheduleLoadingComplete(() => {
@@ -248,7 +264,12 @@ export function AnalysisFoundation({
 
   function acknowledgeRoutedContext() {
     if (!activeHandoff) return;
-    setActiveHandoff(null);
+    const nextState = clearAnalysisRoutedCueState({
+      activeHandoff,
+      navigationHandoff,
+    });
+    setActiveHandoff(nextState.activeHandoff);
+    setNavigationHandoff(nextState.navigationHandoff);
   }
 
   function updateFilter<K extends keyof AnalysisFilters>(key: K, value: AnalysisFilters[K]) {
@@ -483,7 +504,7 @@ export function AnalysisFoundation({
                                   sessionId: evidence.sessionId!,
                                   source: evidence.source!,
                                   rootId: resolveAnalysisSessionRootId({
-                                    handoff: activeHandoff,
+                                    handoff: navigationHandoff,
                                     sessionId: evidence.sessionId!,
                                     source: evidence.source!,
                                     explicitRootId: evidence.rootId,
@@ -539,7 +560,7 @@ export function AnalysisFoundation({
                           onOpenBackup={onOpenBackup}
                           onOpenOverview={onOpenOverview}
                           onOpenSession={onOpenSession}
-                          handoff={activeHandoff}
+                          navigationHandoff={navigationHandoff}
                         />
                       </div>
                     </div>

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -68,10 +68,17 @@ export type HomeClientAssetHandoff = {
   subtype: ContextAssetSubtype;
 };
 
+export type HomeClientAnalysisHandoff = {
+  sessionId: string;
+  source: Source;
+  rootId?: string;
+};
+
 export type HomeClientProps = {
   chrome?: "full" | "embedded";
   externalSelection?: HomeClientExternalSelection | null;
   onOpenAssetsForSession?(handoff: HomeClientAssetHandoff): void;
+  onOpenAnalysisForSession?(handoff: HomeClientAnalysisHandoff): void;
 };
 
 export function resolveInitialSource(input: {
@@ -1430,7 +1437,12 @@ function fromSelectionKey(key: string | null): { rootId?: string; id: string } |
   }
 }
 
-export default function HomeClient({ chrome = "full", externalSelection = null, onOpenAssetsForSession }: HomeClientProps = {}) {
+export default function HomeClient({
+  chrome = "full",
+  externalSelection = null,
+  onOpenAssetsForSession,
+  onOpenAnalysisForSession,
+}: HomeClientProps = {}) {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [status, setStatus] = useState<SourcesStatus | null>(null);
   const [source, setSource] = useState<Source>("antigravity");
@@ -2685,6 +2697,22 @@ export default function HomeClient({ chrome = "full", externalSelection = null, 
                     title="Route to Assets with a bounded subtype handoff from the selected session"
                   >
                     Inspect in Assets
+                  </Button>
+                ) : null}
+                {onOpenAnalysisForSession ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      onOpenAnalysisForSession({
+                        sessionId: selectedId,
+                        source,
+                        ...(selectedItem?.rootId ? { rootId: selectedItem.rootId } : {}),
+                      })
+                    }
+                    title="Route to Analysis with bounded session evidence context"
+                  >
+                    Review in Analysis
                   </Button>
                 ) : null}
                 <Button

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -171,6 +171,7 @@ export function buildAnalysisHandoffFromSession(input: HomeClientAnalysisHandoff
     objectType: "session",
     sessionId: input.sessionId,
     source: input.source,
+    rootId: input.rootId,
   };
 }
 
@@ -234,6 +235,7 @@ export function buildAnalysisFoundationInstanceKey(handoff: AnalysisHandoff | nu
     handoff.assetSubtype ?? "no-subtype",
     handoff.sessionId ?? "no-session",
     handoff.source ?? "no-source",
+    handoff.rootId ?? "no-root",
     handoff.issueLabel ?? "no-issue",
   ].join(":");
 }

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -387,8 +387,8 @@ function ProjectOverviewSurface(props: {
           </Button>
         </div>
         <p className="mt-4 text-xs leading-5 text-muted">
-          Assets is now a bounded foundation surface. Analysis and Backup / Migration remain placeholders, and working
-          session backup remains available from a selected session.
+          Assets and Analysis are now bounded foundation surfaces. Backup / Migration remains a placeholder, and
+          working session backup remains available from a selected session.
         </p>
       </Card>
     </div>

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -168,7 +168,6 @@ export function buildAnalysisHandoffFromSession(input: HomeClientAnalysisHandoff
     continueLabel: "Keep the session evidence boundary visible while interpreting matching findings.",
     returnLabel: "Return to the originating session if you need transcript or trajectory detail.",
     issueClass: "preservation",
-    objectType: "session",
     sessionId: input.sessionId,
     source: input.source,
     rootId: input.rootId,

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -3,12 +3,14 @@
 import Link from "next/link";
 import React, { useCallback, useEffect, useState } from "react";
 
+import AnalysisFoundation from "@/components/AnalysisFoundation";
 import AssetsFoundation from "@/components/AssetsFoundation";
-import HomeClient, { type HomeClientAssetHandoff, type HomeClientExternalSelection } from "@/components/HomeClient";
+import HomeClient, { type HomeClientAnalysisHandoff, type HomeClientAssetHandoff, type HomeClientExternalSelection } from "@/components/HomeClient";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import type { AnalysisFindingStatus, AnalysisHandoff, AnalysisIssueClass, AnalysisObjectType, AnalysisSeverity } from "@/lib/analysisFindings";
 import type { AssetsHandoff, ContextAssetScope, ContextAssetStatus, ContextAssetSubtype } from "@/lib/contextAssets";
 import { cancelPendingUrlSync } from "@/lib/urlState";
 import { cn } from "@/lib/utils";
@@ -107,6 +109,71 @@ export function buildAssetsHandoffFromAnalysis(input: {
   };
 }
 
+function mapAssetStatusToAnalysisIssueClass(status?: ContextAssetStatus): AnalysisIssueClass | undefined {
+  if (status === "stale") return "stale";
+  if (status === "conflicted") return "conflict";
+  if (status === "orphaned") return "provenance";
+  if (status === "unknown") return "unknown";
+  return undefined;
+}
+
+export function buildAnalysisHandoffFromAssets(input: {
+  issueLabel: string;
+  assetId?: string;
+  subtype?: ContextAssetSubtype;
+  status?: ContextAssetStatus;
+}): AnalysisHandoff {
+  const issueClass = mapAssetStatusToAnalysisIssueClass(input.status);
+
+  return {
+    origin: "assets",
+    subtitle: `Review issue context from Assets: ${input.issueLabel}.`,
+    continueLabel: "Interpret the affected asset issue, then route corrective work to the owning surface.",
+    returnLabel: "Return to Assets to continue object-level review.",
+    issueClass,
+    objectType: "asset",
+    assetId: input.assetId,
+    assetSubtype: input.subtype,
+    issueLabel: input.issueLabel,
+  };
+}
+
+export function buildAnalysisHandoffFromOverview(input: {
+  subtitle: string;
+  issueClass?: AnalysisIssueClass;
+  severity?: AnalysisSeverity;
+  objectType?: AnalysisObjectType;
+  status?: AnalysisFindingStatus;
+  findingId?: string;
+  issueLabel?: string;
+}): AnalysisHandoff {
+  return {
+    origin: "overview",
+    subtitle: input.subtitle,
+    continueLabel: "Start from the project-level issue framing, then inspect the matching finding or adjust filters.",
+    returnLabel: "Return to Project Overview when the broader project picture matters again.",
+    issueClass: input.issueClass,
+    severity: input.severity,
+    objectType: input.objectType,
+    status: input.status,
+    findingId: input.findingId,
+    issueLabel: input.issueLabel,
+  };
+}
+
+export function buildAnalysisHandoffFromSession(input: HomeClientAnalysisHandoff): AnalysisHandoff {
+  return {
+    origin: "sessions",
+    subtitle: "Review analysis findings related to the selected session evidence.",
+    continueLabel: "Keep the session evidence boundary visible while interpreting matching findings.",
+    returnLabel: "Return to the originating session if you need transcript or trajectory detail.",
+    issueClass: "preservation",
+    objectType: "session",
+    sessionId: input.sessionId,
+    source: input.source,
+  };
+}
+
 const SESSION_VIEWER_QUERY_KEYS = [
   "source",
   "id",
@@ -152,6 +219,25 @@ export function buildAssetsFoundationInstanceKey(handoff: AssetsHandoff | null):
   ].join(":");
 }
 
+export function buildAnalysisFoundationInstanceKey(handoff: AnalysisHandoff | null): string {
+  if (!handoff) return "analysis:no-handoff";
+
+  return [
+    "analysis",
+    handoff.origin,
+    handoff.issueClass ?? "all-classes",
+    handoff.severity ?? "all-severities",
+    handoff.objectType ?? "all-objects",
+    handoff.status ?? "all-statuses",
+    handoff.findingId ?? "no-finding",
+    handoff.assetId ?? "no-asset",
+    handoff.assetSubtype ?? "no-subtype",
+    handoff.sessionId ?? "no-session",
+    handoff.source ?? "no-source",
+    handoff.issueLabel ?? "no-issue",
+  ].join(":");
+}
+
 function clearSessionViewerUrlState(): void {
   if (typeof window === "undefined") return;
 
@@ -167,6 +253,7 @@ function clearSessionViewerUrlState(): void {
 function ProjectOverviewSurface(props: {
   onNavigate(page: ProjectShellPage): void;
   onOpenAssets(handoff: AssetsHandoff): void;
+  onOpenAnalysis(handoff: AnalysisHandoff): void;
 }) {
   return (
     <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -237,6 +324,25 @@ function ProjectOverviewSurface(props: {
             <Button className="mt-4" variant="outline" size="sm" onClick={() => props.onNavigate("sessions")}>
               Review Sessions
             </Button>
+            <Button
+              className="ml-2 mt-4"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                props.onOpenAnalysis(
+                  buildAnalysisHandoffFromOverview({
+                    subtitle: "Review preservation-sensitive findings from project attention context.",
+                    issueClass: "preservation",
+                    severity: "high",
+                    objectType: "backup",
+                    findingId: "finding-preserve-before-migration",
+                    issueLabel: "preservation",
+                  })
+                )
+              }
+            >
+              Review Analysis
+            </Button>
           </Card>
         </div>
       </div>
@@ -259,7 +365,19 @@ function ProjectOverviewSurface(props: {
           >
             Inspect context assets
           </Button>
-          <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => props.onNavigate("analysis")}>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              props.onOpenAnalysis(
+                buildAnalysisHandoffFromOverview({
+                  subtitle: "Review open context findings across this local project.",
+                  issueLabel: "project attention",
+                })
+              )
+            }
+          >
             Review analysis
           </Button>
           <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => props.onNavigate("backup")}>
@@ -320,7 +438,7 @@ export default function ProjectShellClient() {
   const [activePage, setActivePage] = useState<ProjectShellPage>("overview");
   const [externalSelection, setExternalSelection] = useState<HomeClientExternalSelection | null>(null);
   const [assetsHandoff, setAssetsHandoff] = useState<AssetsHandoff | null>(null);
-  const [analysisCue, setAnalysisCue] = useState<PlaceholderCue | null>(null);
+  const [analysisHandoff, setAnalysisHandoff] = useState<AnalysisHandoff | null>(null);
   const [backupCue, setBackupCue] = useState<PlaceholderCue | null>(null);
 
   const leaveSessionsSurface = useCallback(() => {
@@ -334,7 +452,7 @@ export default function ProjectShellClient() {
 
   const handleSearchSelect = useCallback((sessionId: string, source: Source, rootId?: string) => {
     setAssetsHandoff(null);
-    setAnalysisCue(null);
+    setAnalysisHandoff(null);
     setBackupCue(null);
     setActivePage("sessions");
     setExternalSelection((prev) =>
@@ -350,7 +468,7 @@ export default function ProjectShellClient() {
   const handleNavigate = useCallback((page: ProjectShellPage) => {
     if (page !== "sessions") leaveSessionsSurface();
     setAssetsHandoff(null);
-    setAnalysisCue(null);
+    setAnalysisHandoff(null);
     setBackupCue(null);
     setActivePage(page);
   }, [leaveSessionsSurface]);
@@ -358,7 +476,7 @@ export default function ProjectShellClient() {
   const handleOpenAssets = useCallback((handoff: AssetsHandoff) => {
     leaveSessionsSurface();
     setAssetsHandoff(handoff);
-    setAnalysisCue(null);
+    setAnalysisHandoff(null);
     setBackupCue(null);
     setActivePage("assets");
   }, [leaveSessionsSurface]);
@@ -366,14 +484,22 @@ export default function ProjectShellClient() {
   const handleOpenAssetsFromSession = useCallback((handoff: HomeClientAssetHandoff) => {
     leaveSessionsSurface();
     setAssetsHandoff(buildAssetsHandoffFromSession({ sessionId: handoff.sessionId, subtype: handoff.subtype }));
-    setAnalysisCue(null);
+    setAnalysisHandoff(null);
     setBackupCue(null);
     setActivePage("assets");
   }, [leaveSessionsSurface]);
 
-  const handleOpenSessionFromAssets = useCallback((selection: { sessionId: string; source: Source; rootId?: string }) => {
+  const handleOpenAnalysisFromSession = useCallback((handoff: HomeClientAnalysisHandoff) => {
+    leaveSessionsSurface();
     setAssetsHandoff(null);
-    setAnalysisCue(null);
+    setAnalysisHandoff(buildAnalysisHandoffFromSession(handoff));
+    setBackupCue(null);
+    setActivePage("analysis");
+  }, [leaveSessionsSurface]);
+
+  const handleOpenSessionFromContext = useCallback((selection: { sessionId: string; source: Source; rootId?: string }) => {
+    setAssetsHandoff(null);
+    setAnalysisHandoff(null);
     setBackupCue(null);
     setActivePage("sessions");
     setExternalSelection((prev) =>
@@ -395,20 +521,41 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setBackupCue(null);
-    setAnalysisCue({
-      title: "Routed from Assets",
-      body: `Issue focus: ${context.issueLabel}. ${context.subtype ? `Subtype: ${context.subtype}. ` : ""}${context.status ? `Status: ${context.status}.` : ""}`.trim(),
-    });
+    setAnalysisHandoff(buildAnalysisHandoffFromAssets(context));
     setActivePage("analysis");
   }, [leaveSessionsSurface]);
 
   const handleOpenBackupFromAssets = useCallback((context: { assetId?: string; subtype?: ContextAssetSubtype }) => {
     leaveSessionsSurface();
     setAssetsHandoff(null);
-    setAnalysisCue(null);
+    setAnalysisHandoff(null);
     setBackupCue({
       title: "Routed from Assets",
       body: `Prepare bounded backup or migration work${context.subtype ? ` for ${context.subtype} assets` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}. Workflow execution still belongs to Backup / Migration.`,
+    });
+    setActivePage("backup");
+  }, [leaveSessionsSurface]);
+
+  const handleOpenAnalysis = useCallback((handoff: AnalysisHandoff) => {
+    leaveSessionsSurface();
+    setAssetsHandoff(null);
+    setAnalysisHandoff(handoff);
+    setBackupCue(null);
+    setActivePage("analysis");
+  }, [leaveSessionsSurface]);
+
+  const handleOpenBackupFromAnalysis = useCallback((context: {
+    findingId: string;
+    title: string;
+    preservationWarning?: string;
+    routeLabel?: string;
+  }) => {
+    leaveSessionsSurface();
+    setAssetsHandoff(null);
+    setAnalysisHandoff(null);
+    setBackupCue({
+      title: "Routed from Analysis",
+      body: `${context.routeLabel ?? "Recommended route"} for ${context.title}. ${context.preservationWarning ?? "Backup / Migration owns workflow validation and execution."}`,
     });
     setActivePage("backup");
   }, [leaveSessionsSurface]);
@@ -470,46 +617,32 @@ export default function ProjectShellClient() {
             </div>
           ) : null}
 
-          {activePage === "overview" ? <ProjectOverviewSurface onNavigate={handleNavigate} onOpenAssets={handleOpenAssets} /> : null}
+          {activePage === "overview" ? <ProjectOverviewSurface onNavigate={handleNavigate} onOpenAssets={handleOpenAssets} onOpenAnalysis={handleOpenAnalysis} /> : null}
           {activePage === "sessions" ? (
             <HomeClient
               chrome="embedded"
               externalSelection={externalSelection}
               onOpenAssetsForSession={handleOpenAssetsFromSession}
+              onOpenAnalysisForSession={handleOpenAnalysisFromSession}
             />
           ) : null}
           {activePage === "assets" ? (
             <AssetsFoundation
               key={buildAssetsFoundationInstanceKey(assetsHandoff)}
               handoff={assetsHandoff}
-              onOpenSession={handleOpenSessionFromAssets}
+              onOpenSession={handleOpenSessionFromContext}
               onOpenAnalysis={handleOpenAnalysisFromAssets}
               onOpenBackup={handleOpenBackupFromAssets}
             />
           ) : null}
           {activePage === "analysis" ? (
-            <PlaceholderSurface
-              title="Analysis"
-              label="interpretation"
-              body="Analysis will summarize context issues and route each finding to a concrete object or workflow. This placeholder avoids creating a findings inventory before analysis contracts exist."
-              preservedPath="Use Sessions inspector and error center for current evidence-driven investigation."
-              onNavigateSessions={() => handleNavigate("sessions")}
-              cue={analysisCue ?? undefined}
-              {...(analysisCue
-                ? {
-                    actionLabel: "Review affected assets",
-                    onAction: () =>
-                      handleOpenAssets(
-                        buildAssetsHandoffFromAnalysis({
-                          subtitle: "Review the affected reusable asset class from Analysis.",
-                          subtype: "skill",
-                          status: "conflicted",
-                          assetId: "asset-skill-global-generated",
-                          issueLabel: "conflicted asset",
-                        })
-                      ),
-                  }
-                : {})}
+            <AnalysisFoundation
+              key={buildAnalysisFoundationInstanceKey(analysisHandoff)}
+              handoff={analysisHandoff}
+              onOpenAssets={handleOpenAssets}
+              onOpenBackup={handleOpenBackupFromAnalysis}
+              onOpenOverview={() => handleNavigate("overview")}
+              onOpenSession={handleOpenSessionFromContext}
             />
           ) : null}
           {activePage === "backup" ? (

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -94,6 +94,7 @@ export type AnalysisHandoff = {
   assetSubtype?: ContextAssetSubtype;
   sessionId?: string;
   source?: Source;
+  rootId?: string;
   issueLabel?: string;
 };
 
@@ -464,4 +465,16 @@ export function buildAssetsHandoffFromAnalysisRoute(route: AnalysisRoute, findin
     assetId: route.assetId,
     issueLabel: formatAnalysisIssueClassLabel(finding.issueClass),
   };
+}
+
+export function resolveAnalysisSessionRootId(input: {
+  handoff: AnalysisHandoff | null;
+  sessionId: string;
+  source: Source;
+  explicitRootId?: string;
+}): string | undefined {
+  if (input.explicitRootId) return input.explicitRootId;
+  if (input.handoff?.sessionId !== input.sessionId) return undefined;
+  if (input.handoff.source && input.handoff.source !== input.source) return undefined;
+  return input.handoff.rootId;
 }

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -381,9 +381,20 @@ export function resolveAnalysisFindingSelection(
   }
 
   if (handoff.sessionId) {
+    const matchesSessionIdentity = (
+      item: { sessionId?: string; source?: string; rootId?: string }
+    ) => {
+      if (item.sessionId !== handoff.sessionId) return false;
+      // When handoff provides source, require matching source
+      if (handoff.source && item.source && item.source !== handoff.source) return false;
+      // When both sides provide rootId, require matching rootId
+      if (handoff.rootId && item.rootId && item.rootId !== handoff.rootId) return false;
+      return true;
+    };
+
     const bySession = findings.find((finding) =>
-      finding.evidence.some((evidence) => evidence.sessionId === handoff.sessionId) ||
-      finding.routes.some((route) => route.sessionId === handoff.sessionId)
+      finding.evidence.some(matchesSessionIdentity) ||
+      finding.routes.some(matchesSessionIdentity)
     );
     if (bySession) return bySession;
   }

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -385,10 +385,14 @@ export function resolveAnalysisFindingSelection(
       item: { sessionId?: string; source?: string; rootId?: string }
     ) => {
       if (item.sessionId !== handoff.sessionId) return false;
-      // When handoff provides source, require matching source
-      if (handoff.source && item.source && item.source !== handoff.source) return false;
-      // When both sides provide rootId, require matching rootId
-      if (handoff.rootId && item.rootId && item.rootId !== handoff.rootId) return false;
+      // When handoff provides source, item must have the same source
+      if (handoff.source) {
+        if (!item.source || item.source !== handoff.source) return false;
+      }
+      // When handoff provides rootId, item must have the same rootId
+      if (handoff.rootId) {
+        if (!item.rootId || item.rootId !== handoff.rootId) return false;
+      }
       return true;
     };
 

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -402,11 +402,14 @@ export function deriveAnalysisSurfaceState(input: {
   const selected = input.selectedFindingId
     ? input.filteredFindings.find((finding) => finding.id === input.selectedFindingId)
     : undefined;
+  const hasPreservationWarning = (finding: AnalysisFinding) =>
+    Boolean(finding.preservationWarning) || finding.routes.some((route) => route.preservationWarning);
+
   const issueHeavy = input.filteredFindings.some(
-    (finding) => finding.severity === "high" || Boolean(finding.preservationWarning)
+    (finding) => finding.severity === "high" || hasPreservationWarning(finding)
   );
 
-  if (selected && (selected.severity === "high" || selected.preservationWarning)) return "issue-heavy";
+  if (selected && (selected.severity === "high" || hasPreservationWarning(selected))) return "issue-heavy";
   if (issueHeavy) return "issue-heavy";
   if (selected) return "selected";
   return "normal";

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -1,0 +1,467 @@
+import type { AssetsHandoff, ContextAssetStatus, ContextAssetSubtype } from "@/lib/contextAssets";
+import type { Source } from "@/lib/types";
+
+export const ANALYSIS_ISSUE_CLASSES = ["provenance", "stale", "conflict", "preservation", "unknown"] as const;
+export const ANALYSIS_SEVERITIES = ["high", "medium", "low", "unknown"] as const;
+export const ANALYSIS_FINDING_STATUSES = ["open", "watching", "resolved", "unknown"] as const;
+export const ANALYSIS_OBJECT_TYPES = ["session", "asset", "backup", "project", "unknown"] as const;
+export const ANALYSIS_ROUTE_TARGETS = ["sessions", "assets", "backup", "overview"] as const;
+
+export type AnalysisIssueClass = (typeof ANALYSIS_ISSUE_CLASSES)[number];
+export type AnalysisSeverity = (typeof ANALYSIS_SEVERITIES)[number];
+export type AnalysisFindingStatus = (typeof ANALYSIS_FINDING_STATUSES)[number];
+export type AnalysisObjectType = (typeof ANALYSIS_OBJECT_TYPES)[number];
+export type AnalysisRouteTarget = (typeof ANALYSIS_ROUTE_TARGETS)[number];
+export type AnalysisHandoffOrigin = "assets" | "overview" | "sessions";
+export type AnalysisSurfaceState = "loading" | "empty" | "normal" | "selected" | "issue-heavy";
+
+export type AnalysisEvidenceReference = {
+  label: string;
+  target: "session" | "asset" | "backup" | "source" | "unknown";
+  sessionId?: string;
+  assetId?: string;
+  source?: Source;
+  rootId?: string;
+};
+
+export type AnalysisRoute = {
+  target: AnalysisRouteTarget;
+  label: string;
+  reason: string;
+  sessionId?: string;
+  source?: Source;
+  rootId?: string;
+  assetId?: string;
+  assetSubtype?: ContextAssetSubtype;
+  assetStatus?: ContextAssetStatus;
+  preservationWarning?: string;
+};
+
+export type AnalysisFinding = {
+  id: string;
+  title: string;
+  issueClass: AnalysisIssueClass;
+  severity: AnalysisSeverity;
+  status: AnalysisFindingStatus;
+  affectedObjectType: AnalysisObjectType;
+  affectedObjectLabel: string;
+  whyItMatters: string;
+  evidence: AnalysisEvidenceReference[];
+  routes: AnalysisRoute[];
+  preservationWarning?: string;
+};
+
+export type AnalysisFindingInput = {
+  id: string;
+  title: string;
+  issueClass?: string | null;
+  severity?: string | null;
+  status?: string | null;
+  affectedObjectType?: string | null;
+  affectedObjectLabel?: string | null;
+  whyItMatters?: string | null;
+  evidence?: AnalysisEvidenceReference[] | null;
+  routes?: AnalysisRoute[] | null;
+  preservationWarning?: string | null;
+};
+
+export type AnalysisFilters = {
+  issueClass: AnalysisIssueClass | "all";
+  severity: AnalysisSeverity | "all";
+  objectType: AnalysisObjectType | "all";
+  status: AnalysisFindingStatus | "all";
+};
+
+export type AnalysisSummary = {
+  total: number;
+  highSeverity: number;
+  preservationSensitive: number;
+  issueClassCounts: Record<AnalysisIssueClass, number>;
+  severityCounts: Record<AnalysisSeverity, number>;
+};
+
+export type AnalysisHandoff = {
+  origin: AnalysisHandoffOrigin;
+  subtitle: string;
+  continueLabel?: string;
+  returnLabel?: string;
+  issueClass?: AnalysisIssueClass;
+  severity?: AnalysisSeverity;
+  objectType?: AnalysisObjectType;
+  status?: AnalysisFindingStatus;
+  findingId?: string;
+  assetId?: string;
+  assetSubtype?: ContextAssetSubtype;
+  sessionId?: string;
+  source?: Source;
+  issueLabel?: string;
+};
+
+export function normalizeAnalysisIssueClass(input?: string | null): AnalysisIssueClass {
+  if (!input) return "unknown";
+  return ANALYSIS_ISSUE_CLASSES.includes(input as AnalysisIssueClass) ? (input as AnalysisIssueClass) : "unknown";
+}
+
+export function normalizeAnalysisSeverity(input?: string | null): AnalysisSeverity {
+  if (!input) return "unknown";
+  return ANALYSIS_SEVERITIES.includes(input as AnalysisSeverity) ? (input as AnalysisSeverity) : "unknown";
+}
+
+export function normalizeAnalysisFindingStatus(input?: string | null): AnalysisFindingStatus {
+  if (!input) return "unknown";
+  return ANALYSIS_FINDING_STATUSES.includes(input as AnalysisFindingStatus) ? (input as AnalysisFindingStatus) : "unknown";
+}
+
+export function normalizeAnalysisObjectType(input?: string | null): AnalysisObjectType {
+  if (!input) return "unknown";
+  return ANALYSIS_OBJECT_TYPES.includes(input as AnalysisObjectType) ? (input as AnalysisObjectType) : "unknown";
+}
+
+export function normalizeAnalysisFinding(input: AnalysisFindingInput): AnalysisFinding {
+  return {
+    id: input.id,
+    title: input.title,
+    issueClass: normalizeAnalysisIssueClass(input.issueClass),
+    severity: normalizeAnalysisSeverity(input.severity),
+    status: normalizeAnalysisFindingStatus(input.status),
+    affectedObjectType: normalizeAnalysisObjectType(input.affectedObjectType),
+    affectedObjectLabel: input.affectedObjectLabel?.trim() || "Affected object unavailable.",
+    whyItMatters: input.whyItMatters?.trim() || "Impact explanation unavailable.",
+    evidence: input.evidence ?? [],
+    routes: input.routes ?? [],
+    ...(input.preservationWarning?.trim() ? { preservationWarning: input.preservationWarning.trim() } : {}),
+  };
+}
+
+export function createDefaultAnalysisFilters(): AnalysisFilters {
+  return {
+    issueClass: "all",
+    severity: "all",
+    objectType: "all",
+    status: "open",
+  };
+}
+
+export function createAnalysisFindingSeeds(): AnalysisFinding[] {
+  return [
+    normalizeAnalysisFinding({
+      id: "finding-preserve-before-migration",
+      title: "Preserve session evidence before migration cleanup",
+      issueClass: "preservation",
+      severity: "high",
+      status: "open",
+      affectedObjectType: "backup",
+      affectedObjectLabel: "Session backup set",
+      whyItMatters: "Migration or cleanup work can destroy the evidence needed to explain source-specific session behavior.",
+      evidence: [
+        {
+          label: "Backup-related failure session",
+          target: "session",
+          sessionId: "session-command-antigravity-4",
+          source: "antigravity",
+        },
+      ],
+      routes: [
+        {
+          target: "backup",
+          label: "Preserve in Backup / Migration",
+          reason: "Preserve source evidence before changing backup or migration state.",
+          preservationWarning: "Preserve before destructive cleanup or migration changes.",
+        },
+        {
+          target: "sessions",
+          label: "Open affected session",
+          reason: "Inspect the failure evidence that triggered the preservation warning.",
+          sessionId: "session-command-antigravity-4",
+          source: "antigravity",
+        },
+      ],
+      preservationWarning: "Preserve before risky migration or cleanup work.",
+    }),
+    normalizeAnalysisFinding({
+      id: "finding-conflicted-skill",
+      title: "Conflicted OpenSpec helper skill",
+      issueClass: "conflict",
+      severity: "high",
+      status: "open",
+      affectedObjectType: "asset",
+      affectedObjectLabel: "OpenSpec apply helper skill",
+      whyItMatters: "Multiple local copies disagree, so agents may follow different implementation workflow rules.",
+      evidence: [
+        {
+          label: "Conflicted generated skill",
+          target: "asset",
+          assetId: "asset-skill-global-generated",
+        },
+      ],
+      routes: [
+        {
+          target: "assets",
+          label: "Open affected asset",
+          reason: "Review the conflicting skill object and its provenance.",
+          assetId: "asset-skill-global-generated",
+          assetSubtype: "skill",
+          assetStatus: "conflicted",
+        },
+      ],
+    }),
+    normalizeAnalysisFinding({
+      id: "finding-stale-memory",
+      title: "Stale review preference memory",
+      issueClass: "stale",
+      severity: "medium",
+      status: "open",
+      affectedObjectType: "asset",
+      affectedObjectLabel: "User review preference memory",
+      whyItMatters: "A stale memory can bias future review decisions if it is not confirmed against current project practice.",
+      evidence: [
+        {
+          label: "Related Windsurf session",
+          target: "session",
+          sessionId: "session-memory-windsurf-2",
+          source: "windsurf",
+        },
+        {
+          label: "Stale memory asset",
+          target: "asset",
+          assetId: "asset-memory-user-windsurf",
+        },
+      ],
+      routes: [
+        {
+          target: "assets",
+          label: "Review memory asset",
+          reason: "Inspect the stale memory object before deciding whether it still applies.",
+          assetId: "asset-memory-user-windsurf",
+          assetSubtype: "memory",
+          assetStatus: "stale",
+        },
+        {
+          target: "sessions",
+          label: "Open source session",
+          reason: "Check the session evidence behind the stale memory.",
+          sessionId: "session-memory-windsurf-2",
+          source: "windsurf",
+        },
+      ],
+    }),
+    normalizeAnalysisFinding({
+      id: "finding-missing-provenance",
+      title: "Imported context fragment has missing provenance",
+      issueClass: "provenance",
+      severity: "medium",
+      status: "watching",
+      affectedObjectType: "asset",
+      affectedObjectLabel: "Imported context package fragment",
+      whyItMatters: "Unknown provenance makes it harder to decide whether imported context should influence project work.",
+      evidence: [
+        {
+          label: "Imported unknown asset",
+          target: "asset",
+          assetId: "asset-unknown-imported-1",
+        },
+      ],
+      routes: [
+        {
+          target: "assets",
+          label: "Open imported asset",
+          reason: "Inspect missing metadata and available source context.",
+          assetId: "asset-unknown-imported-1",
+          assetSubtype: "unknown",
+          assetStatus: "unknown",
+        },
+      ],
+    }),
+    normalizeAnalysisFinding({
+      id: "finding-project-rule-active",
+      title: "Project coding rules are active and traceable",
+      issueClass: "provenance",
+      severity: "low",
+      status: "resolved",
+      affectedObjectType: "asset",
+      affectedObjectLabel: "Project coding rules",
+      whyItMatters: "This object is included as a low-risk baseline for normal analysis filtering and selected-detail states.",
+      evidence: [
+        {
+          label: "Traceable rule asset",
+          target: "asset",
+          assetId: "asset-rule-project-codex",
+        },
+      ],
+      routes: [
+        {
+          target: "assets",
+          label: "Open rule asset",
+          reason: "Review the traceable in-effect rule object.",
+          assetId: "asset-rule-project-codex",
+          assetSubtype: "rule",
+          assetStatus: "active",
+        },
+      ],
+    }),
+    normalizeAnalysisFinding({
+      id: "finding-unknown-import",
+      title: "Unknown imported context requires classification",
+      issueClass: undefined,
+      severity: undefined,
+      status: undefined,
+      affectedObjectType: undefined,
+      affectedObjectLabel: null,
+      whyItMatters: null,
+      evidence: [],
+      routes: [],
+    }),
+  ];
+}
+
+export function applyAnalysisFilters(findings: AnalysisFinding[], filters: AnalysisFilters): AnalysisFinding[] {
+  return findings.filter((finding) => {
+    if (filters.issueClass !== "all" && finding.issueClass !== filters.issueClass) return false;
+    if (filters.severity !== "all" && finding.severity !== filters.severity) return false;
+    if (filters.objectType !== "all" && finding.affectedObjectType !== filters.objectType) return false;
+    if (filters.status !== "all" && finding.status !== filters.status) return false;
+    return true;
+  });
+}
+
+export function summarizeAnalysisFindings(findings: AnalysisFinding[]): AnalysisSummary {
+  const issueClassCounts = Object.fromEntries(ANALYSIS_ISSUE_CLASSES.map((key) => [key, 0])) as Record<AnalysisIssueClass, number>;
+  const severityCounts = Object.fromEntries(ANALYSIS_SEVERITIES.map((key) => [key, 0])) as Record<AnalysisSeverity, number>;
+  let highSeverity = 0;
+  let preservationSensitive = 0;
+
+  for (const finding of findings) {
+    issueClassCounts[finding.issueClass] += 1;
+    severityCounts[finding.severity] += 1;
+    if (finding.severity === "high") highSeverity += 1;
+    if (finding.preservationWarning || finding.routes.some((route) => route.preservationWarning)) {
+      preservationSensitive += 1;
+    }
+  }
+
+  return {
+    total: findings.length,
+    highSeverity,
+    preservationSensitive,
+    issueClassCounts,
+    severityCounts,
+  };
+}
+
+export function buildFiltersFromAnalysisHandoff(
+  handoff: AnalysisHandoff | null,
+  fallback?: AnalysisFilters | null
+): AnalysisFilters {
+  return {
+    issueClass: handoff?.issueClass ?? fallback?.issueClass ?? "all",
+    severity: handoff?.severity ?? fallback?.severity ?? "all",
+    objectType: handoff?.objectType ?? fallback?.objectType ?? "all",
+    status: handoff?.status ?? fallback?.status ?? "open",
+  };
+}
+
+export function resolveAnalysisFindingSelection(
+  findings: AnalysisFinding[],
+  handoff: AnalysisHandoff | null
+): AnalysisFinding | null {
+  if (!handoff) return null;
+
+  if (handoff.findingId) {
+    const byFinding = findings.find((finding) => finding.id === handoff.findingId);
+    if (byFinding) return byFinding;
+  }
+
+  if (handoff.assetId) {
+    const byAsset = findings.find((finding) =>
+      finding.evidence.some((evidence) => evidence.assetId === handoff.assetId) ||
+      finding.routes.some((route) => route.assetId === handoff.assetId)
+    );
+    if (byAsset) return byAsset;
+  }
+
+  if (handoff.sessionId) {
+    const bySession = findings.find((finding) =>
+      finding.evidence.some((evidence) => evidence.sessionId === handoff.sessionId) ||
+      finding.routes.some((route) => route.sessionId === handoff.sessionId)
+    );
+    if (bySession) return bySession;
+  }
+
+  return null;
+}
+
+export function deriveAnalysisSurfaceState(input: {
+  isLoading: boolean;
+  filteredFindings: AnalysisFinding[];
+  selectedFindingId?: string | null;
+}): AnalysisSurfaceState {
+  if (input.isLoading) return "loading";
+  if (input.filteredFindings.length === 0) return "empty";
+
+  const selected = input.selectedFindingId
+    ? input.filteredFindings.find((finding) => finding.id === input.selectedFindingId)
+    : undefined;
+  const issueHeavy = input.filteredFindings.some(
+    (finding) => finding.severity === "high" || Boolean(finding.preservationWarning)
+  );
+
+  if (selected && (selected.severity === "high" || selected.preservationWarning)) return "issue-heavy";
+  if (issueHeavy) return "issue-heavy";
+  if (selected) return "selected";
+  return "normal";
+}
+
+export function formatAnalysisIssueClassLabel(issueClass: AnalysisIssueClass): string {
+  const labels: Record<AnalysisIssueClass, string> = {
+    provenance: "Provenance",
+    stale: "Stale",
+    conflict: "Conflict",
+    preservation: "Preservation",
+    unknown: "Unknown",
+  };
+  return labels[issueClass];
+}
+
+export function formatAnalysisSeverityLabel(severity: AnalysisSeverity): string {
+  const labels: Record<AnalysisSeverity, string> = {
+    high: "High",
+    medium: "Medium",
+    low: "Low",
+    unknown: "Unknown",
+  };
+  return labels[severity];
+}
+
+export function formatAnalysisFindingStatusLabel(status: AnalysisFindingStatus): string {
+  const labels: Record<AnalysisFindingStatus, string> = {
+    open: "Open",
+    watching: "Watching",
+    resolved: "Resolved",
+    unknown: "Unknown",
+  };
+  return labels[status];
+}
+
+export function formatAnalysisObjectTypeLabel(objectType: AnalysisObjectType): string {
+  const labels: Record<AnalysisObjectType, string> = {
+    session: "Session",
+    asset: "Asset",
+    backup: "Backup",
+    project: "Project",
+    unknown: "Unknown",
+  };
+  return labels[objectType];
+}
+
+export function buildAssetsHandoffFromAnalysisRoute(route: AnalysisRoute, finding: AnalysisFinding): AssetsHandoff {
+  return {
+    origin: "analysis",
+    subtitle: `Review affected asset from Analysis: ${finding.title}.`,
+    continueLabel: route.reason,
+    returnLabel: "Return to Analysis to continue grouped interpretation after object review.",
+    subtype: route.assetSubtype,
+    status: route.assetStatus,
+    assetId: route.assetId,
+    issueLabel: formatAnalysisIssueClassLabel(finding.issueClass),
+  };
+}

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -389,10 +389,9 @@ export function resolveAnalysisFindingSelection(
       if (handoff.source) {
         if (!item.source || item.source !== handoff.source) return false;
       }
-      // When handoff provides rootId, item must have the same rootId
-      if (handoff.rootId) {
-        if (!item.rootId || item.rootId !== handoff.rootId) return false;
-      }
+      // When both handoff and item provide rootId, they must match
+      // Item without rootId is treated as wildcard (matches any handoff rootId)
+      if (handoff.rootId && item.rootId && item.rootId !== handoff.rootId) return false;
       return true;
     };
 

--- a/tests/analysisFindings.test.ts
+++ b/tests/analysisFindings.test.ts
@@ -174,11 +174,11 @@ describe("analysis handoff state derivation", () => {
     ).toBeNull();
   });
 
-  it("requires evidence to have source/rootId when handoff provides them", () => {
-    // Create a finding where evidence lacks source (handoff provides source)
-    const findingWithSourcelessEvidence = normalizeAnalysisFinding({
-      id: "finding-sourceless",
-      title: "Sourceless evidence test",
+  it("requires source match but treats missing rootId as wildcard", () => {
+    // Create a finding where evidence has source but lacks rootId
+    const findingWithSourceNoRootId = normalizeAnalysisFinding({
+      id: "finding-source-no-root",
+      title: "Evidence with source but no rootId",
       issueClass: "provenance",
       severity: "low",
       status: "open",
@@ -187,34 +187,81 @@ describe("analysis handoff state derivation", () => {
       whyItMatters: "Test",
       evidence: [
         {
-          label: "Session without source",
+          label: "Session with source, no rootId",
           target: "session",
           sessionId: "session-test-1",
-          // Note: no source field
+          source: "antigravity",
+          // Note: no rootId field - should be wildcard
         },
       ],
       routes: [],
     });
 
-    // When handoff provides source, evidence without source should NOT match
+    // Source is strict: handoff provides different source, no match
     expect(
-      resolveAnalysisFindingSelection([findingWithSourcelessEvidence], {
+      resolveAnalysisFindingSelection([findingWithSourceNoRootId], {
         origin: "sessions",
-        subtitle: "Test sourceless evidence.",
+        subtitle: "Test source mismatch.",
         sessionId: "session-test-1",
-        source: "antigravity",
+        source: "windsurf", // different from evidence's antigravity
       })
     ).toBeNull();
 
-    // But should match when handoff doesn't provide source
+    // rootId is wildcard: handoff provides rootId, evidence without rootId still matches
+    // (as long as source matches)
     expect(
-      resolveAnalysisFindingSelection([findingWithSourcelessEvidence], {
+      resolveAnalysisFindingSelection([findingWithSourceNoRootId], {
         origin: "sessions",
-        subtitle: "Test sourceless evidence without handoff source.",
+        subtitle: "Test rootId wildcard with matching source.",
         sessionId: "session-test-1",
-        // Note: no source field in handoff
+        source: "antigravity", // matches evidence
+        rootId: "root-a", // evidence lacks rootId but should still match (wildcard)
       })?.id
-    ).toBe("finding-sourceless");
+    ).toBe("finding-source-no-root");
+
+    // Create a finding where evidence has both source and rootId
+    const findingWithRootId = normalizeAnalysisFinding({
+      id: "finding-with-root",
+      title: "Evidence with rootId",
+      issueClass: "provenance",
+      severity: "low",
+      status: "open",
+      affectedObjectType: "session",
+      affectedObjectLabel: "Test session",
+      whyItMatters: "Test",
+      evidence: [
+        {
+          label: "Session with rootId",
+          target: "session",
+          sessionId: "session-test-2",
+          source: "antigravity",
+          rootId: "root-b",
+        },
+      ],
+      routes: [],
+    });
+
+    // Same rootId matches
+    expect(
+      resolveAnalysisFindingSelection([findingWithRootId], {
+        origin: "sessions",
+        subtitle: "Test matching rootId.",
+        sessionId: "session-test-2",
+        source: "antigravity",
+        rootId: "root-b",
+      })?.id
+    ).toBe("finding-with-root");
+
+    // Different rootId does not match (both have rootId, must match)
+    expect(
+      resolveAnalysisFindingSelection([findingWithRootId], {
+        origin: "sessions",
+        subtitle: "Test mismatched rootId.",
+        sessionId: "session-test-2",
+        source: "antigravity",
+        rootId: "root-c", // different from evidence's root-b
+      })
+    ).toBeNull();
   });
 
   it("degrades stale finding references to null while filters can remain valid", () => {

--- a/tests/analysisFindings.test.ts
+++ b/tests/analysisFindings.test.ts
@@ -174,6 +174,49 @@ describe("analysis handoff state derivation", () => {
     ).toBeNull();
   });
 
+  it("requires evidence to have source/rootId when handoff provides them", () => {
+    // Create a finding where evidence lacks source (handoff provides source)
+    const findingWithSourcelessEvidence = normalizeAnalysisFinding({
+      id: "finding-sourceless",
+      title: "Sourceless evidence test",
+      issueClass: "provenance",
+      severity: "low",
+      status: "open",
+      affectedObjectType: "session",
+      affectedObjectLabel: "Test session",
+      whyItMatters: "Test",
+      evidence: [
+        {
+          label: "Session without source",
+          target: "session",
+          sessionId: "session-test-1",
+          // Note: no source field
+        },
+      ],
+      routes: [],
+    });
+
+    // When handoff provides source, evidence without source should NOT match
+    expect(
+      resolveAnalysisFindingSelection([findingWithSourcelessEvidence], {
+        origin: "sessions",
+        subtitle: "Test sourceless evidence.",
+        sessionId: "session-test-1",
+        source: "antigravity",
+      })
+    ).toBeNull();
+
+    // But should match when handoff doesn't provide source
+    expect(
+      resolveAnalysisFindingSelection([findingWithSourcelessEvidence], {
+        origin: "sessions",
+        subtitle: "Test sourceless evidence without handoff source.",
+        sessionId: "session-test-1",
+        // Note: no source field in handoff
+      })?.id
+    ).toBe("finding-sourceless");
+  });
+
   it("degrades stale finding references to null while filters can remain valid", () => {
     const findings = createAnalysisFindingSeeds();
     const filtered = applyAnalysisFilters(findings, {

--- a/tests/analysisFindings.test.ts
+++ b/tests/analysisFindings.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyAnalysisFilters,
+  buildAssetsHandoffFromAnalysisRoute,
+  buildFiltersFromAnalysisHandoff,
+  createAnalysisFindingSeeds,
+  deriveAnalysisSurfaceState,
+  normalizeAnalysisFinding,
+  resolveAnalysisFindingSelection,
+  summarizeAnalysisFindings,
+} from "@/lib/analysisFindings";
+
+describe("normalizeAnalysisFinding", () => {
+  it("keeps missing finding metadata explicit", () => {
+    expect(
+      normalizeAnalysisFinding({
+        id: "finding-1",
+        title: "Unknown issue",
+      })
+    ).toMatchObject({
+      id: "finding-1",
+      title: "Unknown issue",
+      issueClass: "unknown",
+      severity: "unknown",
+      status: "unknown",
+      affectedObjectType: "unknown",
+      affectedObjectLabel: "Affected object unavailable.",
+      whyItMatters: "Impact explanation unavailable.",
+      evidence: [],
+      routes: [],
+    });
+  });
+
+  it("normalizes unsupported values to unknown", () => {
+    const finding = normalizeAnalysisFinding({
+      id: "finding-2",
+      title: "Unsupported issue",
+      issueClass: "latency",
+      severity: "critical",
+      status: "triaged",
+      affectedObjectType: "database",
+    });
+
+    expect(finding.issueClass).toBe("unknown");
+    expect(finding.severity).toBe("unknown");
+    expect(finding.status).toBe("unknown");
+    expect(finding.affectedObjectType).toBe("unknown");
+  });
+});
+
+describe("analysis finding seeds and filters", () => {
+  it("provides bounded local findings across route targets and unknown cases", () => {
+    const findings = createAnalysisFindingSeeds();
+
+    expect(findings.length).toBeGreaterThan(4);
+    expect(findings.some((finding) => finding.severity === "high")).toBe(true);
+    expect(findings.some((finding) => finding.issueClass === "preservation")).toBe(true);
+    expect(findings.some((finding) => finding.issueClass === "unknown")).toBe(true);
+    expect(findings.some((finding) => finding.routes.some((route) => route.target === "assets"))).toBe(true);
+    expect(findings.some((finding) => finding.routes.some((route) => route.target === "sessions"))).toBe(true);
+    expect(findings.some((finding) => finding.routes.some((route) => route.target === "backup"))).toBe(true);
+  });
+
+  it("filters by issue class, severity, object type, and status", () => {
+    const findings = createAnalysisFindingSeeds();
+    const filtered = applyAnalysisFilters(findings, {
+      issueClass: "conflict",
+      severity: "high",
+      objectType: "asset",
+      status: "open",
+    });
+
+    expect(filtered.map((finding) => finding.id)).toEqual(["finding-conflicted-skill"]);
+  });
+
+  it("summarizes high severity and preservation-sensitive findings", () => {
+    const summary = summarizeAnalysisFindings(createAnalysisFindingSeeds());
+
+    expect(summary.total).toBeGreaterThan(0);
+    expect(summary.highSeverity).toBeGreaterThan(0);
+    expect(summary.preservationSensitive).toBeGreaterThan(0);
+    expect(summary.issueClassCounts.conflict).toBeGreaterThan(0);
+  });
+});
+
+describe("analysis handoff state derivation", () => {
+  it("builds filters from handoff while preserving fallback status", () => {
+    expect(
+      buildFiltersFromAnalysisHandoff(
+        {
+          origin: "assets",
+          subtitle: "Review conflicted asset.",
+          issueClass: "conflict",
+          objectType: "asset",
+        },
+        {
+          issueClass: "all",
+          severity: "all",
+          objectType: "all",
+          status: "watching",
+        }
+      )
+    ).toEqual({
+      issueClass: "conflict",
+      severity: "all",
+      objectType: "asset",
+      status: "watching",
+    });
+  });
+
+  it("selects by finding id when routed context is still valid", () => {
+    const findings = createAnalysisFindingSeeds();
+    const filtered = applyAnalysisFilters(findings, {
+      issueClass: "conflict",
+      severity: "all",
+      objectType: "all",
+      status: "open",
+    });
+
+    expect(
+      resolveAnalysisFindingSelection(filtered, {
+        origin: "overview",
+        subtitle: "Review conflicts.",
+        issueClass: "conflict",
+        findingId: "finding-conflicted-skill",
+      })?.id
+    ).toBe("finding-conflicted-skill");
+  });
+
+  it("selects by affected asset or session evidence", () => {
+    const findings = createAnalysisFindingSeeds();
+
+    expect(
+      resolveAnalysisFindingSelection(findings, {
+        origin: "assets",
+        subtitle: "Review skill conflict.",
+        assetId: "asset-skill-global-generated",
+      })?.id
+    ).toBe("finding-conflicted-skill");
+
+    expect(
+      resolveAnalysisFindingSelection(findings, {
+        origin: "sessions",
+        subtitle: "Review session failure.",
+        sessionId: "session-command-antigravity-4",
+      })?.id
+    ).toBe("finding-preserve-before-migration");
+  });
+
+  it("degrades stale finding references to null while filters can remain valid", () => {
+    const findings = createAnalysisFindingSeeds();
+    const filtered = applyAnalysisFilters(findings, {
+      issueClass: "stale",
+      severity: "all",
+      objectType: "all",
+      status: "open",
+    });
+
+    expect(
+      resolveAnalysisFindingSelection(filtered, {
+        origin: "assets",
+        subtitle: "Review stale asset.",
+        issueClass: "stale",
+        findingId: "missing-finding",
+      })
+    ).toBeNull();
+    expect(filtered.length).toBeGreaterThan(0);
+  });
+
+  it("derives loading, empty, selected, and issue-heavy states", () => {
+    const findings = createAnalysisFindingSeeds();
+    const lowFindings = applyAnalysisFilters(findings, {
+      issueClass: "provenance",
+      severity: "low",
+      objectType: "all",
+      status: "resolved",
+    });
+    const highFindings = applyAnalysisFilters(findings, {
+      issueClass: "preservation",
+      severity: "all",
+      objectType: "all",
+      status: "open",
+    });
+
+    expect(deriveAnalysisSurfaceState({ isLoading: true, filteredFindings: findings, selectedFindingId: null })).toBe("loading");
+    expect(deriveAnalysisSurfaceState({ isLoading: false, filteredFindings: [], selectedFindingId: null })).toBe("empty");
+    expect(
+      deriveAnalysisSurfaceState({
+        isLoading: false,
+        filteredFindings: lowFindings,
+        selectedFindingId: "finding-project-rule-active",
+      })
+    ).toBe("selected");
+    expect(deriveAnalysisSurfaceState({ isLoading: false, filteredFindings: highFindings, selectedFindingId: null })).toBe("issue-heavy");
+  });
+
+  it("builds bounded Assets handoff from an analysis route", () => {
+    const finding = createAnalysisFindingSeeds().find((item) => item.id === "finding-conflicted-skill");
+    const route = finding?.routes.find((item) => item.target === "assets");
+
+    expect(finding).toBeTruthy();
+    expect(route).toBeTruthy();
+    expect(buildAssetsHandoffFromAnalysisRoute(route!, finding!)).toMatchObject({
+      origin: "analysis",
+      subtype: "skill",
+      status: "conflicted",
+      assetId: "asset-skill-global-generated",
+      issueLabel: "Conflict",
+    });
+  });
+});

--- a/tests/analysisFindings.test.ts
+++ b/tests/analysisFindings.test.ts
@@ -149,6 +149,31 @@ describe("analysis handoff state derivation", () => {
     ).toBe("finding-preserve-before-migration");
   });
 
+  it("selects by session with source-aware matching for precise identity", () => {
+    const findings = createAnalysisFindingSeeds();
+
+    // Matches when source aligns with evidence
+    expect(
+      resolveAnalysisFindingSelection(findings, {
+        origin: "sessions",
+        subtitle: "Review session evidence.",
+        sessionId: "session-command-antigravity-4",
+        source: "antigravity",
+      })?.id
+    ).toBe("finding-preserve-before-migration");
+
+    // Cross-source: same sessionId but different source should not match
+    // (the finding has source: "antigravity", handoff has source: "windsurf")
+    expect(
+      resolveAnalysisFindingSelection(findings, {
+        origin: "sessions",
+        subtitle: "Cross-source session check.",
+        sessionId: "session-command-antigravity-4",
+        source: "windsurf",
+      })
+    ).toBeNull();
+  });
+
   it("degrades stale finding references to null while filters can remain valid", () => {
     const findings = createAnalysisFindingSeeds();
     const filtered = applyAnalysisFilters(findings, {

--- a/tests/analysisFindings.test.ts
+++ b/tests/analysisFindings.test.ts
@@ -8,6 +8,7 @@ import {
   deriveAnalysisSurfaceState,
   normalizeAnalysisFinding,
   resolveAnalysisFindingSelection,
+  resolveAnalysisSessionRootId,
   summarizeAnalysisFindings,
 } from "@/lib/analysisFindings";
 
@@ -208,5 +209,40 @@ describe("analysis handoff state derivation", () => {
       assetId: "asset-skill-global-generated",
       issueLabel: "Conflict",
     });
+  });
+
+  it("preserves routed session root id only for matching session context", () => {
+    const handoff = {
+      origin: "sessions" as const,
+      subtitle: "Review selected session evidence.",
+      sessionId: "session-command-antigravity-4",
+      source: "antigravity" as const,
+      rootId: "root-a",
+    };
+
+    expect(
+      resolveAnalysisSessionRootId({
+        handoff,
+        sessionId: "session-command-antigravity-4",
+        source: "antigravity",
+      })
+    ).toBe("root-a");
+
+    expect(
+      resolveAnalysisSessionRootId({
+        handoff,
+        sessionId: "session-command-antigravity-4",
+        source: "antigravity",
+        explicitRootId: "explicit-root",
+      })
+    ).toBe("explicit-root");
+
+    expect(
+      resolveAnalysisSessionRootId({
+        handoff,
+        sessionId: "other-session",
+        source: "antigravity",
+      })
+    ).toBeUndefined();
   });
 });

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -101,4 +101,5 @@ describe("AnalysisFoundation", () => {
     expect(html).toContain("The original finding could not be selected.");
     expect(html).toContain("Stale review preference memory");
   });
+
 });

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -117,10 +117,7 @@ describe("AnalysisFoundation", () => {
     };
 
     const navigationHandoff = resolveAnalysisNavigationHandoff(handoff);
-    const nextState = clearAnalysisRoutedCueState({
-      activeHandoff: handoff,
-      navigationHandoff,
-    });
+    const nextState = clearAnalysisRoutedCueState(navigationHandoff);
 
     expect(nextState.activeHandoff).toBeNull();
     expect(nextState.navigationHandoff).toEqual(handoff);

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { AnalysisFoundation } from "@/components/AnalysisFoundation";
-import type { AnalysisHandoff } from "@/lib/analysisFindings";
+import {
+  AnalysisFoundation,
+  clearAnalysisRoutedCueState,
+  resolveAnalysisNavigationHandoff,
+} from "@/components/AnalysisFoundation";
+import { resolveAnalysisSessionRootId, type AnalysisHandoff } from "@/lib/analysisFindings";
 
 function renderAnalysisFoundation(handoff: AnalysisHandoff | null) {
   return renderToStaticMarkup(
@@ -100,6 +104,44 @@ describe("AnalysisFoundation", () => {
 
     expect(html).toContain("The original routed context could not be selected.");
     expect(html).toContain("Stale review preference memory");
+  });
+
+  it("retains session navigation handoff even after routed cue is cleared", () => {
+    const handoff: AnalysisHandoff = {
+      origin: "sessions",
+      subtitle: "Review session evidence.",
+      issueClass: "preservation",
+      sessionId: "session-command-antigravity-4",
+      source: "antigravity",
+      rootId: "root-a",
+    };
+
+    const navigationHandoff = resolveAnalysisNavigationHandoff(handoff);
+    const nextState = clearAnalysisRoutedCueState({
+      activeHandoff: handoff,
+      navigationHandoff,
+    });
+
+    expect(nextState.activeHandoff).toBeNull();
+    expect(nextState.navigationHandoff).toEqual(handoff);
+    expect(
+      resolveAnalysisSessionRootId({
+        handoff: nextState.navigationHandoff,
+        sessionId: "session-command-antigravity-4",
+        source: "antigravity",
+      })
+    ).toBe("root-a");
+  });
+
+  it("only retains navigation handoff for session-scoped routed context", () => {
+    expect(
+      resolveAnalysisNavigationHandoff({
+        origin: "assets",
+        subtitle: "Review issue context from Assets: conflicted asset.",
+        issueClass: "conflict",
+        assetId: "asset-skill-global-generated",
+      })
+    ).toBeNull();
   });
 
 });

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -98,7 +98,7 @@ describe("AnalysisFoundation", () => {
       findingId: "missing-finding",
     });
 
-    expect(html).toContain("The original finding could not be selected.");
+    expect(html).toContain("The original routed context could not be selected.");
     expect(html).toContain("Stale review preference memory");
   });
 

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { AnalysisFoundation } from "@/components/AnalysisFoundation";
+import type { AnalysisHandoff } from "@/lib/analysisFindings";
+
+function renderAnalysisFoundation(handoff: AnalysisHandoff | null) {
+  return renderToStaticMarkup(
+    <AnalysisFoundation
+      handoff={handoff}
+      loadingDelayMs={0}
+      onOpenAssets={vi.fn()}
+      onOpenBackup={vi.fn()}
+      onOpenOverview={vi.fn()}
+      onOpenSession={vi.fn()}
+    />
+  );
+}
+
+describe("AnalysisFoundation", () => {
+  it("renders issue-heavy state without claiming automated remediation", () => {
+    const html = renderAnalysisFoundation(null);
+
+    expect(html).toContain("Analysis");
+    expect(html).toContain("issue-heavy state");
+    expect(html).toContain("Context Health Summary");
+    expect(html).toContain("Findings Inventory");
+    expect(html).toContain("This foundation does not claim automatic fixes");
+  });
+
+  it("renders selected routed-in state from Assets with object context", () => {
+    const html = renderAnalysisFoundation({
+      origin: "assets",
+      subtitle: "Review issue context from Assets: conflicted asset.",
+      issueClass: "conflict",
+      objectType: "asset",
+      assetId: "asset-skill-global-generated",
+      issueLabel: "conflicted asset",
+    });
+
+    expect(html).toContain("routed analysis");
+    expect(html).toContain("from assets");
+    expect(html).toContain("Conflicted OpenSpec helper skill");
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain("Open affected asset");
+  });
+
+  it("renders selected non-issue state when handoff targets resolved low-risk finding", () => {
+    const html = renderAnalysisFoundation({
+      origin: "overview",
+      subtitle: "Review traceable project rule baseline.",
+      issueClass: "provenance",
+      severity: "low",
+      objectType: "asset",
+      status: "resolved",
+      findingId: "finding-project-rule-active",
+    });
+
+    expect(html).toContain("selected finding active");
+    expect(html).toContain("Project coding rules are active and traceable");
+    expect(html).not.toContain("issue-heavy state");
+  });
+
+  it("renders normal state when filters match only low-risk unselected findings", () => {
+    const html = renderAnalysisFoundation({
+      origin: "overview",
+      subtitle: "Review low-risk provenance findings.",
+      issueClass: "provenance",
+      severity: "low",
+      status: "resolved",
+    });
+
+    expect(html).toContain("Project coding rules are active and traceable");
+    expect(html).not.toContain("issue-heavy state");
+    expect(html).not.toContain("selected finding active");
+  });
+
+  it("renders empty routed-in state without fake findings", () => {
+    const html = renderAnalysisFoundation({
+      origin: "overview",
+      subtitle: "Review high-severity stale findings.",
+      issueClass: "stale",
+      severity: "high",
+      objectType: "asset",
+    });
+
+    expect(html).toContain("No findings match the current issue and object context.");
+    expect(html).toContain("No findings currently match the routed context.");
+    expect(html).not.toContain("Stale review preference memory");
+  });
+
+  it("degrades stale handoff safely when the referenced finding is missing", () => {
+    const html = renderAnalysisFoundation({
+      origin: "overview",
+      subtitle: "Review stale findings from project attention.",
+      issueClass: "stale",
+      findingId: "missing-finding",
+    });
+
+    expect(html).toContain("The original finding could not be selected.");
+    expect(html).toContain("Stale review preference memory");
+  });
+});

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { resolveRestoredSelection } from "@/components/HomeClient";
 import {
+  buildAnalysisFoundationInstanceKey,
+  buildAnalysisHandoffFromAssets,
+  buildAnalysisHandoffFromOverview,
+  buildAnalysisHandoffFromSession,
   buildAssetsHandoffFromAnalysis,
   buildAssetsFoundationInstanceKey,
   buildAssetsHandoffFromOverview,
@@ -188,5 +192,85 @@ describe("assets handoff builders", () => {
       assetId: "asset-skill-global-generated",
       issueLabel: "conflicted asset",
     });
+  });
+});
+
+describe("analysis handoff builders", () => {
+  it("builds an Assets to Analysis handoff with issue and object context", () => {
+    expect(
+      buildAnalysisHandoffFromAssets({
+        issueLabel: "conflicted asset",
+        assetId: "asset-skill-global-generated",
+        subtype: "skill",
+        status: "conflicted",
+      })
+    ).toMatchObject({
+      origin: "assets",
+      issueClass: "conflict",
+      objectType: "asset",
+      assetId: "asset-skill-global-generated",
+      assetSubtype: "skill",
+      issueLabel: "conflicted asset",
+    });
+  });
+
+  it("builds a Project Overview to Analysis handoff without carrying overview state", () => {
+    expect(
+      buildAnalysisHandoffFromOverview({
+        subtitle: "Review preservation-sensitive findings.",
+        issueClass: "preservation",
+        severity: "high",
+        objectType: "backup",
+        findingId: "finding-preserve-before-migration",
+      })
+    ).toMatchObject({
+      origin: "overview",
+      issueClass: "preservation",
+      severity: "high",
+      objectType: "backup",
+      findingId: "finding-preserve-before-migration",
+    });
+  });
+
+  it("builds a Sessions to Analysis handoff without carrying transcript state", () => {
+    expect(
+      buildAnalysisHandoffFromSession({
+        sessionId: "session-command-antigravity-4",
+        source: "antigravity",
+        rootId: "root-a",
+      })
+    ).toMatchObject({
+      origin: "sessions",
+      issueClass: "preservation",
+      objectType: "session",
+      sessionId: "session-command-antigravity-4",
+      source: "antigravity",
+    });
+  });
+});
+
+describe("buildAnalysisFoundationInstanceKey", () => {
+  it("changes when routed Analysis context changes", () => {
+    const first = buildAnalysisFoundationInstanceKey({
+      origin: "assets",
+      subtitle: "Review conflicted asset.",
+      issueClass: "conflict",
+      objectType: "asset",
+      assetId: "asset-skill-global-generated",
+    });
+    const second = buildAnalysisFoundationInstanceKey({
+      origin: "sessions",
+      subtitle: "Review session evidence.",
+      issueClass: "preservation",
+      objectType: "session",
+      sessionId: "session-command-antigravity-4",
+      source: "antigravity",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("keeps a stable non-routed key for normal Analysis browsing", () => {
+    expect(buildAnalysisFoundationInstanceKey(null)).toBe("analysis:no-handoff");
   });
 });

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -242,7 +242,6 @@ describe("analysis handoff builders", () => {
     ).toMatchObject({
       origin: "sessions",
       issueClass: "preservation",
-      objectType: "session",
       sessionId: "session-command-antigravity-4",
       source: "antigravity",
       rootId: "root-a",

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -245,6 +245,7 @@ describe("analysis handoff builders", () => {
       objectType: "session",
       sessionId: "session-command-antigravity-4",
       source: "antigravity",
+      rootId: "root-a",
     });
   });
 });
@@ -265,6 +266,30 @@ describe("buildAnalysisFoundationInstanceKey", () => {
       objectType: "session",
       sessionId: "session-command-antigravity-4",
       source: "antigravity",
+      rootId: "root-a",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("changes when routed session root context changes", () => {
+    const first = buildAnalysisFoundationInstanceKey({
+      origin: "sessions",
+      subtitle: "Review session evidence.",
+      issueClass: "preservation",
+      objectType: "session",
+      sessionId: "session-command-antigravity-4",
+      source: "antigravity",
+      rootId: "root-a",
+    });
+    const second = buildAnalysisFoundationInstanceKey({
+      origin: "sessions",
+      subtitle: "Review session evidence.",
+      issueClass: "preservation",
+      objectType: "session",
+      sessionId: "session-command-antigravity-4",
+      source: "antigravity",
+      rootId: "root-b",
     });
 
     expect(first).not.toBe(second);


### PR DESCRIPTION
## Summary

- Replace the Analysis placeholder with a bounded interpretation-and-routing foundation surface.
- Add local analysis finding seeds, normalization/filter/summary helpers, selected finding resolution, routed cues, evidence context, and route-only recommended actions.
- Wire routed handoff into Analysis from Project Overview, Assets, and Sessions, plus outbound routes to Sessions, Assets, and Backup / Migration.
- Add external QA prompt for Analysis foundation smoke and routed handoff flows.

Tracks #47

## Validation

- `pnpm test`
- `pnpm build`
- `OPENSPEC_TELEMETRY=0 openspec validate analysis-foundation --strict`