### PR TITLE
spec(openspec): archive analysis foundation

### DIFF
--- a/openspec/changes/archive/2026-04-13-analysis-foundation/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-13-analysis-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/archive/2026-04-13-analysis-foundation/design.md
+++ b/openspec/changes/archive/2026-04-13-analysis-foundation/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The current project shell has real `Sessions` and `Assets` surfaces, while
+`Analysis` still communicates intent through a placeholder. The UX architecture
+documents define `Analysis` as an interpretation-and-routing page: it should
+make problems visible, explain why they matter, and route users to the page that
+owns corrective work.
+
+This foundation should continue the same local-first approach used by
+`assets-foundation`: seeded data and explicit bounded behavior first, with no
+claim that complete cross-agent analysis exists.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a real `Analysis` foundation surface with context health summary,
+  findings inventory, selected finding detail, and recommended outbound actions.
+- Preserve issue framing when routed in from `Assets`, `Project Overview`, or
+  `Sessions`.
+- Route corrective work to owning pages: evidence review in `Sessions`, object
+  review in `Assets`, and preservation workflows in `Backup / Migration`.
+- Make missing evidence, stale references, and bounded foundation limits
+  explicit.
+
+**Non-Goals:**
+
+- No complete automated project analysis engine.
+- No AI-generated findings from arbitrary local files.
+- No inline asset editing, session mutation, backup execution, or migration
+  execution inside `Analysis`.
+- No cloud sync, team dashboard, or external telemetry dependency.
+- No high-fidelity redesign or design-system overhaul.
+
+## Decisions
+
+### Decision 1: Introduce a small local analysis finding model
+
+Use a bounded model for findings with fields such as id, title, issue class,
+severity, affected object references, evidence references, status, route targets,
+and optional preservation warning.
+
+Alternative considered: derive findings directly from Assets UI state. That
+would make `Analysis` too dependent on `Assets` and would blur page ownership.
+The model should be independent enough to represent session, asset, and backup
+risks while still using seeded data in the foundation phase.
+
+### Decision 2: Keep Analysis as interpretation plus routing
+
+`Analysis` owns explanation and prioritization, not execution. Recommended
+actions should call shell-level route handlers that open `Sessions`, `Assets`, or
+`Backup / Migration` with bounded handoff context.
+
+Alternative considered: add inline correction panels. That would make Analysis a
+workflow page and conflict with the current IA.
+
+### Decision 3: Use compact routed cues by default
+
+Routed-in context should appear as compact origin / issue cues near the Analysis
+header and selected finding region. Page-level banners are reserved for states
+where the user must understand the route before proceeding.
+
+Alternative considered: always use a page-level banner. That would overweight
+handoff context and make normal triage feel like an interrupted workflow.
+
+### Decision 4: Treat foundation findings as representative seed data
+
+The first implementation should use deterministic seed findings that cover the
+required states and route targets. The UI copy must make the bounded foundation
+scope clear and avoid implying full analysis coverage.
+
+Alternative considered: no seed findings until real adapters exist. That would
+leave the page too abstract to validate layout, routed handoff, and action
+semantics.
+
+## Risks / Trade-offs
+
+- Fake-authority risk -> Use bounded copy and avoid claiming complete analysis
+  coverage.
+- Page-role drift -> Keep recommended actions outbound and prevent inline
+  workflow execution.
+- Duplicate Assets behavior -> Show affected object references and route to
+  `Assets`, but do not embed asset inventory or provenance panels in `Analysis`.
+- Routing complexity -> Keep handoff payloads minimal and test route helpers
+  separately from UI rendering.
+- Seed-data brittleness -> Cover every required state in tests so the seed layer
+  remains intentional rather than incidental.

