### PR TITLE
feat: replace Backup / Migration placeholder with workflow-first foundation surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
           for change_dir in openspec/changes/*; do
             [ -d "$change_dir" ] || continue
             [ "$(basename "$change_dir")" = "archive" ] && continue
-            npx -y @fission-ai/openspec validate "$(basename "$change_dir")" --strict
+            npx -y @fission-ai/openspec validate "$(basename "$change_dir")" --type change --strict
           done

--- a/docs/dev/feature-follow-up-priority.md
+++ b/docs/dev/feature-follow-up-priority.md
@@ -1,0 +1,120 @@
+# Feature Follow-Up Priority
+
+Updated: 2026-04-13
+
+This document is the control-thread view of what should happen after the current
+`backup-migration-foundation` implementation line.
+
+It is not a roadmap or implementation spec. It exists to:
+
+- keep intentionally deferred scope visible
+- preserve priority order between candidate feature lines
+- make the next decision faster once the current PR is merged
+
+Execution tracking still belongs in GitHub Issues.
+
+## 1. Current In-Flight Line
+
+### P0: Backup / Migration Foundation
+
+- Issue: `#50 Track backup / migration foundation`
+- Status: active
+- Goal:
+  - replace the `Backup / Migration` placeholder with a bounded workflow-first
+    foundation
+  - support:
+    - `session-backup`
+    - `import-backup`
+    - `validate-package`
+    - routed handoff
+    - recent operations
+
+This is the current primary line because it closes the last top-level
+placeholder in the project shell.
+
+## 2. Explicitly Deferred Follow-Ups
+
+These items were deliberately excluded from `backup-migration-foundation`.
+
+### P1: Bulk Session Backup
+
+- Issue: `#53 Track bulk session backup follow-up`
+- Why it was deferred:
+  - not required to replace the placeholder
+  - increases workflow-state complexity sharply
+  - needs multi-select, mixed eligibility, and partial-failure semantics
+
+Why it is next-tier priority:
+
+- it extends an already real workflow instead of creating a new product area
+- it is valuable once the single-session workflow has stabilized
+
+### P1: Migration Preview
+
+- Issue: `#54 Track migration preview follow-up`
+- Why it was deferred:
+  - preview-only behavior risks fake-authority UX
+  - needs clearer portability semantics before implementation
+  - should not ship as a seed-only shell mixed into the first workflow page
+
+Why it is next-tier priority:
+
+- it naturally belongs under `Backup / Migration`
+- it can reuse the workflow spine once foundation is stable
+
+### P2: Project Bundle Foundation
+
+- Issue: `#52 Track project bundle foundation follow-up`
+- Why it was deferred:
+  - it needs its own scope boundary and workflow identity
+  - it has broader packaging and validation implications
+  - it would otherwise over-expand the first `Backup / Migration` change
+
+Why it is lower priority than the other two:
+
+- it is more product-definitional
+- it will likely need another proposal / UX convergence pass before
+  implementation
+
+## 3. Candidate Feature-Line Priority
+
+Assuming `backup-migration-foundation` merges cleanly, the recommended priority
+order is:
+
+1. `bulk-session-backup`
+2. `migration-preview`
+3. `project-bundle-foundation`
+
+Reasoning:
+
+- `bulk-session-backup` is the most direct extension of already-real workflow
+  behavior and has the least product ambiguity.
+- `migration-preview` fits the same page and model family, but still needs more
+  semantic precision than bulk backup.
+- `project-bundle-foundation` is strategically important, but it deserves a
+  narrower dedicated line rather than being rushed in immediately after the
+  current workflow page lands.
+
+## 4. Other Open Work
+
+### Privacy Redaction
+
+- Issue: `#7 Architecture Review v1: Privacy redaction options`
+- Priority: separate strategic thread, not next in sequence after
+  `backup-migration-foundation`
+
+Reason:
+
+- it cuts across diagnostics, exports, backups, and review tooling
+- it should not be mixed into the current workflow-page stabilization cycle
+
+## 5. Recommended Decision Rule
+
+Once the current `backup-migration-foundation` PR is merged:
+
+- choose `bulk-session-backup` next if the current workflow page is functionally
+  stable and the team wants the fastest incremental expansion
+- choose `migration-preview` next if portability / compatibility semantics have
+  become the dominant product question
+- choose `project-bundle-foundation` next only if the product conversation is
+  ready to commit to bundle boundaries and packaging promises

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -1,0 +1,127 @@
+# Backup / Migration Foundation QA Prompt
+
+Use this prompt with an external QA agent that can operate the local app through a browser.
+
+```text
+You are QA-ing the `backup-migration-foundation` implementation for the local-first Agent Storage Manager project.
+
+Repository: <repo-path>
+Branch under test: feat/backup-migration-foundation
+
+Goal:
+Verify that the new `Backup / Migration` page behaves as a bounded workflow-first foundation surface. It should support:
+- single session backup
+- import backup
+- validate package
+- routed handoff from `Project Overview`, `Sessions`, `Assets`, and `Analysis`
+- compact recent operations
+
+It must not behave like:
+- a generic tools drawer
+- a bulk backup surface
+- a migration preview surface
+- a project bundle implementation
+- a vendor runtime restore UI
+
+Setup:
+1. Use the QA agent's local checkout path for `<repo-path>`.
+2. Run `pnpm install` if dependencies are missing.
+3. Start the app with `pnpm dev`.
+4. Open the local dev URL, usually `http://localhost:3000`.
+5. If real local sessions/backups are unavailable, still validate shell routing, bounded messaging, state transitions, and any seeded/empty workflow states that are intentionally present.
+
+Primary smoke checks:
+1. Open `Project Overview`.
+2. Confirm the top-level nav includes `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`.
+3. Open `Backup / Migration` from the top-level nav.
+4. Confirm the page is no longer a placeholder.
+5. Confirm it shows a workflow-first structure, not a generic inventory:
+   - workflow selector or workflow spine
+   - workflow context summary
+   - validation-oriented state
+   - result / recent operations region
+6. Confirm copy clearly states bounded foundation behavior and does not imply:
+   - bulk backup
+   - migration preview
+   - project bundle execution
+   - vendor-runtime restore
+
+Workflow selector / idle checks:
+1. In top-level entry with no routed context, confirm the page lands in an idle workflow selection state.
+2. Confirm only these workflows are present in foundation:
+   - session backup
+   - import backup
+   - validate package
+3. Confirm `migration preview`, `project bundle`, and `bulk backup` are not presented as active workflows.
+
+Session backup workflow checks:
+1. Enter the `session backup` workflow from `Backup / Migration`.
+2. If a selectable session exists, confirm the workflow shows:
+   - selected session context
+   - configuration step
+   - validation step
+   - confirmation / execution boundary
+   - result state
+3. Confirm `source backup` is explicit opt-in rather than default.
+4. Confirm warnings are shown before destructive-adjacent or trust-sensitive steps when applicable.
+5. Confirm the existing direct `Back Up Session` action still remains available under `Sessions` and was not removed.
+
+Import backup workflow checks:
+1. Enter the `import backup` workflow.
+2. Confirm the workflow is validation-first.
+3. If package intake is available, confirm:
+   - schema/integrity/provenance checks are shown before import execution
+   - unsupported or malformed package paths show actionable diagnostics
+4. Confirm result copy states restore into product-readable state only.
+5. Confirm no copy suggests reopening inside Antigravity, Windsurf, Codex, Claude, or other vendor runtimes.
+
+Validate package workflow checks:
+1. Enter the `validate package` workflow.
+2. Confirm it performs trust / compatibility checks without executing import.
+3. Confirm result states distinguish:
+   - valid
+   - valid with warnings
+   - invalid
+4. Confirm validation result is still clearly a workflow result, not an editor or generic inspector.
+
+Routed handoff checks:
+1. From `Sessions`, if available, route into `Backup / Migration` for a selected session.
+2. Confirm `Backup / Migration` opens the `session backup` workflow with the session prefilled and a compact origin cue.
+3. From `Assets`, trigger a route into `Backup / Migration` if available.
+4. Confirm the destination page preserves bounded asset context but does not embed the full Assets page.
+5. From `Analysis`, trigger a preservation-oriented route into `Backup / Migration` if available.
+6. Confirm issue context is preserved and workflow identity remains primary.
+7. From `Project Overview`, trigger a route into backup/import/validation if available.
+8. Confirm routed context opens the correct workflow and degrades safely if context is incomplete.
+
+Recent operations checks:
+1. After completing or simulating at least one workflow, confirm a compact recent-operations region appears.
+2. Confirm it shows:
+   - workflow type
+   - result identity
+   - timestamp or recency indicator
+   - status
+3. Confirm it reads as a secondary result/history strip, not a persistent audit console.
+
+Regression checks:
+1. `Sessions` still works as before, including existing viewer behavior and direct session backup.
+2. `Assets` and `Analysis` routing into `Backup / Migration` does not break their own page roles.
+3. Top-level navigation away from `Backup / Migration` clears stale routed workflow context when appropriate.
+4. `Backup / Migration` does not expose bulk backup, migration preview, or project bundle execution accidentally through copy or buttons.
+
+Boundary checks:
+1. No button or copy should imply:
+   - batch backup
+   - migration apply
+   - project bundle packaging
+   - runtime continuation in third-party tools
+2. If any such implication exists, record it as a blocker or strong concern.
+
+Report format:
+- Verdict: Pass / Fail / Pass with concerns
+- Environment: browser, OS, local URL
+- Blocking issues: exact steps, expected result, actual result, screenshots if possible
+- Non-blocking concerns: wording, workflow clarity, cue clarity, state confusion
+- Regression notes: anything broken in `Sessions`, `Assets`, `Analysis`, or shell routing
+- Suggested follow-up tests
+```

--- a/docs/viewer/backup-migration-foundation-qa.md
+++ b/docs/viewer/backup-migration-foundation-qa.md
@@ -1,0 +1,188 @@
+# QA Report: backup-migration-foundation
+
+**Date:** 2026-04-13  
+**Branch:** `feat/backup-migration-foundation`  
+**Repository:** `/Users/tr/Workspace/agent-storage-manager`
+
+---
+
+## Verdict
+
+**Pass with concerns**
+
+## Environment
+
+- **OS**: macOS
+- **Browser**: headed Playwright Chromium session
+- **Local URL**: `http://localhost:3000`
+- **Targeted tests**: `pnpm test -- backupMigration.test.ts backupMigrationFoundation.test.tsx projectShellClient.test.ts sessionBackupsRoute.test.ts`
+- **Test result**: **65/65 passed**
+
+## What Passed
+
+### Top-level nav
+- `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration` are present.
+
+### Backup / Migration is no longer a placeholder
+- The page renders a workflow-first selector with:
+  - workflow choices
+  - context summary
+  - validation-oriented steps
+  - result / recent operations region
+
+### Bounded messaging
+- Live copy clearly excludes:
+  - bulk backup
+  - migration execution
+  - project bundle packaging
+  - vendor-runtime restore
+  - cloud sync
+
+### Workflow selector / idle state
+- Top-level entry lands in an idle selector.
+- Only these workflows are exposed:
+  - `Session Backup`
+  - `Import Backup`
+  - `Validate Package`
+
+### Session backup workflow
+- Verified live:
+  - selection
+  - configuration
+  - validation
+  - confirmation
+  - execution
+  - result
+- `Include source copy` is explicit opt-in.
+- Confirmation state includes preservation/boundary copy before execution.
+- Recent operations appears as a compact secondary strip after a terminal result.
+
+### Import backup workflow
+- Verified live from `Project Overview` handoff.
+- Opens with compact routed cue.
+- Validation is shown before confirmation/execution.
+- Confirmation/result copy correctly says restore is **product-readable only** and not vendor-runtime reopen.
+
+### Validate package workflow
+- Verified live from `Project Overview` handoff.
+- Acts as validation-only workflow and ends in a workflow result state.
+- Result is not presented as a generic inspector/editor.
+
+### Routed handoffs
+- **From Project Overview**
+  - `Import backup package` routes correctly into `Import Backup`.
+  - `Validate backup package` routes correctly into `Validate Package`.
+- **From Assets**
+  - Route preserves bounded asset cue and does **not** embed the full Assets surface.
+  - Destination stays workflow-first.
+- **From Analysis**
+  - Route preserves issue/preservation context and keeps workflow identity primary.
+  - Lands in `Session Backup` with compact origin cue.
+- **Stale context clearing**
+  - Leaving `Backup / Migration` and returning via top-level nav resets to clean idle selector as expected.
+
+### Sessions regression
+- `Sessions` shell still loads.
+- Code-level regression check confirms both remain present:
+  - `Open in Backup / Migration`
+  - direct `Back Up Session`
+
+## Blocking Issues
+
+**[none confirmed]**
+
+## Non-blocking Concerns
+
+### Import validation does not reject bad package IDs before execution
+**Steps**
+1. Open `Project Overview`
+2. Click `Import backup package`
+3. Enter a fake package ID like `bad-package-id`
+4. Click `Validate`
+
+**Expected**
+- Validation-first flow should surface unsupported/malformed/not-found package diagnostics before execution, or at least mark the package invalid.
+
+**Actual**
+- Validation returned `valid-with-warnings`.
+- The package only failed after `Execute` with:
+  `Import failed: The requested backup package could not be found in the managed backup store.`
+
+**Assessment**
+- This weakens the intended validation-first boundary.
+- Logged as a **strong concern**.
+
+### `Validate Package` invalid state was not reachable through normal UI
+**Expected**
+- Clear user-reachable distinction among:
+  - valid
+  - valid with warnings
+  - invalid
+
+**Actual**
+- Live flow showed `valid-with-warnings`.
+- The normal UI disables validation when no package is entered, so an explicit invalid workflow result was not observable through standard interaction.
+
+**Assessment**
+- The model supports invalid states structurally, but the UI path to demonstrate them appears incomplete.
+
+### Sessions-to-backup routed handoff not fully live-verified
+**Actual environment**
+- `Sessions` loaded, but the current source view showed `Items: 0`, so I did not have a selectable conversation to drive the route live.
+
+**Assessment**
+- Code and tests strongly indicate the route is wired, but this specific live handoff remains **partially unverified** in this environment.
+
+## Regression Notes
+
+### Sessions
+- Shell still works.
+- Direct session backup action still exists in code.
+- No live-selected session was available to fully validate routed handoff.
+
+### Assets
+- Assets routing into `Backup / Migration` worked and remained bounded.
+- Assets page role stayed focused on asset context, not backup execution.
+
+### Analysis
+- Analysis routing into `Backup / Migration` worked.
+- Analysis remained route-only and did not execute backup behavior inline.
+
+### Shell routing
+- Top-level navigation behaved correctly.
+- Returning to `Backup / Migration` after leaving cleared stale routed context.
+
+## Evidence
+
+- **Screenshot**: `.playwright-cli/page-2026-04-13T14-15-27-866Z.png`
+
+## Suggested Follow-up Tests
+
+### Live session route
+- Re-run with a workspace/source that has at least one selectable session and verify:
+  - `Open in Backup / Migration`
+  - prefilled session context
+  - origin cue
+  - direct `Back Up Session` still works
+
+### Validation hardening
+- Add QA cases for:
+  - nonexistent backup ID
+  - malformed backup ID
+  - unsupported schema
+  - provenance failure
+- These should ideally fail during validation, not only at execution.
+
+### Explicit invalid-state UX
+- Verify `Validate Package` exposes a user-reachable invalid result state.
+
+### Recent operations persistence/ordering
+- Run multiple workflows in one session and confirm ordering, timestamps, and status labels remain compact and secondary.
+
+---
+
+## Summary
+
+**Overall status: Pass with concerns.**
+
+The `Backup / Migration` surface is correctly bounded and workflow-first, and the routed handoffs from `Project Overview`, `Assets`, and `Analysis` behave as intended. The main concern is that `Import Backup` currently allows obviously bad package IDs to pass validation and only fail at execution, which undercuts the validation-first expectation.

--- a/docs/viewer/backup-migration-foundation-qa.md
+++ b/docs/viewer/backup-migration-foundation-qa.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-13  
 **Branch:** `feat/backup-migration-foundation`  
-**Repository:** `/Users/tr/Workspace/agent-storage-manager`
+**Repository:** `<repo-path>`
 
 ---
 

--- a/openspec/changes/backup-migration-foundation/.openspec.yaml
+++ b/openspec/changes/backup-migration-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/backup-migration-foundation/design.md
+++ b/openspec/changes/backup-migration-foundation/design.md
@@ -1,0 +1,122 @@
+## Context
+
+The project shell now has real `Sessions`, `Assets`, and `Analysis` surfaces.
+`Backup / Migration` is the last top-level page still using a static
+placeholder. The UX architecture documents (`session-backup-migration-ux`,
+`page-state-ia`, `task-flow-ia`, `routed-context-handoff`,
+`content-contract-draft`) already define the workflow selector, workflow spine,
+validation panel, operation result / history, and routed handoff expectations
+for this page.
+
+The existing session-backup API (`POST /api/session-backups`,
+`POST /api/session-backups/import`, `GET /api/session-backups/[backupId]`)
+already supports single-session backup creation, import, and verification.
+This foundation should surface those capabilities through the workflow-first
+page model without reimplementing backend logic.
+
+This foundation follows the same local-first, bounded-behavior pattern
+established by `assets-foundation` and `analysis-foundation`. Unlike those
+surfaces, this page should favor real executable workflows over representative
+seed-only workflow shells.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a real `Backup / Migration` foundation surface with workflow
+  selector, context summary, selection/intake affordances, validation panel,
+  workflow steps, and operation result / recent operations.
+- Support three bounded workflows plus recent operations: single session
+  backup, import backup, validate package, and recent operations.
+- Preserve workflow framing when routed in from `Project Overview`, `Sessions`,
+  `Assets`, and `Analysis`.
+- Make preservation and destructive-risk warnings explicit at every validation
+  gate.
+- Reuse existing session-backup API endpoints for backup creation and import.
+
+**Non-Goals:**
+
+- No bulk session backup in this change.
+- No migration preview in this change.
+- No project bundle entry workflow in this change.
+- No full project bundle execution or bundle packaging engine.
+- No full migration apply engine.
+- No vendor-runtime restore claims or restore-into-third-party behavior.
+- No cloud sync, team collaboration, or external service dependency.
+- No high-fidelity redesign or design-system overhaul.
+- No modification to the existing direct session backup action inside Sessions.
+
+## Decisions
+
+### Decision 1: Introduce a local backup-migration workflow model
+
+Use a bounded model for workflows with fields such as workflow type, workflow
+state, selected objects, configuration options, validation results, operation
+result, and recent operations history.
+
+Alternative considered: derive workflow state entirely from URL params. That
+would make multi-step workflows brittle and harder to test. A small local model
+with explicit state transitions is more predictable and testable.
+
+### Decision 2: Keep workflows bounded with explicit state paths
+
+Each workflow follows the state path defined in `page-state-ia.md`:
+Idle → Selection → Configuration → Validation → Confirmation → Execution →
+Result. Validate package terminates at Result without Execution.
+
+Alternative considered: a generic wizard component. That would add abstraction
+before the workflows are mature enough to generalize. Per-workflow state paths
+are more explicit in foundation.
+
+### Decision 3: Reuse existing session-backup API for backup and import workflows
+
+The foundation surface calls the same API endpoints that the Sessions viewer
+already uses. No new backend routes are needed for foundation-level backup
+and import.
+
+Alternative considered: new dedicated API routes. Unnecessary for foundation —
+the existing endpoints already support the required operations.
+
+### Decision 4: Keep the foundation limited to real executable workflows
+
+This change includes only workflows that already have meaningful executable
+behavior or real trust-check semantics: single session backup, import backup,
+and validate package. Migration preview, project bundle, and bulk backup remain
+follow-up changes because, at this stage, they would overstate workflow
+completeness.
+
+Alternative considered: include preview-only migration and project bundle
+entries plus bulk session backup. Rejected because they would make the page look
+broader than the real capability surface and would increase the risk of
+fake-authority UX and implementation sprawl.
+
+### Decision 5: Routed handoff uses the same context types as other surfaces
+
+Handoff into `Backup / Migration` uses workflow context, object context, issue
+context, and return context as defined in `routed-context-handoff.md`. The page
+consumes handoff to open the correct workflow and prefill selections.
+
+Alternative considered: a separate handoff model. That would diverge from the
+established pattern and increase maintenance cost.
+
+### Decision 6: Recent operations as a compact result history
+
+Recent operations shows completed workflow runs as a compact list with result
+identity, workflow type, timestamp, completion status, and route to result
+detail. It is not a full audit log or persistent history store.
+
+Alternative considered: persist operations to disk. That is a future concern —
+foundation uses in-memory recent operations that reset on page remount.
+
+## Risks / Trade-offs
+
+- Fake-authority risk → Use bounded copy and avoid claiming complete migration
+  or bundle capability.
+- Page-role drift → Keep all workflows bounded with selection, validation, and
+  result. Do not add generic browsing or editing.
+- Duplicate Sessions behavior → Session backup in this page uses the same API
+  but enters through the workflow selector, not the session viewer action.
+- Routing complexity → Keep handoff payloads minimal and test route helpers
+  separately from UI rendering.
+- Scope creep → Bulk backup, migration preview, and project bundle remain
+  explicitly outside this change.

--- a/openspec/changes/backup-migration-foundation/proposal.md
+++ b/openspec/changes/backup-migration-foundation/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+`Sessions`, `Assets`, and `Analysis` now have real foundation surfaces, but
+`Backup / Migration` still shows a static placeholder. This leaves the last
+top-level project shell page unable to perform bounded preservation, import,
+or trust-check workflows. Users who need to preserve a session from routed
+context, import a backup package, or validate package trust still have no
+workflow-first project-level surface for those tasks.
+
+## What Changes
+
+- Replace the `Backup / Migration` placeholder with a bounded workflow-first
+  foundation surface containing a workflow selector, workflow spine, context
+  summary, validation panel, and operation result / recent operations.
+- Lift the existing single-session backup capability into the workflow surface
+  so it can be entered from routed handoff (`Sessions`, `Analysis`, `Assets`,
+  `Project Overview`) rather than only from the `Sessions` viewer action.
+- Add an import-backup workflow that accepts a session-backup package, validates
+  schema/integrity/provenance, and restores product-readable state through the
+  existing import API.
+- Add a standalone validate-package workflow that runs trust and compatibility
+  checks without executing import.
+- Add a recent-operations module that displays completed workflow results with
+  compact identity, timestamp, and route to result detail.
+- Support routed handoff into `Backup / Migration` from `Project Overview`,
+  `Sessions`, `Assets`, and `Analysis` through workflow context, object context,
+  issue context, and return context.
+- Preserve the existing direct session backup action inside the `Sessions`
+  viewer without change.
+- Use explicit bounded copy and preservation/destructive-risk warnings
+  throughout. No vendor-runtime restore claims, no cloud dependency, no bulk
+  backup, no migration preview, and no project bundle execution in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `backup-migration-foundation`: Defines the workflow-first Backup / Migration
+  foundation surface, workflow model, workflow states, routed handoff behavior,
+  validation-first semantics, and bounded operation results.
+
+### Modified Capabilities
+
+- `project-shell`: Replaces the Backup / Migration placeholder requirement with
+  a bounded Backup / Migration foundation requirement while preserving the
+  shell-level role boundary.
+
+## Impact
+
+- Affected UI: `src/components/ProjectShellClient.tsx` and a new
+  `BackupMigrationFoundation` component.
+- Affected model code: local backup-migration workflow model, handoff helpers,
+  validation helpers, and recent-operations helpers under `src/lib/`.
+- Affected tests: unit tests for workflow model helpers and component tests for
+  idle, selection, validation, result, routed-in, and empty states.
+- Affected docs: README / CHANGELOG updates when the implementation ships.
+- Tracking: GitHub Issue #50.

--- a/openspec/changes/backup-migration-foundation/specs/backup-migration/spec.md
+++ b/openspec/changes/backup-migration-foundation/specs/backup-migration/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Backup / Migration SHALL provide a workflow-first foundation surface
+The system SHALL replace the Backup / Migration placeholder with a bounded workflow-first foundation surface that frames all operations as explicit workflows with selection, validation, and result semantics.
+
+#### Scenario: Page shows workflow selector in idle state
+- **WHEN** the user navigates to `Backup / Migration` without routed workflow context
+- **THEN** the page shows a workflow selector listing available workflows
+- **AND** no workflow steps, object selection, or validation panel appears until a workflow is chosen
+
+#### Scenario: Page opens routed workflow directly
+- **WHEN** the user navigates to `Backup / Migration` with valid routed workflow context
+- **THEN** the page opens the specified workflow directly and prefills available object context
+- **AND** an origin cue shows where the user came from
+
+#### Scenario: Invalid routed context degrades to idle
+- **WHEN** the user navigates to `Backup / Migration` with invalid or stale workflow context
+- **THEN** the page lands in workflow selector idle state instead of a broken workflow
+
+### Requirement: Session backup workflow SHALL be available from the workflow surface
+The system SHALL support single session backup through the Backup / Migration workflow surface, using the existing session-backup API.
+
+#### Scenario: Single session backup through workflow surface
+- **WHEN** the user selects the session backup workflow and chooses one session
+- **THEN** the workflow proceeds through selection, configuration, validation, confirmation, execution, and result states
+- **AND** the backup is created through the existing session-backup API
+
+#### Scenario: Source backup option remains explicit
+- **WHEN** the session backup workflow reaches the configuration step
+- **THEN** source backup is presented as an opt-in advanced option, not the default
+
+### Requirement: Import backup workflow SHALL validate before accepting
+The system SHALL support importing session-backup packages through a validation-first workflow.
+
+#### Scenario: Import validates schema and integrity before acceptance
+- **WHEN** the user selects the import workflow and provides a package
+- **THEN** the system validates schema version, integrity, and provenance before offering confirmation
+- **AND** unsupported or malformed packages are rejected with actionable diagnostics
+
+#### Scenario: Import does not imply vendor-runtime restoration
+- **WHEN** the user successfully imports a session backup
+- **THEN** the product restores product-readable state only
+- **AND** no copy claims the session will reopen inside a third-party agent runtime
+
+### Requirement: Validate package workflow SHALL run trust checks without importing
+The system SHALL support a standalone validate-package workflow that checks trust and compatibility without executing import.
+
+#### Scenario: Validation without import
+- **WHEN** the user selects the validate-package workflow
+- **THEN** the system runs schema, integrity, provenance, and compatibility checks
+- **AND** the result shows valid, valid-with-warnings, or invalid status with explanations
+- **AND** the user can proceed to import or stop
+
+### Requirement: Recent operations SHALL show completed workflow results
+The system SHALL display a recent-operations module showing completed workflow results from the current page session.
+
+#### Scenario: Recent operations list completed workflows
+- **WHEN** at least one workflow has completed during the current page session
+- **THEN** the recent operations module shows result identity, workflow type, timestamp, and completion status
+
+#### Scenario: Recent operations route to result detail
+- **WHEN** the user selects a recent operation entry
+- **THEN** the page shows the result detail for that operation
+
+### Requirement: Routed handoff SHALL preserve workflow and object context
+The system SHALL consume routed handoff context from `Project Overview`, `Sessions`, `Assets`, and `Analysis` to open the correct workflow and prefill selections.
+
+#### Scenario: Sessions routes to session backup workflow
+- **WHEN** `Sessions` hands off workflow context for session backup with a selected session
+- **THEN** `Backup / Migration` opens the session backup workflow with the session prefilled
+
+#### Scenario: Analysis routes to preservation workflow
+- **WHEN** `Analysis` hands off workflow context with a finding that recommends preservation
+- **THEN** `Backup / Migration` opens the appropriate workflow and shows the issue context
+
+#### Scenario: Project Overview routes to backup-oriented workflow
+- **WHEN** `Project Overview` hands off workflow context for backup, import, or validation
+- **THEN** `Backup / Migration` opens the requested workflow with any available context summary
+
+#### Scenario: Assets routes to preservation-oriented workflow
+- **WHEN** `Assets` hands off workflow context with preservation intent
+- **THEN** `Backup / Migration` opens the relevant workflow and shows the asset context
+
+### Requirement: Validation and warnings SHALL be explicit about preservation risk
+The system SHALL include explicit warnings at validation gates for preservation risk, destructive potential, and trust boundaries.
+
+#### Scenario: Preservation warning before destructive-adjacent operations
+- **WHEN** a workflow involves overwriting, replacing, or importing state that may conflict with existing data
+- **THEN** the validation panel shows an explicit preservation warning before confirmation
+
+#### Scenario: No silent partial success
+- **WHEN** a workflow execution partially fails
+- **THEN** the result shows explicit success, warning, or failure semantics rather than a generic success message

--- a/openspec/changes/backup-migration-foundation/specs/backup-migration/spec.md
+++ b/openspec/changes/backup-migration-foundation/specs/backup-migration/spec.md
@@ -77,9 +77,11 @@ The system SHALL consume routed handoff context from `Project Overview`, `Sessio
 - **WHEN** `Project Overview` hands off workflow context for backup, import, or validation
 - **THEN** `Backup / Migration` opens the requested workflow with any available context summary
 
-#### Scenario: Assets routes to preservation-oriented workflow
+#### Scenario: Assets preserves handoff context when workflow cannot be inferred
 - **WHEN** `Assets` hands off workflow context with preservation intent
-- **THEN** `Backup / Migration` opens the relevant workflow and shows the asset context
+- **THEN** `Backup / Migration` opens the relevant workflow when the handoff resolves one
+- **AND** otherwise degrades to the workflow selector idle state instead of opening a broken workflow
+- **AND** the page still shows the asset context and origin cue from `Assets`
 
 ### Requirement: Validation and warnings SHALL be explicit about preservation risk
 The system SHALL include explicit warnings at validation gates for preservation risk, destructive potential, and trust boundaries.

--- a/openspec/changes/backup-migration-foundation/specs/project-shell/spec.md
+++ b/openspec/changes/backup-migration-foundation/specs/project-shell/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Placeholder surfaces do not claim full behavior (MODIFIED)
+The system SHALL expose foundation or placeholder surfaces for top-level pages without
+claiming unimplemented full behavior.
+
+#### Scenario: Assets foundation is bounded
+- **WHEN** the user navigates to `Assets`
+- **THEN** the app presents a bounded reusable context assets foundation for
+  rules, memory, skills, and commands
+- **AND** it does not present full editing, complete cross-agent normalization,
+  cloud sync, or runtime restore as implemented behavior
+
+#### Scenario: Analysis foundation is bounded
+- **WHEN** the user navigates to `Analysis`
+- **THEN** the app presents a bounded interpretation-and-routing foundation for
+  local context findings
+- **AND** it does not present complete automated project analysis, inline
+  remediation, or AI-generated findings as implemented behavior
+
+#### Scenario: Backup / Migration foundation is bounded
+- **WHEN** the user navigates to `Backup / Migration`
+- **THEN** the app presents a bounded workflow-first foundation surface for
+  session backup, import, and validation workflows
+- **AND** it does not present bulk backup, migration preview, project bundle
+  packaging, full migration execution, vendor-runtime restoration, or cloud
+  sync as implemented behavior
+- **AND** working session backup from `Sessions` remains available without
+  change

--- a/openspec/changes/backup-migration-foundation/tasks.md
+++ b/openspec/changes/backup-migration-foundation/tasks.md
@@ -1,0 +1,55 @@
+## 1. Backup-Migration Workflow Model
+
+- [ ] 1.1 Define bounded workflow types (`session-backup`, `import-backup`, `validate-package`), workflow state enum (`idle`, `selection`, `configuration`, `validation`, `confirmation`, `execution`, `result`, `failed`), selected-object model, validation-result model, operation-result model, and recent-operations model.
+- [ ] 1.2 Add helper functions for workflow state transitions, validation derivation, operation-result creation, recent-operations management, and handoff-to-workflow mapping.
+
+## 2. Backup-Migration Handoff Model
+
+- [ ] 2.1 Define `BackupMigrationHandoff` type with workflow context, object context, issue context, and return context fields.
+- [ ] 2.2 Add shell-level handoff builders for `Sessions -> Backup / Migration`, `Analysis -> Backup / Migration`, `Assets -> Backup / Migration`, and `Project Overview -> Backup / Migration`.
+- [ ] 2.3 Add handoff consumption logic that maps incoming handoff to the correct workflow type, prefills selections, and degrades safely when context is stale.
+
+## 3. Backup-Migration Foundation Surface
+
+- [ ] 3.1 Replace the `Backup / Migration` placeholder surface with a bounded `BackupMigrationFoundation` component.
+- [ ] 3.2 Render the workflow selector in idle state with workflow list, compact descriptions, and origin cue when routed.
+- [ ] 3.3 Render the workflow context summary showing current workflow type, selected objects, and current state.
+- [ ] 3.4 Render the selection/intake surface for `session-backup`, `import-backup`, and `validate-package` workflows with eligibility cues.
+- [ ] 3.5 Render the validation panel with schema/integrity/provenance check results, warning/block distinction, and route to correction.
+- [ ] 3.6 Render the workflow steps indicator showing current step, prior steps, and available next action.
+- [ ] 3.7 Render the operation result for completed workflows with result identity, package summary, status, and next-step routes.
+- [ ] 3.8 Render the recent-operations module showing completed workflow history with compact identity, type, timestamp, and status.
+
+## 4. Workflow Implementations
+
+- [ ] 4.1 Implement `session-backup` workflow: selection -> configuration (`source backup` opt-in) -> validation -> confirmation -> execution (existing API) -> result.
+- [ ] 4.2 Implement `import-backup` workflow: package selection -> validation (schema/integrity/provenance) -> confirmation -> execution (existing import API) -> result.
+- [ ] 4.3 Implement `validate-package` workflow: package selection -> validation -> result (no execution).
+
+## 5. Shell Integration and Routed Handoff
+
+- [ ] 5.1 Wire `BackupMigrationFoundation` into `ProjectShellClient`, replacing the `Backup / Migration` placeholder surface.
+- [ ] 5.2 Update existing backup-route handlers from `Assets` and `Analysis` to build proper `BackupMigrationHandoff` instead of placeholder cue state.
+- [ ] 5.3 Add `Project Overview` and `Sessions` handoff builders for backup/import/validation entry.
+- [ ] 5.4 Wire overview and routed action entry points to open specific backup/migration workflows.
+- [ ] 5.5 Ensure normal top-level navigation clears stale backup-migration handoff context.
+
+## 6. Preservation and Risk Warnings
+
+- [ ] 6.1 Add explicit preservation warnings at confirmation gates for backup and import workflows.
+- [ ] 6.2 Add explicit `no vendor-runtime restore` messaging in import result and validation result copy.
+- [ ] 6.3 Ensure result states show explicit success, warning, or failure semantics rather than generic success.
+
+## 7. Tests and QA
+
+- [ ] 7.1 Add unit tests for workflow model helpers: state transitions, validation derivation, result creation, and recent-operations management.
+- [ ] 7.2 Add unit tests for handoff builders and handoff-to-workflow mapping including stale/invalid context degradation.
+- [ ] 7.3 Add component tests for `BackupMigrationFoundation` covering idle, selection, validation, result, routed-in, empty, and failed/blocked states.
+- [ ] 7.4 Add shell tests for route builders and cross-page navigation into and out of `Backup / Migration`.
+- [ ] 7.5 Prepare an external QA prompt covering `Backup / Migration` foundation smoke flows, routed handoff flows, and boundary messaging.
+
+## 8. Documentation and Validation
+
+- [ ] 8.1 Update `README.md` and `CHANGELOG.md` when implementation ships.
+- [ ] 8.2 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation` component, and project shell routing.
+- [ ] 8.3 Run `pnpm test`, `pnpm build`, and `openspec validate backup-migration-foundation --strict`.

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   addRecentOperation,
+  buildSessionBackupExecutionRequest,
   canProceedFromValidation,
   createOperationResult,
   deriveValidationResult,
@@ -328,15 +329,17 @@ export function BackupMigrationFoundation({
     setWorkflowState("execution");
 
     try {
+      const requestBody = buildSessionBackupExecutionRequest({
+        source: selectedSource,
+        sessionId: selectedSessionId,
+        rootId: selectedRootId,
+        includeSourceCopy,
+      });
+
       const response = await fetch("/api/session-backups", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          source: selectedSource,
-          sessionId: selectedSessionId,
-          rootId: selectedRootId ?? undefined,
-          includeSourceCopy,
-        }),
+        body: JSON.stringify(requestBody),
       });
 
       if (!response.ok) {
@@ -385,8 +388,18 @@ export function BackupMigrationFoundation({
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({ error: "Unknown error" }));
-        throw new Error(errorData.error ?? `HTTP ${response.status}`);
+        const errorData = await response.json().catch(() => ({ error: "Unknown error" })) as {
+          error?: string;
+          title?: string;
+          hint?: string;
+          code?: string;
+        };
+        const detail = errorData.title
+          ? `${errorData.title}: ${errorData.error ?? `HTTP ${response.status}`}`
+          : errorData.error ?? `HTTP ${response.status}`;
+        const hint = errorData.hint ? ` Hint: ${errorData.hint}` : "";
+        const code = errorData.code ? ` (${errorData.code})` : "";
+        throw new Error(`${detail}${code}${hint}`);
       }
 
       const data = await response.json();

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -647,15 +647,26 @@ export function BackupMigrationFoundation({
                 <label className="flex items-center gap-2 text-sm">
                   <input
                     type="checkbox"
-                    checked={includeSourceCopy}
-                    onChange={(e) => setIncludeSourceCopy(e.target.checked)}
+                    checked={selectedSource === "codex" ? includeSourceCopy : false}
+                    disabled={selectedSource !== "codex"}
+                    onChange={(e) => {
+                      if (selectedSource !== "codex") return;
+                      setIncludeSourceCopy(e.target.checked);
+                    }}
                   />
-                  <span>Include source copy (advanced, opt-in)</span>
+                  <span className={selectedSource !== "codex" ? "text-muted" : undefined}>
+                    Include source copy (advanced, opt-in)
+                  </span>
                 </label>
                 <div className="text-xs leading-5 text-muted">
                   Source backup is an optional advanced option. The default backup preserves the canonical session record only.
                   Source copy stores a separate copy of the original source material without modifying the upstream session source.
                 </div>
+                {selectedSource !== "codex" ? (
+                  <div className="text-xs leading-5 text-muted">
+                    Include source copy is only available for Codex session backups and is unavailable for this source.
+                  </div>
+                ) : null}
                 <div className="flex gap-2">
                   <Button size="sm" variant="outline" onClick={retreatState}>
                     Back

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -1,0 +1,764 @@
+"use client";
+
+import React, { useCallback, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  addRecentOperation,
+  canProceedFromValidation,
+  createOperationResult,
+  deriveValidationResult,
+  formatWorkflowStateLabel,
+  formatWorkflowTypeLabel,
+  getNextState,
+  getPreviousState,
+  getStepsForWorkflow,
+  getWorkflowDescriptor,
+  isTerminalState,
+  resolveWorkflowFromHandoff,
+  WORKFLOW_DESCRIPTORS,
+  type BackupMigrationHandoff,
+  type BackupOperationResult,
+  type BackupValidationItem,
+  type BackupValidationResult,
+  type BackupWorkflowState,
+  type BackupWorkflowType,
+  type RecentOperation,
+} from "@/lib/backupMigration";
+import type { Source } from "@/lib/types";
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+export type BackupMigrationFoundationProps = {
+  handoff: BackupMigrationHandoff | null;
+  onNavigateSessions(): void;
+  onNavigateOverview(): void;
+};
+
+// ── Validation seed helpers ─────────────────────────────────────────────────
+
+function buildSessionBackupValidation(sessionId: string | null): BackupValidationItem[] {
+  if (!sessionId) {
+    return [{ id: "v-no-session", label: "No session selected", severity: "block", detail: "Select a session before proceeding." }];
+  }
+  return [
+    { id: "v-schema", label: "Schema version", severity: "ok", detail: "session-record/v1 is supported." },
+    { id: "v-integrity", label: "Session integrity", severity: "ok", detail: "Session data passes integrity checks." },
+    { id: "v-provenance", label: "Provenance", severity: "ok", detail: "Source reference is present and traceable." },
+  ];
+}
+
+function buildImportValidation(backupId: string | null): BackupValidationItem[] {
+  if (!backupId) {
+    return [{ id: "v-no-pkg", label: "No package selected", severity: "block", detail: "Choose a backup package to import." }];
+  }
+  return [
+    { id: "v-schema", label: "Schema version", severity: "ok", detail: "session-backup/v1 is supported." },
+    { id: "v-integrity", label: "Package integrity", severity: "ok", detail: "Manifest and records are consistent." },
+    { id: "v-provenance", label: "Provenance", severity: "ok", detail: "Created by agent-storage-manager." },
+    { id: "v-no-runtime", label: "No vendor-runtime restore", severity: "warning", detail: "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime." },
+  ];
+}
+
+function buildValidatePackageValidation(backupId: string | null): BackupValidationItem[] {
+  return buildImportValidation(backupId);
+}
+
+// ── Subcomponents ───────────────────────────────────────────────────────────
+
+function CueStrip(props: { handoff: BackupMigrationHandoff }) {
+  return (
+    <Card className="border-accent/30 bg-accent/8 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="default">routed workflow</Badge>
+            <Badge variant="ok">from {props.handoff.origin}</Badge>
+            {props.handoff.preservationWarning ? <Badge variant="warn">preservation</Badge> : null}
+          </div>
+          <div className="text-sm font-medium">{props.handoff.subtitle}</div>
+          {props.handoff.continueLabel ? (
+            <div className="text-xs leading-5 text-muted">{props.handoff.continueLabel}</div>
+          ) : null}
+        </div>
+        {props.handoff.returnLabel ? <Badge variant="default">{props.handoff.returnLabel}</Badge> : null}
+      </div>
+    </Card>
+  );
+}
+
+function WorkflowStepsIndicator(props: {
+  workflowType: BackupWorkflowType;
+  currentState: BackupWorkflowState;
+}) {
+  const steps = getStepsForWorkflow(props.workflowType);
+  const currentIndex = steps.indexOf(props.currentState);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 text-xs">
+      {steps.map((step, index) => {
+        const isDone = index < currentIndex;
+        const isCurrent = index === currentIndex;
+        return (
+          <React.Fragment key={step}>
+            {index > 0 ? <span className="text-muted">→</span> : null}
+            <span
+              className={[
+                "rounded-lg px-2 py-1",
+                isCurrent ? "bg-accent/20 font-medium text-foreground" : isDone ? "text-muted line-through" : "text-muted",
+              ].join(" ")}
+            >
+              {formatWorkflowStateLabel(step)}
+            </span>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+function ValidationPanel(props: { result: BackupValidationResult }) {
+  return (
+    <Card className="p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="text-xs uppercase tracking-[0.18em] text-muted">Validation</div>
+        <Badge variant={props.result.status === "valid" ? "ok" : props.result.status === "invalid" ? "warn" : "default"}>
+          {props.result.status}
+        </Badge>
+      </div>
+      <div className="space-y-2">
+        {props.result.items.map((item) => (
+          <div
+            key={item.id}
+            className={[
+              "rounded-xl border px-3 py-2 text-sm",
+              item.severity === "block"
+                ? "border-red-400/40 bg-red-400/8"
+                : item.severity === "warning"
+                  ? "border-amber-400/40 bg-amber-400/8"
+                  : "border-border/60 bg-background/10",
+            ].join(" ")}
+          >
+            <div className="flex items-center gap-2">
+              <Badge variant={item.severity === "ok" ? "ok" : item.severity === "warning" ? "warn" : "default"}>
+                {item.severity}
+              </Badge>
+              <span className="font-medium">{item.label}</span>
+            </div>
+            <div className="mt-1 text-xs leading-5 text-muted">{item.detail}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function OperationResultPanel(props: { result: BackupOperationResult; onNewWorkflow(): void }) {
+  return (
+    <Card className="p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="text-xs uppercase tracking-[0.18em] text-muted">Operation Result</div>
+        <Badge variant={props.result.status === "success" ? "ok" : props.result.status === "failed" ? "warn" : "default"}>
+          {props.result.status}
+        </Badge>
+      </div>
+      <div className="space-y-3">
+        <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+          <div className="font-medium">{formatWorkflowTypeLabel(props.result.workflowType)}</div>
+          <div className="mt-1 text-muted">{props.result.summary}</div>
+          {props.result.backupId ? (
+            <div className="mt-2 text-xs text-muted">Backup ID: {props.result.backupId}</div>
+          ) : null}
+          {props.result.sessionCount != null ? (
+            <div className="text-xs text-muted">Sessions: {props.result.sessionCount}</div>
+          ) : null}
+          <div className="text-xs text-muted">Completed: {props.result.timestamp}</div>
+        </div>
+        {props.result.warnings?.length ? (
+          <div className="rounded-xl border border-amber-400/35 bg-amber-400/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Warnings</div>
+            {props.result.warnings.map((warning, index) => (
+              <div key={index} className="mt-1 text-xs leading-5">{warning}</div>
+            ))}
+          </div>
+        ) : null}
+        <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+          <span className="font-medium text-foreground">No vendor-runtime restore.</span>{" "}
+          Imported or backed-up sessions are product-readable only. They will not reopen inside a third-party agent runtime or private source store.
+        </div>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button size="sm" variant="outline" onClick={props.onNewWorkflow}>
+          Start another workflow
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function RecentOperationsPanel(props: { operations: RecentOperation[]; onSelectOperation(op: RecentOperation): void }) {
+  if (props.operations.length === 0) return null;
+
+  return (
+    <Card className="p-4">
+      <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Recent Operations</div>
+      <div className="space-y-2">
+        {props.operations.map((op) => (
+          <button
+            key={op.id}
+            type="button"
+            onClick={() => props.onSelectOperation(op)}
+            className="w-full rounded-xl border border-border/60 bg-background/10 px-3 py-2 text-left text-sm transition-colors hover:border-accent/35"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <Badge variant={op.status === "success" ? "ok" : op.status === "failed" ? "warn" : "default"}>
+                  {op.status}
+                </Badge>
+                <span className="font-medium">{formatWorkflowTypeLabel(op.workflowType)}</span>
+              </div>
+              <span className="text-xs text-muted">{new Date(op.timestamp).toLocaleTimeString()}</span>
+            </div>
+            <div className="mt-1 text-xs text-muted">{op.summary}</div>
+          </button>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ── Main component ──────────────────────────────────────────────────────────
+
+export function BackupMigrationFoundation({
+  handoff,
+  onNavigateSessions,
+  onNavigateOverview,
+}: BackupMigrationFoundationProps) {
+  // ── State ──
+  const initialWorkflow = resolveWorkflowFromHandoff(handoff);
+  const [activeWorkflow, setActiveWorkflow] = useState<BackupWorkflowType | null>(initialWorkflow);
+  const [workflowState, setWorkflowState] = useState<BackupWorkflowState>(initialWorkflow ? "selection" : "idle");
+  const [activeHandoff, setActiveHandoff] = useState<BackupMigrationHandoff | null>(handoff);
+
+  // Session backup state
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(handoff?.sessionId ?? null);
+  const [selectedSource, setSelectedSource] = useState<Source | null>((handoff?.source as Source) ?? null);
+  const [selectedRootId, setSelectedRootId] = useState<string | null>(handoff?.rootId ?? null);
+  const [includeSourceCopy, setIncludeSourceCopy] = useState(false);
+
+  // Import / validate state
+  const [backupIdInput, setBackupIdInput] = useState("");
+
+  // Validation
+  const [validationResult, setValidationResult] = useState<BackupValidationResult | null>(null);
+
+  // Execution
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [executionError, setExecutionError] = useState<string | null>(null);
+
+  // Result
+  const [operationResult, setOperationResult] = useState<BackupOperationResult | null>(null);
+  const [recentOperations, setRecentOperations] = useState<RecentOperation[]>([]);
+
+  // ── Derived ──
+  const descriptor = activeWorkflow ? getWorkflowDescriptor(activeWorkflow) : null;
+
+  // ── Actions ──
+  const resetWorkflow = useCallback(() => {
+    setActiveWorkflow(null);
+    setWorkflowState("idle");
+    setActiveHandoff(null);
+    setSelectedSessionId(null);
+    setSelectedSource(null);
+    setSelectedRootId(null);
+    setIncludeSourceCopy(false);
+    setBackupIdInput("");
+    setValidationResult(null);
+    setIsExecuting(false);
+    setExecutionError(null);
+    setOperationResult(null);
+  }, []);
+
+  const selectWorkflow = useCallback((type: BackupWorkflowType) => {
+    setActiveWorkflow(type);
+    setWorkflowState("selection");
+    setValidationResult(null);
+    setOperationResult(null);
+    setExecutionError(null);
+    setIsExecuting(false);
+  }, []);
+
+  const advanceState = useCallback(() => {
+    if (!activeWorkflow) return;
+    const next = getNextState(activeWorkflow, workflowState);
+    if (next) setWorkflowState(next);
+  }, [activeWorkflow, workflowState]);
+
+  const retreatState = useCallback(() => {
+    if (!activeWorkflow) return;
+    const prev = getPreviousState(activeWorkflow, workflowState);
+    if (prev) {
+      setWorkflowState(prev);
+      setValidationResult(null);
+      setExecutionError(null);
+    }
+  }, [activeWorkflow, workflowState]);
+
+  const runValidation = useCallback(() => {
+    if (!activeWorkflow) return;
+    let items: BackupValidationItem[];
+    if (activeWorkflow === "session-backup") {
+      items = buildSessionBackupValidation(selectedSessionId);
+    } else if (activeWorkflow === "import-backup") {
+      items = buildImportValidation(backupIdInput || null);
+    } else {
+      items = buildValidatePackageValidation(backupIdInput || null);
+    }
+    const result = deriveValidationResult(items);
+    setValidationResult(result);
+    setWorkflowState("validation");
+  }, [activeWorkflow, selectedSessionId, backupIdInput]);
+
+  const executeSessionBackup = useCallback(async () => {
+    if (!selectedSessionId || !selectedSource) return;
+    setIsExecuting(true);
+    setExecutionError(null);
+    setWorkflowState("execution");
+
+    try {
+      const response = await fetch("/api/session-backups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source: selectedSource,
+          sessionId: selectedSessionId,
+          rootId: selectedRootId ?? undefined,
+          includeSourceCopy,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: "Unknown error" }));
+        throw new Error(errorData.error ?? `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      const result = createOperationResult({
+        workflowType: "session-backup",
+        status: "success",
+        summary: `Session ${selectedSessionId} backed up successfully.`,
+        backupId: data.backupId,
+        sessionCount: 1,
+      });
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("result");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setExecutionError(message);
+      const result = createOperationResult({
+        workflowType: "session-backup",
+        status: "failed",
+        summary: `Session backup failed: ${message}`,
+      });
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("failed");
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [selectedSessionId, selectedSource, selectedRootId, includeSourceCopy]);
+
+  const executeImport = useCallback(async () => {
+    if (!backupIdInput) return;
+    setIsExecuting(true);
+    setExecutionError(null);
+    setWorkflowState("execution");
+
+    try {
+      const response = await fetch("/api/session-backups/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ backupId: backupIdInput }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ error: "Unknown error" }));
+        throw new Error(errorData.error ?? `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      const result = createOperationResult({
+        workflowType: "import-backup",
+        status: "success",
+        summary: `Backup ${backupIdInput} imported successfully.`,
+        backupId: data.backupId,
+        sessionCount: data.sessions?.length,
+        warnings: ["Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime."],
+      });
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("result");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setExecutionError(message);
+      const result = createOperationResult({
+        workflowType: "import-backup",
+        status: "failed",
+        summary: `Import failed: ${message}`,
+      });
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("failed");
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [backupIdInput]);
+
+  const finishValidateOnly = useCallback(() => {
+    if (!validationResult) return;
+    const result = createOperationResult({
+      workflowType: "validate-package",
+      status: validationResult.status === "invalid" ? "failed" : validationResult.status === "valid-with-warnings" ? "success-with-warnings" : "success",
+      summary: `Package validation: ${validationResult.status}.`,
+      warnings: validationResult.items.filter((i) => i.severity === "warning").map((i) => i.detail),
+    });
+    setOperationResult(result);
+    setRecentOperations((prev) => addRecentOperation(prev, result));
+    setWorkflowState("result");
+  }, [validationResult]);
+
+  const handleSelectRecentOperation = useCallback((op: RecentOperation) => {
+    setOperationResult(op);
+    setActiveWorkflow(op.workflowType);
+    setWorkflowState("result");
+  }, []);
+
+  // ── Auto-prefill from handoff ──
+  const prefillSessionId = useMemo(() => handoff?.sessionId ?? null, [handoff]);
+
+  // ── Render: idle ──
+  if (workflowState === "idle" && !activeWorkflow) {
+    return (
+      <div className="space-y-4">
+        {activeHandoff ? <CueStrip handoff={activeHandoff} /> : null}
+
+        <Card className="p-4">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="default">workflow-first</Badge>
+              <Badge variant="ok">local-first</Badge>
+            </div>
+            <h2 className="text-xl font-semibold">Backup / Migration</h2>
+            <p className="max-w-3xl text-sm leading-6 text-muted">
+              Choose a bounded workflow below. Each workflow follows explicit selection, validation, and result steps.
+              This foundation does not support bulk backup, migration execution, project bundle packaging, vendor-runtime restore, or cloud sync.
+            </p>
+          </div>
+        </Card>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          {WORKFLOW_DESCRIPTORS.map((descriptor) => (
+            <Card key={descriptor.type} className="p-4">
+              <div className="text-xs uppercase tracking-[0.18em] text-muted">{descriptor.label}</div>
+              <p className="mt-2 text-sm leading-6 text-muted">{descriptor.description}</p>
+              <Button className="mt-4" size="sm" onClick={() => selectWorkflow(descriptor.type)}>
+                Start {descriptor.label}
+              </Button>
+            </Card>
+          ))}
+        </div>
+
+        <RecentOperationsPanel operations={recentOperations} onSelectOperation={handleSelectRecentOperation} />
+      </div>
+    );
+  }
+
+  // ── Render: result / failed ──
+  if (operationResult && isTerminalState(workflowState)) {
+    return (
+      <div className="space-y-4">
+        {activeHandoff ? <CueStrip handoff={activeHandoff} /> : null}
+
+        <Card className="p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Badge variant="default">{descriptor?.label ?? "Workflow"}</Badge>
+                <Badge variant={workflowState === "failed" ? "warn" : "ok"}>{formatWorkflowStateLabel(workflowState)}</Badge>
+              </div>
+              <h2 className="text-xl font-semibold">Backup / Migration</h2>
+            </div>
+          </div>
+        </Card>
+
+        <OperationResultPanel result={operationResult} onNewWorkflow={resetWorkflow} />
+
+        <RecentOperationsPanel operations={recentOperations} onSelectOperation={handleSelectRecentOperation} />
+      </div>
+    );
+  }
+
+  // ── Render: active workflow ──
+  return (
+    <div className="space-y-4">
+      {activeHandoff ? <CueStrip handoff={activeHandoff} /> : null}
+
+      <Card className="p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Badge variant="default">{descriptor?.label ?? "Workflow"}</Badge>
+              <Badge variant="ok">{formatWorkflowStateLabel(workflowState)}</Badge>
+              {isExecuting ? <Badge variant="warn">executing…</Badge> : null}
+            </div>
+            <h2 className="text-xl font-semibold">Backup / Migration</h2>
+          </div>
+          <Button size="sm" variant="outline" onClick={resetWorkflow}>
+            Cancel
+          </Button>
+        </div>
+        {activeWorkflow ? (
+          <div className="mt-3">
+            <WorkflowStepsIndicator workflowType={activeWorkflow} currentState={workflowState} />
+          </div>
+        ) : null}
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.75fr)]">
+        <div className="space-y-4">
+          {/* Selection / intake */}
+          {workflowState === "selection" && activeWorkflow === "session-backup" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Session</div>
+              <div className="space-y-3">
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Session ID</span>
+                  <input
+                    type="text"
+                    value={selectedSessionId ?? ""}
+                    onChange={(e) => setSelectedSessionId(e.target.value || null)}
+                    placeholder="Enter session ID"
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Source</span>
+                  <select
+                    value={selectedSource ?? ""}
+                    onChange={(e) => setSelectedSource((e.target.value as Source) || null)}
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  >
+                    <option value="">Choose source</option>
+                    <option value="antigravity">Antigravity</option>
+                    <option value="windsurf">Windsurf</option>
+                    <option value="codex">Codex</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Root ID (optional)</span>
+                  <input
+                    type="text"
+                    value={selectedRootId ?? ""}
+                    onChange={(e) => setSelectedRootId(e.target.value || null)}
+                    placeholder="Optional root ID"
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                {prefillSessionId ? (
+                  <div className="text-xs text-muted">Pre-filled from routed handoff.</div>
+                ) : null}
+                <Button size="sm" disabled={!selectedSessionId || !selectedSource} onClick={advanceState}>
+                  Continue to Configuration
+                </Button>
+              </div>
+            </Card>
+          ) : null}
+
+          {workflowState === "selection" && (activeWorkflow === "import-backup" || activeWorkflow === "validate-package") ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Package</div>
+              <div className="space-y-3">
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Backup ID</span>
+                  <input
+                    type="text"
+                    value={backupIdInput}
+                    onChange={(e) => setBackupIdInput(e.target.value)}
+                    placeholder="Enter backup ID from managed backup store"
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                <Button size="sm" disabled={!backupIdInput} onClick={runValidation}>
+                  Validate
+                </Button>
+              </div>
+            </Card>
+          ) : null}
+
+          {/* Configuration (session-backup only) */}
+          {workflowState === "configuration" && activeWorkflow === "session-backup" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Configure Backup</div>
+              <div className="space-y-3">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                  <div className="font-medium">Session: {selectedSessionId}</div>
+                  <div className="text-xs text-muted">Source: {selectedSource}{selectedRootId ? ` / Root: ${selectedRootId}` : ""}</div>
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={includeSourceCopy}
+                    onChange={(e) => setIncludeSourceCopy(e.target.checked)}
+                  />
+                  <span>Include source copy (advanced, opt-in)</span>
+                </label>
+                <div className="text-xs leading-5 text-muted">
+                  Source backup is an optional advanced option. The default backup preserves the canonical session record only.
+                  Source copy stores a separate copy of the original source material without modifying the upstream session source.
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={retreatState}>
+                    Back
+                  </Button>
+                  <Button size="sm" onClick={runValidation}>
+                    Validate
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
+          {/* Validation */}
+          {workflowState === "validation" && validationResult ? (
+            <div className="space-y-4">
+              <ValidationPanel result={validationResult} />
+              <div className="flex flex-wrap gap-2">
+                <Button size="sm" variant="outline" onClick={retreatState}>
+                  Back
+                </Button>
+                {activeWorkflow === "validate-package" ? (
+                  <Button size="sm" onClick={finishValidateOnly}>
+                    Complete Validation
+                  </Button>
+                ) : canProceedFromValidation(validationResult) ? (
+                  <Button size="sm" onClick={advanceState}>
+                    Proceed to Confirmation
+                  </Button>
+                ) : (
+                  <div className="text-sm text-muted">Resolve blocking issues before proceeding.</div>
+                )}
+              </div>
+            </div>
+          ) : null}
+
+          {/* Confirmation */}
+          {workflowState === "confirmation" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Confirm Operation</div>
+              <div className="space-y-3">
+                {activeWorkflow === "session-backup" ? (
+                  <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                    <div className="font-medium">Create backup for session {selectedSessionId}</div>
+                    <div className="text-xs text-muted">
+                      Source: {selectedSource}{includeSourceCopy ? " (with source copy)" : ""}
+                    </div>
+                  </div>
+                ) : null}
+                {activeWorkflow === "import-backup" ? (
+                  <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                    <div className="font-medium">Import backup package {backupIdInput}</div>
+                  </div>
+                ) : null}
+                <div className="rounded-xl border border-amber-400/35 bg-amber-400/10 px-3 py-3 text-sm text-muted">
+                  <span className="font-medium text-foreground">Preservation notice:</span>{" "}
+                  {activeWorkflow === "import-backup"
+                    ? "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime or private source store."
+                    : "This backup preserves a canonical session record. It does not modify, move, or delete the upstream session source."}
+                </div>
+                {validationResult?.items.some((i) => i.severity === "warning") ? (
+                  <div className="rounded-xl border border-amber-400/25 bg-amber-400/8 px-3 py-3 text-sm text-muted">
+                    Validation passed with warnings. Review them before confirming.
+                  </div>
+                ) : null}
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={retreatState}>
+                    Back
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={isExecuting}
+                    onClick={activeWorkflow === "session-backup" ? executeSessionBackup : executeImport}
+                  >
+                    {isExecuting ? "Executing…" : "Execute"}
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
+          {/* Execution */}
+          {workflowState === "execution" && isExecuting ? (
+            <Card className="p-4">
+              <div className="text-sm text-muted">Executing workflow… Please wait.</div>
+            </Card>
+          ) : null}
+
+          {/* Execution error shown in failed state is handled by the terminal render above */}
+          {executionError && workflowState !== "failed" ? (
+            <Card className="border-red-400/40 p-4">
+              <div className="text-sm font-medium text-foreground">Execution error</div>
+              <div className="mt-1 text-sm text-muted">{executionError}</div>
+            </Card>
+          ) : null}
+        </div>
+
+        {/* Right sidebar: context summary + navigation */}
+        <div className="space-y-4">
+          <Card className="p-4">
+            <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Workflow Context</div>
+            <div className="space-y-2 text-sm">
+              {descriptor ? (
+                <div>
+                  <div className="font-medium">{descriptor.label}</div>
+                  <div className="text-xs leading-5 text-muted">{descriptor.description}</div>
+                </div>
+              ) : null}
+              {selectedSessionId && activeWorkflow === "session-backup" ? (
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-2">
+                  <div className="text-xs text-muted">Session</div>
+                  <div className="font-medium">{selectedSessionId}</div>
+                  {selectedSource ? <div className="text-xs text-muted">{selectedSource}</div> : null}
+                </div>
+              ) : null}
+              {backupIdInput && activeWorkflow !== "session-backup" ? (
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-2">
+                  <div className="text-xs text-muted">Backup ID</div>
+                  <div className="font-medium">{backupIdInput}</div>
+                </div>
+              ) : null}
+            </div>
+          </Card>
+
+          <Card className="p-4">
+            <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Navigation</div>
+            <div className="space-y-2">
+              <Button className="w-full justify-start" size="sm" variant="outline" onClick={onNavigateSessions}>
+                Return to Sessions
+              </Button>
+              <Button className="w-full justify-start" size="sm" variant="outline" onClick={onNavigateOverview}>
+                Return to Overview
+              </Button>
+            </div>
+          </Card>
+
+          <RecentOperationsPanel operations={recentOperations} onSelectOperation={handleSelectRecentOperation} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default BackupMigrationFoundation;

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   addRecentOperation,
-  buildPackageValidationItems,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
   createOperationResult,
@@ -19,7 +18,9 @@ import {
   getStepsForWorkflow,
   getWorkflowDescriptor,
   isTerminalState,
+  normalizeBackupId,
   resolveWorkflowFromHandoff,
+  validateBackupPackageRemote,
   WORKFLOW_DESCRIPTORS,
   type BackupMigrationHandoff,
   type BackupOperationResult,
@@ -261,6 +262,7 @@ export function BackupMigrationFoundation({
 
   // ── Derived ──
   const descriptor = activeWorkflow ? getWorkflowDescriptor(activeWorkflow) : null;
+  const normalizedBackupId = normalizeBackupId(backupIdInput);
 
   // ── Actions ──
   const resetWorkflow = useCallback(() => {
@@ -309,42 +311,18 @@ export function BackupMigrationFoundation({
     if (activeWorkflow === "session-backup") {
       items = buildSessionBackupValidation(selectedSessionId);
     } else {
-      const targetBackupId = backupIdInput.trim();
-
-      if (!targetBackupId) {
+      if (!normalizedBackupId) {
         items = activeWorkflow === "import-backup"
           ? buildImportValidation(null)
           : buildValidatePackageValidation(null);
       } else {
-        try {
-          const response = await fetch(`/api/session-backups/${encodeURIComponent(targetBackupId)}`, {
-            method: "GET",
-          });
-          const payload = (await response.json().catch(() => ({ error: "Unknown verification error" }))) as
-            | { backupId: string; verified: true; manifest?: { schemaVersion?: string; createdBy?: string } }
-            | { verified?: false; error?: string; title?: string; hint?: string; code?: string };
-          items = buildPackageValidationItems({
-            backupId: targetBackupId,
-            responseOk: response.ok,
-            payload,
-          });
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          items = [
-            {
-              id: "v-verify-request-failed",
-              label: "Package verification request failed",
-              severity: "block",
-              detail: `Unable to verify backup ${targetBackupId}. ${message}`,
-            },
-          ];
-        }
+        items = await validateBackupPackageRemote(fetch, normalizedBackupId);
       }
     }
     const result = deriveValidationResult(items);
     setValidationResult(result);
     setWorkflowState("validation");
-  }, [activeWorkflow, selectedSessionId, backupIdInput]);
+  }, [activeWorkflow, normalizedBackupId, selectedSessionId]);
 
   const executeSessionBackup = useCallback(async () => {
     if (!selectedSessionId || !selectedSource) return;
@@ -399,7 +377,7 @@ export function BackupMigrationFoundation({
   }, [selectedSessionId, selectedSource, selectedRootId, includeSourceCopy]);
 
   const executeImport = useCallback(async () => {
-    if (!backupIdInput) return;
+    if (!normalizedBackupId) return;
     setIsExecuting(true);
     setExecutionError(null);
     setWorkflowState("execution");
@@ -408,7 +386,7 @@ export function BackupMigrationFoundation({
       const response = await fetch("/api/session-backups/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ backupId: backupIdInput }),
+        body: JSON.stringify({ backupId: normalizedBackupId }),
       });
 
       if (!response.ok) {
@@ -430,7 +408,7 @@ export function BackupMigrationFoundation({
       const result = createOperationResult({
         workflowType: "import-backup",
         status: "success",
-        summary: `Backup ${backupIdInput} imported successfully.`,
+        summary: `Backup ${normalizedBackupId} imported successfully.`,
         backupId: data.backupId,
         sessionCount: data.sessions?.length,
         warnings: ["Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime."],
@@ -452,7 +430,7 @@ export function BackupMigrationFoundation({
     } finally {
       setIsExecuting(false);
     }
-  }, [backupIdInput]);
+  }, [normalizedBackupId]);
 
   const finishValidateOnly = useCallback(() => {
     if (!validationResult) return;
@@ -628,7 +606,7 @@ export function BackupMigrationFoundation({
                     className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
                   />
                 </label>
-                <Button size="sm" disabled={!backupIdInput} onClick={runValidation}>
+                <Button size="sm" disabled={!normalizedBackupId} onClick={runValidation}>
                   Validate
                 </Button>
               </div>
@@ -717,7 +695,7 @@ export function BackupMigrationFoundation({
                 ) : null}
                 {activeWorkflow === "import-backup" ? (
                   <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
-                    <div className="font-medium">Import backup package {backupIdInput}</div>
+                    <div className="font-medium">Import backup package {normalizedBackupId}</div>
                   </div>
                 ) : null}
                 <div className="rounded-xl border border-amber-400/35 bg-amber-400/10 px-3 py-3 text-sm text-muted">
@@ -781,10 +759,10 @@ export function BackupMigrationFoundation({
                   {selectedSource ? <div className="text-xs text-muted">{selectedSource}</div> : null}
                 </div>
               ) : null}
-              {backupIdInput && activeWorkflow !== "session-backup" ? (
+              {normalizedBackupId && activeWorkflow !== "session-backup" ? (
                 <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-2">
                   <div className="text-xs text-muted">Backup ID</div>
-                  <div className="font-medium">{backupIdInput}</div>
+                  <div className="font-medium">{normalizedBackupId}</div>
                 </div>
               ) : null}
             </div>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -453,6 +453,12 @@ export function BackupMigrationFoundation({
 
   // ── Auto-prefill from handoff ──
   const prefillSessionId = useMemo(() => handoff?.sessionId ?? null, [handoff]);
+
+  useEffect(() => {
+    if (selectedSource !== "codex" && includeSourceCopy) {
+      setIncludeSourceCopy(false);
+    }
+  }, [includeSourceCopy, selectedSource]);
 
   // ── Render: idle ──
   if (workflowState === "idle" && !activeWorkflow) {

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   addRecentOperation,
+  buildPackageValidationItems,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
   createOperationResult,
@@ -55,12 +56,7 @@ function buildImportValidation(backupId: string | null): BackupValidationItem[] 
   if (!backupId) {
     return [{ id: "v-no-pkg", label: "No package selected", severity: "block", detail: "Choose a backup package to import." }];
   }
-  return [
-    { id: "v-schema", label: "Schema version", severity: "ok", detail: "session-backup/v1 is supported." },
-    { id: "v-integrity", label: "Package integrity", severity: "ok", detail: "Manifest and records are consistent." },
-    { id: "v-provenance", label: "Provenance", severity: "ok", detail: "Created by agent-storage-manager." },
-    { id: "v-no-runtime", label: "No vendor-runtime restore", severity: "warning", detail: "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime." },
-  ];
+  return [{ id: "v-await-verify", label: "Ready to verify", severity: "ok", detail: `Backup ${backupId} is ready for verification.` }];
 }
 
 function buildValidatePackageValidation(backupId: string | null): BackupValidationItem[] {
@@ -307,15 +303,43 @@ export function BackupMigrationFoundation({
     }
   }, [activeWorkflow, workflowState]);
 
-  const runValidation = useCallback(() => {
+  const runValidation = useCallback(async () => {
     if (!activeWorkflow) return;
     let items: BackupValidationItem[];
     if (activeWorkflow === "session-backup") {
       items = buildSessionBackupValidation(selectedSessionId);
-    } else if (activeWorkflow === "import-backup") {
-      items = buildImportValidation(backupIdInput || null);
     } else {
-      items = buildValidatePackageValidation(backupIdInput || null);
+      const targetBackupId = backupIdInput.trim();
+
+      if (!targetBackupId) {
+        items = activeWorkflow === "import-backup"
+          ? buildImportValidation(null)
+          : buildValidatePackageValidation(null);
+      } else {
+        try {
+          const response = await fetch(`/api/session-backups/${encodeURIComponent(targetBackupId)}`, {
+            method: "GET",
+          });
+          const payload = (await response.json().catch(() => ({ error: "Unknown verification error" }))) as
+            | { backupId: string; verified: true; manifest?: { schemaVersion?: string; createdBy?: string } }
+            | { verified?: false; error?: string; title?: string; hint?: string; code?: string };
+          items = buildPackageValidationItems({
+            backupId: targetBackupId,
+            responseOk: response.ok,
+            payload,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          items = [
+            {
+              id: "v-verify-request-failed",
+              label: "Package verification request failed",
+              severity: "block",
+              detail: `Unable to verify backup ${targetBackupId}. ${message}`,
+            },
+          ];
+        }
+      }
     }
     const result = deriveValidationResult(items);
     setValidationResult(result);

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -68,7 +68,7 @@ export type HomeClientAssetHandoff = {
   subtype: ContextAssetSubtype;
 };
 
-export type HomeClientAnalysisHandoff = {
+export type HomeClientSessionHandoff = {
   sessionId: string;
   source: Source;
   rootId?: string;
@@ -78,8 +78,8 @@ export type HomeClientProps = {
   chrome?: "full" | "embedded";
   externalSelection?: HomeClientExternalSelection | null;
   onOpenAssetsForSession?(handoff: HomeClientAssetHandoff): void;
-  onOpenAnalysisForSession?(handoff: HomeClientAnalysisHandoff): void;
-  onOpenBackupForSession?(handoff: HomeClientAnalysisHandoff): void;
+  onOpenAnalysisForSession?(handoff: HomeClientSessionHandoff): void;
+  onOpenBackupForSession?(handoff: HomeClientSessionHandoff): void;
 };
 
 export function resolveInitialSource(input: {

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -79,6 +79,7 @@ export type HomeClientProps = {
   externalSelection?: HomeClientExternalSelection | null;
   onOpenAssetsForSession?(handoff: HomeClientAssetHandoff): void;
   onOpenAnalysisForSession?(handoff: HomeClientAnalysisHandoff): void;
+  onOpenBackupForSession?(handoff: HomeClientAnalysisHandoff): void;
 };
 
 export function resolveInitialSource(input: {
@@ -1442,6 +1443,7 @@ export default function HomeClient({
   externalSelection = null,
   onOpenAssetsForSession,
   onOpenAnalysisForSession,
+  onOpenBackupForSession,
 }: HomeClientProps = {}) {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [status, setStatus] = useState<SourcesStatus | null>(null);
@@ -2713,6 +2715,22 @@ export default function HomeClient({
                     title="Route to Analysis with bounded session evidence context"
                   >
                     Review in Analysis
+                  </Button>
+                ) : null}
+                {onOpenBackupForSession ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      onOpenBackupForSession({
+                        sessionId: selectedId,
+                        source,
+                        ...(selectedItem?.rootId ? { rootId: selectedItem.rootId } : {}),
+                      })
+                    }
+                    title="Route to Backup / Migration with bounded session backup context"
+                  >
+                    Open in Backup / Migration
                   </Button>
                 ) : null}
                 <Button

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -7,7 +7,7 @@ import AnalysisFoundation from "@/components/AnalysisFoundation";
 import AssetsFoundation from "@/components/AssetsFoundation";
 import BackupMigrationFoundation from "@/components/BackupMigrationFoundation";
 import { buildBackupHandoffInstanceKey, type BackupMigrationHandoff } from "@/lib/backupMigration";
-import HomeClient, { type HomeClientAnalysisHandoff, type HomeClientAssetHandoff, type HomeClientExternalSelection } from "@/components/HomeClient";
+import HomeClient, { type HomeClientAssetHandoff, type HomeClientExternalSelection, type HomeClientSessionHandoff } from "@/components/HomeClient";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -163,7 +163,7 @@ export function buildAnalysisHandoffFromOverview(input: {
   };
 }
 
-export function buildAnalysisHandoffFromSession(input: HomeClientAnalysisHandoff): AnalysisHandoff {
+export function buildAnalysisHandoffFromSession(input: HomeClientSessionHandoff): AnalysisHandoff {
   return {
     origin: "sessions",
     subtitle: "Review analysis findings related to the selected session evidence.",
@@ -581,7 +581,7 @@ export default function ProjectShellClient() {
     setActivePage("assets");
   }, [leaveSessionsSurface]);
 
-  const handleOpenAnalysisFromSession = useCallback((handoff: HomeClientAnalysisHandoff) => {
+  const handleOpenAnalysisFromSession = useCallback((handoff: HomeClientSessionHandoff) => {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(buildAnalysisHandoffFromSession(handoff));

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -5,6 +5,8 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import AnalysisFoundation from "@/components/AnalysisFoundation";
 import AssetsFoundation from "@/components/AssetsFoundation";
+import BackupMigrationFoundation from "@/components/BackupMigrationFoundation";
+import { buildBackupHandoffInstanceKey, type BackupMigrationHandoff } from "@/lib/backupMigration";
 import HomeClient, { type HomeClientAnalysisHandoff, type HomeClientAssetHandoff, type HomeClientExternalSelection } from "@/components/HomeClient";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { Badge } from "@/components/ui/badge";
@@ -219,6 +221,70 @@ export function buildAssetsFoundationInstanceKey(handoff: AssetsHandoff | null):
   ].join(":");
 }
 
+export function buildBackupHandoffFromAssets(context: {
+  assetId?: string;
+  subtype?: ContextAssetSubtype;
+}): BackupMigrationHandoff {
+  return {
+    origin: "assets",
+    subtitle: `Prepare bounded backup or migration work${context.subtype ? ` for ${context.subtype} assets` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}.`,
+    continueLabel: "Workflow execution belongs to Backup / Migration.",
+    returnLabel: "Return to Assets for object-level review.",
+    assetId: context.assetId,
+    assetSubtype: context.subtype,
+  };
+}
+
+export function buildBackupHandoffFromAnalysis(context: {
+  findingId: string;
+  title: string;
+  preservationWarning?: string;
+  routeLabel?: string;
+}): BackupMigrationHandoff {
+  return {
+    origin: "analysis",
+    subtitle: `${context.routeLabel ?? "Recommended route"} for ${context.title}.`,
+    continueLabel: context.preservationWarning ?? "Backup / Migration owns workflow validation and execution.",
+    returnLabel: "Return to Analysis for grouped interpretation.",
+    findingId: context.findingId,
+    preservationWarning: context.preservationWarning,
+    workflowType: "session-backup",
+  };
+}
+
+export function buildBackupHandoffFromSessions(context: {
+  sessionId: string;
+  source: Source;
+  rootId?: string;
+}): BackupMigrationHandoff {
+  return {
+    origin: "sessions",
+    subtitle: `Back up session ${context.sessionId} from Sessions.`,
+    continueLabel: "Use the session backup workflow to preserve this session record.",
+    returnLabel: "Return to the originating session for evidence review.",
+    workflowType: "session-backup",
+    sessionId: context.sessionId,
+    source: context.source,
+    rootId: context.rootId,
+  };
+}
+
+export function buildBackupHandoffFromOverview(workflowType: "session-backup" | "import-backup" | "validate-package"): BackupMigrationHandoff {
+  const subtitles = {
+    "session-backup": "Start a bounded session backup workflow from Project Overview.",
+    "import-backup": "Start a bounded import workflow from Project Overview.",
+    "validate-package": "Start a bounded package validation workflow from Project Overview.",
+  } satisfies Record<"session-backup" | "import-backup" | "validate-package", string>;
+
+  return {
+    origin: "overview",
+    subtitle: subtitles[workflowType],
+    continueLabel: "Workflow execution belongs to Backup / Migration.",
+    returnLabel: "Return to Project Overview.",
+    workflowType,
+  };
+}
+
 export function buildAnalysisFoundationInstanceKey(handoff: AnalysisHandoff | null): string {
   if (!handoff) return "analysis:no-handoff";
 
@@ -255,6 +321,7 @@ function ProjectOverviewSurface(props: {
   onNavigate(page: ProjectShellPage): void;
   onOpenAssets(handoff: AssetsHandoff): void;
   onOpenAnalysis(handoff: AnalysisHandoff): void;
+  onOpenBackup(handoff: BackupMigrationHandoff): void;
 }) {
   return (
     <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -381,13 +448,37 @@ function ProjectOverviewSurface(props: {
           >
             Review analysis
           </Button>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("session-backup"))}
+          >
+            Start session backup
+          </Button>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("import-backup"))}
+          >
+            Import backup package
+          </Button>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("validate-package"))}
+          >
+            Validate backup package
+          </Button>
           <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => props.onNavigate("backup")}>
-            Start backup / migration
+            Browse backup workflows
           </Button>
         </div>
         <p className="mt-4 text-xs leading-5 text-muted">
-          Assets and Analysis are now bounded foundation surfaces. Backup / Migration remains a placeholder, and
-          working session backup remains available from a selected session.
+          Assets, Analysis, and Backup / Migration are now bounded foundation surfaces.
+          Working session backup also remains available from a selected session.
         </p>
       </Card>
     </div>
@@ -440,7 +531,7 @@ export default function ProjectShellClient() {
   const [externalSelection, setExternalSelection] = useState<HomeClientExternalSelection | null>(null);
   const [assetsHandoff, setAssetsHandoff] = useState<AssetsHandoff | null>(null);
   const [analysisHandoff, setAnalysisHandoff] = useState<AnalysisHandoff | null>(null);
-  const [backupCue, setBackupCue] = useState<PlaceholderCue | null>(null);
+  const [backupHandoff, setBackupHandoff] = useState<BackupMigrationHandoff | null>(null);
 
   const leaveSessionsSurface = useCallback(() => {
     clearSessionViewerUrlState();
@@ -454,7 +545,7 @@ export default function ProjectShellClient() {
   const handleSearchSelect = useCallback((sessionId: string, source: Source, rootId?: string) => {
     setAssetsHandoff(null);
     setAnalysisHandoff(null);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage("sessions");
     setExternalSelection((prev) =>
       buildExternalSessionSelection({
@@ -470,7 +561,7 @@ export default function ProjectShellClient() {
     if (page !== "sessions") leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(null);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage(page);
   }, [leaveSessionsSurface]);
 
@@ -478,7 +569,7 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(handoff);
     setAnalysisHandoff(null);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage("assets");
   }, [leaveSessionsSurface]);
 
@@ -486,7 +577,7 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(buildAssetsHandoffFromSession({ sessionId: handoff.sessionId, subtype: handoff.subtype }));
     setAnalysisHandoff(null);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage("assets");
   }, [leaveSessionsSurface]);
 
@@ -494,14 +585,14 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(buildAnalysisHandoffFromSession(handoff));
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage("analysis");
   }, [leaveSessionsSurface]);
 
   const handleOpenSessionFromContext = useCallback((selection: { sessionId: string; source: Source; rootId?: string }) => {
     setAssetsHandoff(null);
     setAnalysisHandoff(null);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage("sessions");
     setExternalSelection((prev) =>
       buildExternalSessionSelection({
@@ -521,7 +612,7 @@ export default function ProjectShellClient() {
   }) => {
     leaveSessionsSurface();
     setAssetsHandoff(null);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setAnalysisHandoff(buildAnalysisHandoffFromAssets(context));
     setActivePage("analysis");
   }, [leaveSessionsSurface]);
@@ -530,10 +621,7 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(null);
-    setBackupCue({
-      title: "Routed from Assets",
-      body: `Prepare bounded backup or migration work${context.subtype ? ` for ${context.subtype} assets` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}. Workflow execution still belongs to Backup / Migration.`,
-    });
+    setBackupHandoff(buildBackupHandoffFromAssets(context));
     setActivePage("backup");
   }, [leaveSessionsSurface]);
 
@@ -541,7 +629,7 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(handoff);
-    setBackupCue(null);
+    setBackupHandoff(null);
     setActivePage("analysis");
   }, [leaveSessionsSurface]);
 
@@ -554,10 +642,15 @@ export default function ProjectShellClient() {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(null);
-    setBackupCue({
-      title: "Routed from Analysis",
-      body: `${context.routeLabel ?? "Recommended route"} for ${context.title}. ${context.preservationWarning ?? "Backup / Migration owns workflow validation and execution."}`,
-    });
+    setBackupHandoff(buildBackupHandoffFromAnalysis(context));
+    setActivePage("backup");
+  }, [leaveSessionsSurface]);
+
+  const handleOpenBackup = useCallback((handoff: BackupMigrationHandoff) => {
+    leaveSessionsSurface();
+    setAssetsHandoff(null);
+    setAnalysisHandoff(null);
+    setBackupHandoff(handoff);
     setActivePage("backup");
   }, [leaveSessionsSurface]);
 
@@ -618,13 +711,21 @@ export default function ProjectShellClient() {
             </div>
           ) : null}
 
-          {activePage === "overview" ? <ProjectOverviewSurface onNavigate={handleNavigate} onOpenAssets={handleOpenAssets} onOpenAnalysis={handleOpenAnalysis} /> : null}
+          {activePage === "overview" ? (
+            <ProjectOverviewSurface
+              onNavigate={handleNavigate}
+              onOpenAssets={handleOpenAssets}
+              onOpenAnalysis={handleOpenAnalysis}
+              onOpenBackup={handleOpenBackup}
+            />
+          ) : null}
           {activePage === "sessions" ? (
             <HomeClient
               chrome="embedded"
               externalSelection={externalSelection}
               onOpenAssetsForSession={handleOpenAssetsFromSession}
               onOpenAnalysisForSession={handleOpenAnalysisFromSession}
+              onOpenBackupForSession={(handoff) => handleOpenBackup(buildBackupHandoffFromSessions(handoff))}
             />
           ) : null}
           {activePage === "assets" ? (
@@ -647,13 +748,11 @@ export default function ProjectShellClient() {
             />
           ) : null}
           {activePage === "backup" ? (
-            <PlaceholderSurface
-              title="Backup / Migration"
-              label="restricted workflow"
-              body="Project-level backup and migration workflows will live here once bundle and migration contracts are implemented. Existing direct session backup remains inside selected Sessions."
-              preservedPath="Open a session and use its Backup Session action for current supported backup behavior."
+            <BackupMigrationFoundation
+              key={buildBackupHandoffInstanceKey(backupHandoff)}
+              handoff={backupHandoff}
               onNavigateSessions={() => handleNavigate("sessions")}
-              cue={backupCue ?? undefined}
+              onNavigateOverview={() => handleNavigate("overview")}
             />
           ) : null}
         </main>

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import AnalysisFoundation from "@/components/AnalysisFoundation";
 import AssetsFoundation from "@/components/AssetsFoundation";
 import BackupMigrationFoundation from "@/components/BackupMigrationFoundation";
-import { buildBackupHandoffInstanceKey, type BackupMigrationHandoff } from "@/lib/backupMigration";
+import { buildBackupHandoffInstanceKey, type BackupMigrationHandoff, type BackupWorkflowType } from "@/lib/backupMigration";
 import HomeClient, { type HomeClientAssetHandoff, type HomeClientExternalSelection, type HomeClientSessionHandoff } from "@/components/HomeClient";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { Badge } from "@/components/ui/badge";
@@ -269,12 +269,12 @@ export function buildBackupHandoffFromSessions(context: {
   };
 }
 
-export function buildBackupHandoffFromOverview(workflowType: "session-backup" | "import-backup" | "validate-package"): BackupMigrationHandoff {
+export function buildBackupHandoffFromOverview(workflowType: BackupWorkflowType): BackupMigrationHandoff {
   const subtitles = {
     "session-backup": "Start a bounded session backup workflow from Project Overview.",
     "import-backup": "Start a bounded import workflow from Project Overview.",
     "validate-package": "Start a bounded package validation workflow from Project Overview.",
-  } satisfies Record<"session-backup" | "import-backup" | "validate-package", string>;
+  } satisfies Record<BackupWorkflowType, string>;
 
   return {
     origin: "overview",

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -33,6 +33,23 @@ export type BackupValidationResult = {
   items: BackupValidationItem[];
 };
 
+export type BackupPackageVerifySuccess = {
+  backupId: string;
+  verified: true;
+  manifest?: {
+    schemaVersion?: string;
+    createdBy?: string;
+  };
+};
+
+export type BackupPackageVerifyFailure = {
+  verified?: false;
+  error?: string;
+  title?: string;
+  hint?: string;
+  code?: string;
+};
+
 // ── Operation result ────────────────────────────────────────────────────────
 
 export type BackupOperationStatus = "success" | "success-with-warnings" | "failed";
@@ -187,6 +204,60 @@ export function deriveValidationResult(items: BackupValidationItem[]): BackupVal
 
 export function canProceedFromValidation(result: BackupValidationResult): boolean {
   return result.status !== "invalid";
+}
+
+export function buildPackageValidationItems(input: {
+  backupId: string;
+  responseOk: boolean;
+  payload: BackupPackageVerifySuccess | BackupPackageVerifyFailure;
+}): BackupValidationItem[] {
+  if (!input.responseOk) {
+    const failure = input.payload as BackupPackageVerifyFailure;
+    const title = failure.title ?? "Package validation failed";
+    const detailParts = [failure.error ?? `Backup ${input.backupId} could not be verified.`];
+    if (failure.code) detailParts.push(`Code: ${failure.code}`);
+    if (failure.hint) detailParts.push(failure.hint);
+
+    return [
+      {
+        id: "v-package-invalid",
+        label: title,
+        severity: "block",
+        detail: detailParts.join(" "),
+      },
+    ];
+  }
+
+  const success = input.payload as BackupPackageVerifySuccess;
+
+  return [
+    {
+      id: "v-schema",
+      label: "Schema version",
+      severity: "ok",
+      detail: `${success.manifest?.schemaVersion ?? "session-backup/v1"} is supported.`,
+    },
+    {
+      id: "v-integrity",
+      label: "Package integrity",
+      severity: "ok",
+      detail: `Backup ${input.backupId} passed manifest and record verification.`,
+    },
+    {
+      id: "v-provenance",
+      label: "Provenance",
+      severity: "ok",
+      detail: success.manifest?.createdBy
+        ? `Created by ${success.manifest.createdBy}.`
+        : "Backup provenance is present and readable.",
+    },
+    {
+      id: "v-no-runtime",
+      label: "No vendor-runtime restore",
+      severity: "warning",
+      detail: "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime.",
+    },
+  ];
 }
 
 // ── Operation result helpers ────────────────────────────────────────────────

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -48,6 +48,13 @@ export type BackupOperationResult = {
   warnings?: string[];
 };
 
+export type SessionBackupExecutionRequest = {
+  source: Source;
+  sessionId: string;
+  rootId?: string;
+  includeSourceCopy?: boolean;
+};
+
 // ── Recent operations ───────────────────────────────────────────────────────
 
 export type RecentOperation = BackupOperationResult;
@@ -205,6 +212,28 @@ export function createOperationResult(input: {
     sessionCount: input.sessionCount,
     warnings: input.warnings,
   };
+}
+
+export function buildSessionBackupExecutionRequest(input: {
+  source: Source;
+  sessionId: string;
+  rootId?: string | null;
+  includeSourceCopy: boolean;
+}): SessionBackupExecutionRequest {
+  const request: SessionBackupExecutionRequest = {
+    source: input.source,
+    sessionId: input.sessionId,
+  };
+
+  if (input.rootId) {
+    request.rootId = input.rootId;
+  }
+
+  if (input.source === "codex" && input.includeSourceCopy) {
+    request.includeSourceCopy = true;
+  }
+
+  return request;
 }
 
 // ── Recent operations ───────────────────────────────────────────────────────

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -50,6 +50,8 @@ export type BackupPackageVerifyFailure = {
   code?: string;
 };
 
+export type BackupPackageVerifyResponse = BackupPackageVerifySuccess | BackupPackageVerifyFailure;
+
 // ── Operation result ────────────────────────────────────────────────────────
 
 export type BackupOperationStatus = "success" | "success-with-warnings" | "failed";
@@ -305,6 +307,50 @@ export function buildSessionBackupExecutionRequest(input: {
   }
 
   return request;
+}
+
+export function normalizeBackupId(input: string): string {
+  return input.trim();
+}
+
+export async function validateBackupPackageRemote(
+  fetchImpl: typeof fetch,
+  backupId: string
+): Promise<BackupValidationItem[]> {
+  const targetBackupId = normalizeBackupId(backupId);
+
+  if (!targetBackupId) {
+    return [
+      {
+        id: "v-no-pkg",
+        label: "No package selected",
+        severity: "block",
+        detail: "Choose a backup package to import.",
+      },
+    ];
+  }
+
+  try {
+    const response = await fetchImpl(`/api/session-backups/${encodeURIComponent(targetBackupId)}`, {
+      method: "GET",
+    });
+    const payload = (await response.json().catch(() => ({ error: "Unknown verification error" }))) as BackupPackageVerifyResponse;
+    return buildPackageValidationItems({
+      backupId: targetBackupId,
+      responseOk: response.ok,
+      payload,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return [
+      {
+        id: "v-verify-request-failed",
+        label: "Package verification request failed",
+        severity: "block",
+        detail: `Unable to verify backup ${targetBackupId}. ${message}`,
+      },
+    ];
+  }
 }
 
 // ── Recent operations ───────────────────────────────────────────────────────

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -347,7 +347,10 @@ export function buildBackupHandoffInstanceKey(handoff: BackupMigrationHandoff | 
     handoff.source ?? "no-source",
     handoff.rootId ?? "no-root",
     handoff.assetId ?? "no-asset",
+    handoff.assetSubtype ?? "no-asset-subtype",
     handoff.findingId ?? "no-finding",
     handoff.issueLabel ?? "no-issue",
+    handoff.preservationWarning ?? "no-preservation-warning",
+    handoff.subtitle,
   ].join(":");
 }

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -1,0 +1,253 @@
+import type { Source } from "@/lib/types";
+
+// ── Workflow types ──────────────────────────────────────────────────────────
+
+export const BACKUP_WORKFLOW_TYPES = ["session-backup", "import-backup", "validate-package"] as const;
+export type BackupWorkflowType = (typeof BACKUP_WORKFLOW_TYPES)[number];
+
+export const BACKUP_WORKFLOW_STATES = [
+  "idle",
+  "selection",
+  "configuration",
+  "validation",
+  "confirmation",
+  "execution",
+  "result",
+  "failed",
+] as const;
+export type BackupWorkflowState = (typeof BACKUP_WORKFLOW_STATES)[number];
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export type BackupValidationSeverity = "ok" | "warning" | "block";
+
+export type BackupValidationItem = {
+  id: string;
+  label: string;
+  severity: BackupValidationSeverity;
+  detail: string;
+};
+
+export type BackupValidationResult = {
+  status: "valid" | "valid-with-warnings" | "invalid";
+  items: BackupValidationItem[];
+};
+
+// ── Operation result ────────────────────────────────────────────────────────
+
+export type BackupOperationStatus = "success" | "success-with-warnings" | "failed";
+
+export type BackupOperationResult = {
+  id: string;
+  workflowType: BackupWorkflowType;
+  status: BackupOperationStatus;
+  timestamp: string;
+  summary: string;
+  backupId?: string;
+  sessionCount?: number;
+  warnings?: string[];
+};
+
+// ── Recent operations ───────────────────────────────────────────────────────
+
+export type RecentOperation = BackupOperationResult;
+
+// ── Handoff ─────────────────────────────────────────────────────────────────
+
+export type BackupMigrationHandoffOrigin = "sessions" | "assets" | "analysis" | "overview";
+
+export type BackupMigrationHandoff = {
+  origin: BackupMigrationHandoffOrigin;
+  subtitle: string;
+  continueLabel?: string;
+  returnLabel?: string;
+  workflowType?: BackupWorkflowType;
+  sessionId?: string;
+  source?: Source;
+  rootId?: string;
+  assetId?: string;
+  assetSubtype?: string;
+  findingId?: string;
+  preservationWarning?: string;
+  issueLabel?: string;
+};
+
+// ── Workflow descriptor ─────────────────────────────────────────────────────
+
+export type BackupWorkflowDescriptor = {
+  type: BackupWorkflowType;
+  label: string;
+  description: string;
+  stepsLabel: string[];
+};
+
+export const WORKFLOW_DESCRIPTORS: BackupWorkflowDescriptor[] = [
+  {
+    type: "session-backup",
+    label: "Session Backup",
+    description: "Create a preserved copy of a canonical session record. Source backup is an opt-in advanced option.",
+    stepsLabel: ["Select session", "Configure", "Validate", "Confirm", "Execute", "Result"],
+  },
+  {
+    type: "import-backup",
+    label: "Import Backup",
+    description: "Import an existing session-backup package. Validates schema, integrity, and provenance before acceptance.",
+    stepsLabel: ["Select package", "Validate", "Confirm", "Execute", "Result"],
+  },
+  {
+    type: "validate-package",
+    label: "Validate Package",
+    description: "Run trust and compatibility checks on a backup package without importing it.",
+    stepsLabel: ["Select package", "Validate", "Result"],
+  },
+];
+
+// ── Helper functions ────────────────────────────────────────────────────────
+
+export function getWorkflowDescriptor(type: BackupWorkflowType): BackupWorkflowDescriptor {
+  return WORKFLOW_DESCRIPTORS.find((d) => d.type === type) ?? WORKFLOW_DESCRIPTORS[0]!;
+}
+
+export function formatWorkflowTypeLabel(type: BackupWorkflowType): string {
+  const labels: Record<BackupWorkflowType, string> = {
+    "session-backup": "Session Backup",
+    "import-backup": "Import Backup",
+    "validate-package": "Validate Package",
+  };
+  return labels[type];
+}
+
+export function formatWorkflowStateLabel(state: BackupWorkflowState): string {
+  const labels: Record<BackupWorkflowState, string> = {
+    idle: "Idle",
+    selection: "Selection",
+    configuration: "Configuration",
+    validation: "Validation",
+    confirmation: "Confirmation",
+    execution: "Executing…",
+    result: "Result",
+    failed: "Failed",
+  };
+  return labels[state];
+}
+
+export function getStepsForWorkflow(type: BackupWorkflowType): BackupWorkflowState[] {
+  switch (type) {
+    case "session-backup":
+      return ["selection", "configuration", "validation", "confirmation", "execution", "result"];
+    case "import-backup":
+      return ["selection", "validation", "confirmation", "execution", "result"];
+    case "validate-package":
+      return ["selection", "validation", "result"];
+  }
+}
+
+export function getNextState(
+  workflowType: BackupWorkflowType,
+  currentState: BackupWorkflowState
+): BackupWorkflowState | null {
+  const steps = getStepsForWorkflow(workflowType);
+  const index = steps.indexOf(currentState);
+  if (index < 0 || index >= steps.length - 1) return null;
+  return steps[index + 1]!;
+}
+
+export function getPreviousState(
+  workflowType: BackupWorkflowType,
+  currentState: BackupWorkflowState
+): BackupWorkflowState | null {
+  const steps = getStepsForWorkflow(workflowType);
+  const index = steps.indexOf(currentState);
+  if (index <= 0) return null;
+  return steps[index - 1]!;
+}
+
+export function isTerminalState(state: BackupWorkflowState): boolean {
+  return state === "result" || state === "failed";
+}
+
+// ── Validation helpers ──────────────────────────────────────────────────────
+
+export function deriveValidationResult(items: BackupValidationItem[]): BackupValidationResult {
+  const hasBlock = items.some((item) => item.severity === "block");
+  const hasWarning = items.some((item) => item.severity === "warning");
+
+  return {
+    status: hasBlock ? "invalid" : hasWarning ? "valid-with-warnings" : "valid",
+    items,
+  };
+}
+
+export function canProceedFromValidation(result: BackupValidationResult): boolean {
+  return result.status !== "invalid";
+}
+
+// ── Operation result helpers ────────────────────────────────────────────────
+
+let operationCounter = 0;
+
+export function createOperationResult(input: {
+  workflowType: BackupWorkflowType;
+  status: BackupOperationStatus;
+  summary: string;
+  backupId?: string;
+  sessionCount?: number;
+  warnings?: string[];
+}): BackupOperationResult {
+  operationCounter += 1;
+  return {
+    id: `op-${Date.now()}-${operationCounter}`,
+    workflowType: input.workflowType,
+    status: input.status,
+    timestamp: new Date().toISOString(),
+    summary: input.summary,
+    backupId: input.backupId,
+    sessionCount: input.sessionCount,
+    warnings: input.warnings,
+  };
+}
+
+// ── Recent operations ───────────────────────────────────────────────────────
+
+export function addRecentOperation(
+  operations: RecentOperation[],
+  operation: RecentOperation,
+  maxCount = 20
+): RecentOperation[] {
+  return [operation, ...operations].slice(0, maxCount);
+}
+
+// ── Handoff consumption ─────────────────────────────────────────────────────
+
+export function resolveWorkflowFromHandoff(
+  handoff: BackupMigrationHandoff | null
+): BackupWorkflowType | null {
+  if (!handoff) return null;
+
+  if (handoff.workflowType && BACKUP_WORKFLOW_TYPES.includes(handoff.workflowType)) {
+    return handoff.workflowType;
+  }
+
+  // Infer from context
+  if (handoff.sessionId) return "session-backup";
+  if (handoff.origin === "overview") return null; // overview routes to selector
+  if (handoff.findingId && handoff.preservationWarning) return "session-backup";
+
+  return null;
+}
+
+export function buildBackupHandoffInstanceKey(handoff: BackupMigrationHandoff | null): string {
+  if (!handoff) return "backup:no-handoff";
+
+  return [
+    "backup",
+    handoff.origin,
+    handoff.workflowType ?? "no-workflow",
+    handoff.sessionId ?? "no-session",
+    handoff.source ?? "no-source",
+    handoff.rootId ?? "no-root",
+    handoff.assetId ?? "no-asset",
+    handoff.findingId ?? "no-finding",
+    handoff.issueLabel ?? "no-issue",
+  ].join(":");
+}

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   addRecentOperation,
+  buildPackageValidationItems,
   buildBackupHandoffInstanceKey,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
@@ -197,6 +198,72 @@ describe("buildSessionBackupExecutionRequest", () => {
       sessionId: "session-2",
       rootId: "root-b",
     });
+  });
+});
+
+describe("buildPackageValidationItems", () => {
+  it("returns blocking diagnostics when verify fails", () => {
+    expect(
+      buildPackageValidationItems({
+        backupId: "missing-backup",
+        responseOk: false,
+        payload: {
+          title: "Backup package not found",
+          error: "The requested backup package could not be found in the managed backup store.",
+          code: "BACKUP_NOT_FOUND",
+          hint: "Check the backup ID and retry verification.",
+        },
+      })
+    ).toEqual([
+      {
+        id: "v-package-invalid",
+        label: "Backup package not found",
+        severity: "block",
+        detail: "The requested backup package could not be found in the managed backup store. Code: BACKUP_NOT_FOUND Check the backup ID and retry verification.",
+      },
+    ]);
+  });
+
+  it("returns validation-first success items when verify succeeds", () => {
+    expect(
+      buildPackageValidationItems({
+        backupId: "backup-1",
+        responseOk: true,
+        payload: {
+          backupId: "backup-1",
+          verified: true,
+          manifest: {
+            schemaVersion: "session-backup/v1",
+            createdBy: "agent-storage-manager",
+          },
+        },
+      })
+    ).toEqual([
+      {
+        id: "v-schema",
+        label: "Schema version",
+        severity: "ok",
+        detail: "session-backup/v1 is supported.",
+      },
+      {
+        id: "v-integrity",
+        label: "Package integrity",
+        severity: "ok",
+        detail: "Backup backup-1 passed manifest and record verification.",
+      },
+      {
+        id: "v-provenance",
+        label: "Provenance",
+        severity: "ok",
+        detail: "Created by agent-storage-manager.",
+      },
+      {
+        id: "v-no-runtime",
+        label: "No vendor-runtime restore",
+        severity: "warning",
+        detail: "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime.",
+      },
+    ]);
   });
 });
 

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -15,7 +15,9 @@ import {
   getStepsForWorkflow,
   getWorkflowDescriptor,
   isTerminalState,
+  normalizeBackupId,
   resolveWorkflowFromHandoff,
+  validateBackupPackageRemote,
   BACKUP_WORKFLOW_TYPES,
   type BackupMigrationHandoff,
   type BackupValidationItem,
@@ -201,6 +203,13 @@ describe("buildSessionBackupExecutionRequest", () => {
   });
 });
 
+describe("normalizeBackupId", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeBackupId("  backup-1  ")).toBe("backup-1");
+    expect(normalizeBackupId("\nbackup-2\t")).toBe("backup-2");
+  });
+});
+
 describe("buildPackageValidationItems", () => {
   it("returns blocking diagnostics when verify fails", () => {
     expect(
@@ -262,6 +271,45 @@ describe("buildPackageValidationItems", () => {
         label: "No vendor-runtime restore",
         severity: "warning",
         detail: "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime.",
+      },
+    ]);
+  });
+});
+
+describe("validateBackupPackageRemote", () => {
+  it("returns a blocking validation item when remote verification reports a missing package", async () => {
+    const fetchMock = async () =>
+      ({
+        ok: false,
+        json: async () => ({
+          title: "Backup not found",
+          error: "The requested backup package could not be found in the managed backup store.",
+          code: "BACKUP_NOT_FOUND",
+          hint: "Check the backup ID and retry verification.",
+        }),
+      }) as Response;
+
+    await expect(validateBackupPackageRemote(fetchMock as typeof fetch, " bad-package-id ")).resolves.toEqual([
+      {
+        id: "v-package-invalid",
+        label: "Backup not found",
+        severity: "block",
+        detail: "The requested backup package could not be found in the managed backup store. Code: BACKUP_NOT_FOUND Check the backup ID and retry verification.",
+      },
+    ]);
+  });
+
+  it("returns a blocking validation item when the verification request itself fails", async () => {
+    const fetchMock = async () => {
+      throw new Error("network down");
+    };
+
+    await expect(validateBackupPackageRemote(fetchMock as typeof fetch, "backup-1")).resolves.toEqual([
+      {
+        id: "v-verify-request-failed",
+        label: "Package verification request failed",
+        severity: "block",
+        detail: "Unable to verify backup backup-1. network down",
       },
     ]);
   });

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   addRecentOperation,
   buildBackupHandoffInstanceKey,
+  buildSessionBackupExecutionRequest,
   canProceedFromValidation,
   createOperationResult,
   deriveValidationResult,
@@ -163,6 +164,39 @@ describe("createOperationResult", () => {
     const r1 = createOperationResult({ workflowType: "session-backup", status: "success", summary: "A" });
     const r2 = createOperationResult({ workflowType: "import-backup", status: "failed", summary: "B" });
     expect(r1.id).not.toBe(r2.id);
+  });
+});
+
+describe("buildSessionBackupExecutionRequest", () => {
+  it("includes rootId and source-copy flag for codex when requested", () => {
+    expect(
+      buildSessionBackupExecutionRequest({
+        source: "codex",
+        sessionId: "session-1",
+        rootId: "root-a",
+        includeSourceCopy: true,
+      })
+    ).toEqual({
+      source: "codex",
+      sessionId: "session-1",
+      rootId: "root-a",
+      includeSourceCopy: true,
+    });
+  });
+
+  it("drops unsupported source-copy requests for non-codex sources", () => {
+    expect(
+      buildSessionBackupExecutionRequest({
+        source: "windsurf",
+        sessionId: "session-2",
+        rootId: "root-b",
+        includeSourceCopy: true,
+      })
+    ).toEqual({
+      source: "windsurf",
+      sessionId: "session-2",
+      rootId: "root-b",
+    });
   });
 });
 

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addRecentOperation,
+  buildBackupHandoffInstanceKey,
+  canProceedFromValidation,
+  createOperationResult,
+  deriveValidationResult,
+  formatWorkflowStateLabel,
+  formatWorkflowTypeLabel,
+  getNextState,
+  getPreviousState,
+  getStepsForWorkflow,
+  getWorkflowDescriptor,
+  isTerminalState,
+  resolveWorkflowFromHandoff,
+  BACKUP_WORKFLOW_TYPES,
+  type BackupMigrationHandoff,
+  type BackupValidationItem,
+} from "@/lib/backupMigration";
+
+describe("getWorkflowDescriptor", () => {
+  it("returns the correct descriptor for each workflow type", () => {
+    for (const type of BACKUP_WORKFLOW_TYPES) {
+      const descriptor = getWorkflowDescriptor(type);
+      expect(descriptor.type).toBe(type);
+      expect(descriptor.label).toBeTruthy();
+      expect(descriptor.description).toBeTruthy();
+      expect(descriptor.stepsLabel.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("formatWorkflowTypeLabel", () => {
+  it("returns a human-readable label", () => {
+    expect(formatWorkflowTypeLabel("session-backup")).toBe("Session Backup");
+    expect(formatWorkflowTypeLabel("import-backup")).toBe("Import Backup");
+    expect(formatWorkflowTypeLabel("validate-package")).toBe("Validate Package");
+  });
+});
+
+describe("formatWorkflowStateLabel", () => {
+  it("returns a human-readable label for each state", () => {
+    expect(formatWorkflowStateLabel("idle")).toBe("Idle");
+    expect(formatWorkflowStateLabel("execution")).toBe("Executing…");
+    expect(formatWorkflowStateLabel("result")).toBe("Result");
+    expect(formatWorkflowStateLabel("failed")).toBe("Failed");
+  });
+});
+
+describe("getStepsForWorkflow", () => {
+  it("returns steps for session-backup", () => {
+    const steps = getStepsForWorkflow("session-backup");
+    expect(steps).toEqual(["selection", "configuration", "validation", "confirmation", "execution", "result"]);
+  });
+
+  it("returns steps for import-backup", () => {
+    const steps = getStepsForWorkflow("import-backup");
+    expect(steps).toEqual(["selection", "validation", "confirmation", "execution", "result"]);
+  });
+
+  it("returns steps for validate-package", () => {
+    const steps = getStepsForWorkflow("validate-package");
+    expect(steps).toEqual(["selection", "validation", "result"]);
+  });
+});
+
+describe("getNextState / getPreviousState", () => {
+  it("advances through session-backup states", () => {
+    expect(getNextState("session-backup", "selection")).toBe("configuration");
+    expect(getNextState("session-backup", "configuration")).toBe("validation");
+    expect(getNextState("session-backup", "result")).toBeNull();
+  });
+
+  it("retreats through session-backup states", () => {
+    expect(getPreviousState("session-backup", "configuration")).toBe("selection");
+    expect(getPreviousState("session-backup", "selection")).toBeNull();
+  });
+
+  it("returns null for unknown states", () => {
+    expect(getNextState("session-backup", "idle")).toBeNull();
+    expect(getPreviousState("session-backup", "idle")).toBeNull();
+  });
+});
+
+describe("isTerminalState", () => {
+  it("identifies result and failed as terminal", () => {
+    expect(isTerminalState("result")).toBe(true);
+    expect(isTerminalState("failed")).toBe(true);
+  });
+
+  it("identifies non-terminal states", () => {
+    expect(isTerminalState("idle")).toBe(false);
+    expect(isTerminalState("selection")).toBe(false);
+    expect(isTerminalState("execution")).toBe(false);
+  });
+});
+
+describe("deriveValidationResult", () => {
+  it("returns valid when all items are ok", () => {
+    const items: BackupValidationItem[] = [
+      { id: "v1", label: "Schema", severity: "ok", detail: "OK" },
+      { id: "v2", label: "Integrity", severity: "ok", detail: "OK" },
+    ];
+    const result = deriveValidationResult(items);
+    expect(result.status).toBe("valid");
+  });
+
+  it("returns valid-with-warnings when a warning is present", () => {
+    const items: BackupValidationItem[] = [
+      { id: "v1", label: "Schema", severity: "ok", detail: "OK" },
+      { id: "v2", label: "Runtime", severity: "warning", detail: "No runtime restore" },
+    ];
+    const result = deriveValidationResult(items);
+    expect(result.status).toBe("valid-with-warnings");
+  });
+
+  it("returns invalid when a block is present", () => {
+    const items: BackupValidationItem[] = [
+      { id: "v1", label: "Missing", severity: "block", detail: "No session" },
+    ];
+    const result = deriveValidationResult(items);
+    expect(result.status).toBe("invalid");
+  });
+
+  it("prefers block over warning", () => {
+    const items: BackupValidationItem[] = [
+      { id: "v1", label: "Warning", severity: "warning", detail: "Warn" },
+      { id: "v2", label: "Block", severity: "block", detail: "Block" },
+    ];
+    const result = deriveValidationResult(items);
+    expect(result.status).toBe("invalid");
+  });
+});
+
+describe("canProceedFromValidation", () => {
+  it("allows proceeding for valid and valid-with-warnings", () => {
+    expect(canProceedFromValidation({ status: "valid", items: [] })).toBe(true);
+    expect(canProceedFromValidation({ status: "valid-with-warnings", items: [] })).toBe(true);
+  });
+
+  it("blocks proceeding for invalid", () => {
+    expect(canProceedFromValidation({ status: "invalid", items: [] })).toBe(false);
+  });
+});
+
+describe("createOperationResult", () => {
+  it("creates a result with unique id and timestamp", () => {
+    const result = createOperationResult({
+      workflowType: "session-backup",
+      status: "success",
+      summary: "Session backed up.",
+    });
+
+    expect(result.id).toMatch(/^op-/);
+    expect(result.workflowType).toBe("session-backup");
+    expect(result.status).toBe("success");
+    expect(result.summary).toBe("Session backed up.");
+    expect(result.timestamp).toBeTruthy();
+  });
+
+  it("produces different ids for successive calls", () => {
+    const r1 = createOperationResult({ workflowType: "session-backup", status: "success", summary: "A" });
+    const r2 = createOperationResult({ workflowType: "import-backup", status: "failed", summary: "B" });
+    expect(r1.id).not.toBe(r2.id);
+  });
+});
+
+describe("addRecentOperation", () => {
+  it("prepends the new operation", () => {
+    const first = createOperationResult({ workflowType: "session-backup", status: "success", summary: "First" });
+    const second = createOperationResult({ workflowType: "import-backup", status: "success", summary: "Second" });
+
+    const list = addRecentOperation([first], second);
+    expect(list[0]!.summary).toBe("Second");
+    expect(list[1]!.summary).toBe("First");
+  });
+
+  it("respects maxCount", () => {
+    const ops = Array.from({ length: 5 }, (_, i) =>
+      createOperationResult({ workflowType: "session-backup", status: "success", summary: `Op ${i}` })
+    );
+    const newOp = createOperationResult({ workflowType: "session-backup", status: "success", summary: "New" });
+
+    const list = addRecentOperation(ops, newOp, 3);
+    expect(list.length).toBe(3);
+    expect(list[0]!.summary).toBe("New");
+  });
+});
+
+describe("resolveWorkflowFromHandoff", () => {
+  it("returns null for null handoff", () => {
+    expect(resolveWorkflowFromHandoff(null)).toBeNull();
+  });
+
+  it("returns the explicit workflowType when present", () => {
+    const handoff: BackupMigrationHandoff = {
+      origin: "analysis",
+      subtitle: "Test",
+      workflowType: "import-backup",
+    };
+    expect(resolveWorkflowFromHandoff(handoff)).toBe("import-backup");
+  });
+
+  it("infers session-backup when sessionId is present", () => {
+    const handoff: BackupMigrationHandoff = {
+      origin: "sessions",
+      subtitle: "Test",
+      sessionId: "session-1",
+      source: "codex",
+    };
+    expect(resolveWorkflowFromHandoff(handoff)).toBe("session-backup");
+  });
+
+  it("infers session-backup from preservation finding", () => {
+    const handoff: BackupMigrationHandoff = {
+      origin: "analysis",
+      subtitle: "Test",
+      findingId: "finding-1",
+      preservationWarning: "Preserve first",
+    };
+    expect(resolveWorkflowFromHandoff(handoff)).toBe("session-backup");
+  });
+
+  it("returns null for overview without explicit workflow", () => {
+    const handoff: BackupMigrationHandoff = {
+      origin: "overview",
+      subtitle: "Test",
+    };
+    expect(resolveWorkflowFromHandoff(handoff)).toBeNull();
+  });
+});
+
+describe("buildBackupHandoffInstanceKey", () => {
+  it("returns stable key for null handoff", () => {
+    expect(buildBackupHandoffInstanceKey(null)).toBe("backup:no-handoff");
+  });
+
+  it("changes when handoff context changes", () => {
+    const first = buildBackupHandoffInstanceKey({
+      origin: "sessions",
+      subtitle: "Test",
+      sessionId: "session-1",
+      source: "codex",
+    });
+    const second = buildBackupHandoffInstanceKey({
+      origin: "analysis",
+      subtitle: "Test",
+      findingId: "finding-1",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("changes when session root changes", () => {
+    const first = buildBackupHandoffInstanceKey({
+      origin: "sessions",
+      subtitle: "Test",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-a",
+    });
+    const second = buildBackupHandoffInstanceKey({
+      origin: "sessions",
+      subtitle: "Test",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-b",
+    });
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackupMigrationFoundation } from "@/components/BackupMigrationFoundation";
+import type { BackupMigrationHandoff } from "@/lib/backupMigration";
+
+function renderBackupMigrationFoundation(handoff: BackupMigrationHandoff | null) {
+  return renderToStaticMarkup(
+    <BackupMigrationFoundation
+      handoff={handoff}
+      onNavigateOverview={vi.fn()}
+      onNavigateSessions={vi.fn()}
+    />
+  );
+}
+
+describe("BackupMigrationFoundation", () => {
+  it("renders idle workflow selector without unimplemented workflows", () => {
+    const html = renderBackupMigrationFoundation(null);
+
+    expect(html).toContain("Backup / Migration");
+    expect(html).toContain("Choose a bounded workflow below.");
+    expect(html).toContain("Start Session Backup");
+    expect(html).toContain("Start Import Backup");
+    expect(html).toContain("Start Validate Package");
+    expect(html).toContain("does not support bulk backup, migration execution, project bundle packaging");
+  });
+
+  it("renders routed session-backup workflow with prefilling context", () => {
+    const html = renderBackupMigrationFoundation({
+      origin: "sessions",
+      subtitle: "Back up session session-1 from Sessions.",
+      workflowType: "session-backup",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-a",
+      continueLabel: "Use the session backup workflow to preserve this session record.",
+      returnLabel: "Return to the originating session for evidence review.",
+    });
+
+    expect(html).toContain("routed workflow");
+    expect(html).toContain("from sessions");
+    expect(html).toContain("Session Backup");
+    expect(html).toContain("Selection");
+    expect(html).toContain("session-1");
+    expect(html).toContain("Pre-filled from routed handoff.");
+  });
+
+  it("degrades vague asset handoff to idle selector instead of opening a broken workflow", () => {
+    const html = renderBackupMigrationFoundation({
+      origin: "assets",
+      subtitle: "Prepare bounded backup or migration work for skill assets.",
+      assetId: "asset-skill-global-generated",
+      assetSubtype: "skill",
+      continueLabel: "Workflow execution belongs to Backup / Migration.",
+      returnLabel: "Return to Assets for object-level review.",
+    });
+
+    expect(html).toContain("routed workflow");
+    expect(html).toContain("from assets");
+    expect(html).toContain("Choose a bounded workflow below.");
+    expect(html).not.toContain("Select Session");
+  });
+
+  it("renders overview-routed validate-package workflow as a direct routed entry", () => {
+    const html = renderBackupMigrationFoundation({
+      origin: "overview",
+      subtitle: "Start a bounded package validation workflow from Project Overview.",
+      workflowType: "validate-package",
+      continueLabel: "Workflow execution belongs to Backup / Migration.",
+      returnLabel: "Return to Project Overview.",
+    });
+
+    expect(html).toContain("from overview");
+    expect(html).toContain("Validate Package");
+    expect(html).toContain("Select Package");
+    expect(html).not.toContain("Choose a bounded workflow below.");
+  });
+});

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -10,6 +10,10 @@ import {
   buildAssetsFoundationInstanceKey,
   buildAssetsHandoffFromOverview,
   buildAssetsHandoffFromSession,
+  buildBackupHandoffFromAnalysis,
+  buildBackupHandoffFromAssets,
+  buildBackupHandoffFromOverview,
+  buildBackupHandoffFromSessions,
   buildExternalSessionSelection,
   resolveInitialProjectShellPage,
   stripSessionViewerSearchParams,
@@ -296,5 +300,66 @@ describe("buildAnalysisFoundationInstanceKey", () => {
 
   it("keeps a stable non-routed key for normal Analysis browsing", () => {
     expect(buildAnalysisFoundationInstanceKey(null)).toBe("analysis:no-handoff");
+  });
+});
+
+describe("backup handoff builders", () => {
+  it("builds a sessions handoff with session identity and workflow type", () => {
+    const handoff = buildBackupHandoffFromSessions({
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-a",
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "sessions",
+      workflowType: "session-backup",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-a",
+    });
+    expect(handoff.subtitle).toContain("session-1");
+  });
+
+  it("builds an assets handoff without carrying asset-viewer state", () => {
+    const handoff = buildBackupHandoffFromAssets({
+      assetId: "asset-skill-global-generated",
+      subtype: "skill",
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "assets",
+      assetId: "asset-skill-global-generated",
+      assetSubtype: "skill",
+    });
+    expect(handoff).not.toHaveProperty("workflowType");
+  });
+
+  it("builds an analysis handoff with preservation warning and finding context", () => {
+    const handoff = buildBackupHandoffFromAnalysis({
+      findingId: "finding-preserve-before-migration",
+      title: "Preserve session evidence before migration cleanup",
+      preservationWarning: "Preserve before risky migration or cleanup work.",
+      routeLabel: "Preserve in Backup / Migration",
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "analysis",
+      workflowType: "session-backup",
+      findingId: "finding-preserve-before-migration",
+      preservationWarning: "Preserve before risky migration or cleanup work.",
+    });
+    expect(handoff.subtitle).toContain("Preserve in Backup / Migration");
+  });
+
+  it("builds an overview handoff with an explicit workflow type", () => {
+    const handoff = buildBackupHandoffFromOverview("import-backup");
+
+    expect(handoff).toMatchObject({
+      origin: "overview",
+      workflowType: "import-backup",
+    });
+    expect(handoff).not.toHaveProperty("sessionId");
+    expect(handoff.subtitle).toContain("import workflow");
   });
 });


### PR DESCRIPTION
## Summary
- replace the Backup / Migration placeholder with a bounded workflow-first foundation surface
- add bounded session backup, import backup, and validate package workflows plus routed handoff and recent operations
- add tests, QA prompt, and follow-up priority documentation for post-foundation work

## Validation
- pnpm test
- pnpm build
- OPENSPEC_TELEMETRY=0 openspec validate backup-migration-foundation --strict

## Scope boundaries
- no bulk backup
- no migration preview
- no project bundle execution
- no vendor runtime restore
- no cloud sync