--- a/openspec/changes/archive/2026-04-13-analysis-foundation/proposal.md
+++ b/openspec/changes/archive/2026-04-13-analysis-foundation/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+`Assets` now exposes reusable context objects and issue-oriented routes, but
+`Analysis` still behaves as a placeholder. This leaves a product gap: users can
+see affected assets, but they do not yet have a bounded interpretation surface
+that explains grouped issues and routes them to the owning page for action.
+
+## What Changes
+
+- Replace the `Analysis` placeholder with a bounded foundation surface for
+  context health, findings, selected finding detail, and recommended outbound
+  actions.
+- Add a local-first seeded analysis model that can represent issue class,
+  severity, affected object references, evidence references, and route targets
+  without claiming complete automated analysis.
+- Support routed handoff into `Analysis` from `Assets`, `Project Overview`, and
+  `Sessions` through issue class filters, selected findings when available, and
+  compact origin / continue-task cues.
+- Support bounded outbound routes from `Analysis` to `Sessions`, `Assets`, and
+  `Backup / Migration` while keeping execution on the owning destination page.
+- Preserve the project-first shell role boundaries: `Analysis` explains and
+  routes; it does not become a second asset inventory, a backup workflow body,
+  or a fake auto-remediation engine.
+
+## Capabilities
+
+### New Capabilities
+
+- `analysis-foundation`: Defines the local-first Analysis foundation surface,
+  finding model, states, routed handoff behavior, and bounded outbound actions.
+
+### Modified Capabilities
+
+- `project-shell`: Replaces the Analysis placeholder requirement with a bounded
+  Analysis foundation requirement while preserving the shell-level role boundary.
+
+## Impact
+
+- Affected UI: `src/components/ProjectShellClient.tsx` and a new or extracted
+  Analysis foundation component.
+- Affected model code: local seeded analysis finding helpers and handoff helpers,
+  likely under `src/lib/`.
+- Affected tests: unit tests for analysis model helpers and component tests for
+  normal, selected, issue-heavy, routed-in, and outbound action states.
+- Affected docs: README / CHANGELOG updates when the implementation ships.
+- Tracking: GitHub Issue #47.

--- a/openspec/changes/archive/2026-04-13-analysis-foundation/specs/analysis-foundation/spec.md
+++ b/openspec/changes/archive/2026-04-13-analysis-foundation/specs/analysis-foundation/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Analysis finding model
+The system SHALL represent bounded local analysis findings with explicit issue
+class, severity, affected object references, evidence references, status, and
+route targets.
+
+#### Scenario: Finding exposes issue classification
+- **WHEN** the system renders an analysis finding
+- **THEN** it identifies the finding issue class
+- **AND** it identifies the finding severity
+- **AND** it identifies the affected object type when known
+- **AND** it shows unknown or unavailable fields explicitly rather than
+  inferring complete analysis coverage
+
+#### Scenario: Finding keeps evidence separate from action
+- **WHEN** a finding references session or asset evidence
+- **THEN** the system exposes the evidence reference as provenance for the
+  finding
+- **AND** it exposes corrective routes separately from evidence references
+
+### Requirement: Analysis page backbone
+The system SHALL provide an Analysis surface that orients users around context
+health, findings, selected finding detail, and recommended outbound actions.
+
+#### Scenario: Analysis page renders fixed backbone
+- **WHEN** the user opens `Analysis`
+- **THEN** the page shows an Analysis header
+- **AND** the page shows a context health summary
+- **AND** the page shows a findings inventory
+
+#### Scenario: Selected finding explains the problem
+- **WHEN** the user selects a finding
+- **THEN** the page shows the selected finding title
+- **AND** it explains why the finding matters
+- **AND** it shows affected object and evidence context when available
+- **AND** it keeps the finding tied to the current findings inventory context
+
+### Requirement: Analysis surface states
+The system SHALL support bounded empty, loading, normal, selected, issue-heavy,
+and routed-in states for the Analysis surface.
+
+#### Scenario: Empty state avoids fake findings
+- **WHEN** no findings match the active issue class or filter context
+- **THEN** the page keeps the active context visible
+- **AND** it shows a zero-state explanation rather than fake finding rows
+- **AND** it offers bounded next actions such as changing filters or inspecting
+  sessions and assets
+
+#### Scenario: Issue-heavy state prioritizes explanation
+- **WHEN** the active findings include high-severity or preservation-sensitive
+  issues
+- **THEN** the page emphasizes the affected issue class
+- **AND** it prioritizes selected finding detail and recommended outbound routes
+- **AND** it does not become a backup or migration workflow surface
+
+### Requirement: Routed handoff into Analysis
+The system SHALL consume routed handoff context into the Analysis surface through
+issue class filters, selected findings when available, and bounded continuity
+cues.
+
+#### Scenario: Assets handoff preserves affected object context
+- **WHEN** the user enters `Analysis` from `Assets` for an affected asset or
+  asset class
+- **THEN** the Analysis page applies the relevant issue class or object filter
+- **AND** it selects a matching finding when available
+- **AND** it shows a compact origin cue referencing the asset context
+- **AND** it does not embed the full asset inventory or detail panel
+
+#### Scenario: Overview handoff preserves issue framing
+- **WHEN** the user enters `Analysis` from `Project Overview` with an issue
+  class or attention item
+- **THEN** the Analysis page applies the relevant issue filter
+- **AND** it shows a compact origin cue referencing the overview context
+- **AND** it does not carry full project-summary state
+
+#### Scenario: Session handoff preserves evidence context
+- **WHEN** the user enters `Analysis` from `Sessions` with a failure or
+  evidence reference
+- **THEN** the Analysis page applies the relevant issue or evidence filter
+- **AND** it shows a compact origin cue referencing the source session
+- **AND** it does not carry the full transcript, trajectory state, or
+  session-local reading mode
+
+#### Scenario: Stale handoff degrades safely
+- **WHEN** routed handoff context references a missing finding or stale source
+- **THEN** the Analysis page keeps any still-valid issue class or object filter
+- **AND** it explains that the original finding could not be selected
+
+### Requirement: Bounded analysis actions
+The system SHALL expose only bounded outbound actions from Analysis and route
+corrective work to the owning page.
+
+#### Scenario: Finding action routes to owning surface
+- **WHEN** a selected finding has a recommended route to sessions, assets,
+  backup, or migration
+- **THEN** the Analysis page presents the action as a contextual route
+- **AND** the destination page owns the evidence review, object review, or
+  workflow execution
+
+#### Scenario: Preservation warning stays explicit
+- **WHEN** a recommended action could affect backup, migration, archive, or
+  destructive cleanup semantics
+- **THEN** the Analysis page shows a preservation warning
+- **AND** it routes the user to `Backup / Migration` rather than executing the
+  workflow inside Analysis
+
+#### Scenario: Analysis does not become remediation engine
+- **WHEN** the user inspects a finding
+- **THEN** the Analysis page does not present automatic fixes, full asset
+  editing, session mutation, or backup execution as implemented foundation
+  behavior

--- a/openspec/changes/archive/2026-04-13-analysis-foundation/specs/project-shell/spec.md
+++ b/openspec/changes/archive/2026-04-13-analysis-foundation/specs/project-shell/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Placeholder surfaces do not claim full behavior
+The system SHALL expose foundation or placeholder surfaces for top-level pages
+without claiming unimplemented full behavior.
+
+#### Scenario: Assets foundation is bounded
+- **WHEN** the user navigates to `Assets`
+- **THEN** the app presents a bounded reusable context assets foundation for
+  rules, memory, skills, and commands
+- **AND** it does not present full editing, complete cross-agent normalization,
+  cloud sync, or runtime restore as implemented behavior
+
+#### Scenario: Analysis foundation is bounded
+- **WHEN** the user navigates to `Analysis`
+- **THEN** the app presents a bounded interpretation and routing foundation for
+  context health, findings, selected finding detail, and recommended outbound
+  actions
+- **AND** it does not present complete automated analysis, fake findings,
+  automatic remediation, or workflow execution as implemented behavior
+
+#### Scenario: Backup Migration placeholder is bounded
+- **WHEN** the user navigates to `Backup / Migration` before full workflow
+  behavior is implemented
+- **THEN** the app communicates the intended workflow role without replacing the
+  existing working session backup action

--- a/openspec/changes/archive/2026-04-13-analysis-foundation/tasks.md
+++ b/openspec/changes/archive/2026-04-13-analysis-foundation/tasks.md
@@ -1,0 +1,32 @@
+## 1. Analysis Model
+
+- [x] 1.1 Define bounded analysis finding, handoff, filter, summary, and route target types.
+- [x] 1.2 Add deterministic local seed findings covering normal, selected, issue-heavy, routed-in, empty, and stale handoff states.
+- [x] 1.3 Add helper functions for normalization, filtering, summary derivation, selected finding resolution, and handoff-to-filter mapping.
+
+## 2. Analysis Surface
+
+- [x] 2.1 Replace the Analysis placeholder with a bounded Analysis foundation component.
+- [x] 2.2 Render the Analysis header, context health summary, findings inventory, selected finding detail, and recommended actions.
+- [x] 2.3 Render explicit empty, loading, normal, selected, issue-heavy, routed-in, and stale handoff states.
+- [x] 2.4 Keep placeholder/bounded copy clear so the surface does not imply complete automated analysis.
+
+## 3. Routed Handoff
+
+- [x] 3.1 Add shell-level handoff builders for `Assets -> Analysis`, `Project Overview -> Analysis`, and `Sessions -> Analysis`.
+- [x] 3.2 Wire Analysis outbound routes to `Sessions`, `Assets`, and `Backup / Migration` without executing destination workflows inline.
+- [x] 3.3 Preserve compact origin, issue, continue-task, and preservation warning cues according to existing cue lifecycle rules.
+- [x] 3.4 Ensure normal top-level navigation clears stale Analysis handoff context.
+
+## 4. Tests and QA
+
+- [x] 4.1 Add unit tests for analysis finding normalization, filters, summaries, and selected finding resolution.
+- [x] 4.2 Add component tests for normal, empty, selected, issue-heavy, routed-in, and stale handoff Analysis states.
+- [x] 4.3 Add shell tests for route builders and cross-page navigation from Analysis to destination surfaces.
+- [x] 4.4 Prepare an external QA prompt covering Analysis foundation smoke flows and routed handoff flows.
+
+## 5. Documentation and Validation
+
+- [x] 5.1 Update README and CHANGELOG when implementation ships.
+- [x] 5.2 Run targeted tests for analysis helpers, Analysis component, and project shell routing.
+- [x] 5.3 Run `pnpm test`, `pnpm build`, and `openspec validate analysis-foundation --strict`.

--- a/openspec/specs/analysis-foundation/spec.md
+++ b/openspec/specs/analysis-foundation/spec.md
@@ -1,0 +1,117 @@
+## Purpose
+
+Define the accepted bounded behavior for the Analysis surface as a local-first
+interpretation-and-routing page inside the project shell.
+
+## Requirements
+
+### Requirement: Analysis finding model
+The system SHALL represent bounded local analysis findings with explicit issue
+class, severity, affected object references, evidence references, status, and
+route targets.
+
+#### Scenario: Finding exposes issue classification
+- **WHEN** the system renders an analysis finding
+- **THEN** it identifies the finding issue class
+- **AND** it identifies the finding severity
+- **AND** it identifies the affected object type when known
+- **AND** it shows unknown or unavailable fields explicitly rather than
+  inferring complete analysis coverage
+
+#### Scenario: Finding keeps evidence separate from action
+- **WHEN** a finding references session or asset evidence
+- **THEN** the system exposes the evidence reference as provenance for the
+  finding
+- **AND** it exposes corrective routes separately from evidence references
+
+### Requirement: Analysis page backbone
+The system SHALL provide an Analysis surface that orients users around context
+health, findings, selected finding detail, and recommended outbound actions.
+
+#### Scenario: Analysis page renders fixed backbone
+- **WHEN** the user opens `Analysis`
+- **THEN** the page shows an Analysis header
+- **AND** the page shows a context health summary
+- **AND** the page shows a findings inventory
+
+#### Scenario: Selected finding explains the problem
+- **WHEN** the user selects a finding
+- **THEN** the page shows the selected finding title
+- **AND** it explains why the finding matters
+- **AND** it shows affected object and evidence context when available
+- **AND** it keeps the finding tied to the current findings inventory context
+
+### Requirement: Analysis surface states
+The system SHALL support bounded empty, loading, normal, selected, issue-heavy,
+and routed-in states for the Analysis surface.
+
+#### Scenario: Empty state avoids fake findings
+- **WHEN** no findings match the active issue class or filter context
+- **THEN** the page keeps the active context visible
+- **AND** it shows a zero-state explanation rather than fake finding rows
+- **AND** it offers bounded next actions such as changing filters or inspecting
+  sessions and assets
+
+#### Scenario: Issue-heavy state prioritizes explanation
+- **WHEN** the active findings include high-severity or preservation-sensitive
+  issues
+- **THEN** the page emphasizes the affected issue class
+- **AND** it prioritizes selected finding detail and recommended outbound routes
+- **AND** it does not become a backup or migration workflow surface
+
+### Requirement: Routed handoff into Analysis
+The system SHALL consume routed handoff context into the Analysis surface through
+issue class filters, selected findings when available, and bounded continuity
+cues.
+
+#### Scenario: Assets handoff preserves affected object context
+- **WHEN** the user enters `Analysis` from `Assets` for an affected asset or
+  asset class
+- **THEN** the Analysis page applies the relevant issue class or object filter
+- **AND** it selects a matching finding when available
+- **AND** it shows a compact origin cue referencing the asset context
+- **AND** it does not embed the full asset inventory or detail panel
+
+#### Scenario: Overview handoff preserves issue framing
+- **WHEN** the user enters `Analysis` from `Project Overview` with an issue
+  class or attention item
+- **THEN** the Analysis page applies the relevant issue filter
+- **AND** it shows a compact origin cue referencing the overview context
+- **AND** it does not carry full project-summary state
+
+#### Scenario: Session handoff preserves evidence context
+- **WHEN** the user enters `Analysis` from `Sessions` with a failure or
+  evidence reference
+- **THEN** the Analysis page applies the relevant issue or evidence filter
+- **AND** it shows a compact origin cue referencing the source session
+- **AND** it does not carry the full transcript, trajectory state, or
+  session-local reading mode
+
+#### Scenario: Stale handoff degrades safely
+- **WHEN** routed handoff context references a missing finding or stale source
+- **THEN** the Analysis page keeps any still-valid issue class or object filter
+- **AND** it explains that the original finding could not be selected
+
+### Requirement: Bounded analysis actions
+The system SHALL expose only bounded outbound actions from Analysis and route
+corrective work to the owning page.
+
+#### Scenario: Finding action routes to owning surface
+- **WHEN** a selected finding has a recommended route to sessions, assets,
+  backup, or migration
+- **THEN** the Analysis page presents the action as a contextual route
+- **AND** the destination page owns the evidence review, object review, or
+  workflow execution
+
+#### Scenario: Preservation warning stays explicit
+- **WHEN** a recommended action could affect backup, migration, archive, or
+  destructive cleanup semantics
+- **THEN** the Analysis page shows a preservation warning
+- **AND** it routes the user to `Backup / Migration` rather than executing the
+  workflow inside Analysis
+
+#### Scenario: Analysis does not become remediation engine
+- **WHEN** the user inspects a finding
+- **THEN** the Analysis page does not present automatic fixes, full asset
+  editing, session mutation, or backup execution as implemented foundation
+  behavior

--- a/openspec/specs/project-shell/spec.md
+++ b/openspec/specs/project-shell/spec.md
@@ -104,11 +104,13 @@ claiming unimplemented full behavior.
 - **AND** it does not present full editing, complete cross-agent normalization,
   cloud sync, or runtime restore as implemented behavior
 
-#### Scenario: Analysis placeholder is bounded
-- **WHEN** the user navigates to `Analysis` before full findings behavior is
-  implemented
-- **THEN** the app communicates the intended interpretation and routing role
-  without presenting fake findings or corrective workflow behavior
+#### Scenario: Analysis foundation is bounded
+- **WHEN** the user navigates to `Analysis`
+- **THEN** the app presents a bounded interpretation and routing foundation for
+  context health, findings, selected finding detail, and recommended outbound
+  actions
+- **AND** it does not present complete automated analysis, fake findings,
+  automatic remediation, or workflow execution as implemented behavior
 
 #### Scenario: Backup Migration placeholder is bounded
 - **WHEN** the user navigates to `Backup / Migration` before full workflow


### PR DESCRIPTION
## Summary

- sync `analysis-foundation` into main OpenSpec specs
- update `project-shell` to reflect the shipped Analysis foundation behavior
- archive the completed `analysis-foundation` change under `openspec/changes/archive/2026-04-13-analysis-foundation`

## Validation

- `OPENSPEC_TELEMETRY=0 openspec validate analysis-foundation --strict`
- `OPENSPEC_TELEMETRY=0 openspec validate project-shell --strict`
