### PR TITLE
feat: implement bounded bulk session backup workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-04-15` — Bulk session backup
+  - Added a bounded `bulk session backup` workflow to `Backup / Migration` with explicit multi-session selection, per-session validation, batch confirmation, and aggregate plus per-session result reporting
+  - Reused the existing single-session backup execution path for batch fan-out and kept recent operations compact with one entry per bulk run
+  - Preserved existing `Sessions` direct single-session backup behavior and retained `import backup` / `validate package` workflows without regression
+
 - `2026-04-11` — Project shell foundation
   - Added a project-first shell with `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration` surfaces
   - Preserved the existing session viewer under `Sessions`, including source diagnostics, URL deep links, search selection, and direct session backup

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - backup packages use canonical `session-record/v1` inside `session-backup/v1`
   - verify/import flows are available through `/api/session-backups`, `/api/session-backups/import`, and `/api/session-backups/[backupId]`
   - v1 `Source Backup` is opt-in and currently supports copy-only source preservation for Codex sessions only
+- Backup / Migration workflows:
+  - `Backup / Migration` now provides bounded `session backup`, `bulk session backup`, `import backup`, and `validate package` workflows
+  - bulk session backup requires explicit session selection, validates each selected session independently, and fans out through the existing single-session backup execution path
+  - bulk results show aggregate status plus per-session detail, while recent operations record one compact batch entry instead of one entry per session
+  - the foundation still does not implement migration preview, project bundle packaging, vendor-runtime restore, or cloud sync
 
 For detailed view semantics and cross-source alignment notes, see `docs/viewer/trajectory-view.md`.
 

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -3,14 +3,15 @@
 Use this prompt with an external QA agent that can operate the local app through a browser.
 
 ```text
-You are QA-ing the `backup-migration-foundation` implementation for the local-first Agent Storage Manager project.
+You are QA-ing the `bulk-session-backup` implementation for the local-first Agent Storage Manager project.
 
 Repository: <repo-path>
-Branch under test: feat/backup-migration-foundation
+Branch under test: feat/bulk-session-backup
 
 Goal:
 Verify that the new `Backup / Migration` page behaves as a bounded workflow-first foundation surface. It should support:
 - single session backup
+- bulk session backup
 - import backup
 - validate package
 - routed handoff from `Project Overview`, `Sessions`, `Assets`, and `Analysis`
@@ -18,7 +19,6 @@ Verify that the new `Backup / Migration` page behaves as a bounded workflow-firs
 
 It must not behave like:
 - a generic tools drawer
-- a bulk backup surface
 - a migration preview surface
 - a project bundle implementation
 - a vendor runtime restore UI
@@ -50,9 +50,10 @@ Workflow selector / idle checks:
 1. In top-level entry with no routed context, confirm the page lands in an idle workflow selection state.
 2. Confirm only these workflows are present in foundation:
    - session backup
+   - bulk session backup
    - import backup
    - validate package
-3. Confirm `migration preview`, `project bundle`, and `bulk backup` are not presented as active workflows.
+3. Confirm `migration preview` and `project bundle` are not presented as active workflows.
 
 Session backup workflow checks:
 1. Enter the `session backup` workflow from `Backup / Migration`.
@@ -65,6 +66,30 @@ Session backup workflow checks:
 3. Confirm `source backup` is explicit opt-in rather than default.
 4. Confirm warnings are shown before destructive-adjacent or trust-sensitive steps when applicable.
 5. Confirm the existing direct `Back Up Session` action still remains available under `Sessions` and was not removed.
+
+Bulk session backup workflow checks:
+1. Enter the `bulk session backup` workflow from `Backup / Migration`.
+2. Confirm the workflow starts in explicit session selection and does not invent a session set automatically.
+3. Add or verify multiple selected sessions and confirm the workflow shows:
+   - explicit selected-session rows
+   - per-session source / root context when available
+   - per-session source-copy configuration
+4. Validate the batch and confirm:
+   - canonical record availability is checked per selected session
+   - provenance is checked per selected session
+   - source-copy readiness is checked per selected session
+   - warning-level items stay visible into confirmation
+   - block-level items prevent confirmation until removed or repaired
+5. Confirm batch confirmation shows:
+   - selected count
+   - source-copy configuration summary
+   - warning count
+   - sequential fan-out semantics using existing single-session backup behavior
+6. Execute or simulate a mixed run if possible and confirm result states distinguish:
+   - full success
+   - partial failure / success with warnings
+   - full failure
+7. Confirm batch result detail shows aggregate status plus per-session rows, including backup IDs and actionable errors when available.
 
 Import backup workflow checks:
 1. Enter the `import backup` workflow.
@@ -87,12 +112,14 @@ Validate package workflow checks:
 Routed handoff checks:
 1. From `Sessions`, if available, route into `Backup / Migration` for a selected session.
 2. Confirm `Backup / Migration` opens the `session backup` workflow with the session prefilled and a compact origin cue.
-3. From `Assets`, trigger a route into `Backup / Migration` if available.
-4. Confirm the destination page preserves bounded asset context but does not embed the full Assets page.
-5. From `Analysis`, trigger a preservation-oriented route into `Backup / Migration` if available.
-6. Confirm issue context is preserved and workflow identity remains primary.
-7. From `Project Overview`, trigger a route into backup/import/validation if available.
-8. Confirm routed context opens the correct workflow and degrades safely if context is incomplete.
+3. If `Sessions` exposes explicit multi-selection under this branch, route that selection into `Backup / Migration`.
+4. Confirm the destination opens `bulk session backup` with the selected sessions prefilled and no silently dropped entries.
+5. From `Assets`, trigger a route into `Backup / Migration` if available.
+6. Confirm the destination page preserves bounded asset context but does not embed the full Assets page.
+7. From `Analysis`, trigger a preservation-oriented route into `Backup / Migration` if available.
+8. Confirm issue context is preserved and workflow identity remains primary.
+9. From `Project Overview`, trigger a route into single backup, bulk backup, import, and validation if available.
+10. Confirm routed context opens the correct workflow and degrades safely if context is incomplete.
 
 Recent operations checks:
 1. After completing or simulating at least one workflow, confirm a compact recent-operations region appears.
@@ -101,13 +128,15 @@ Recent operations checks:
    - result identity
    - timestamp or recency indicator
    - status
+   - session count for bulk runs
 3. Confirm it reads as a secondary result/history strip, not a persistent audit console.
+4. Confirm a bulk run produces one recent-operation entry for the batch, not one entry per selected session.
 
 Regression checks:
 1. `Sessions` still works as before, including existing viewer behavior and direct session backup.
 2. `Assets` and `Analysis` routing into `Backup / Migration` does not break their own page roles.
 3. Top-level navigation away from `Backup / Migration` clears stale routed workflow context when appropriate.
-4. `Backup / Migration` does not expose bulk backup, migration preview, or project bundle execution accidentally through copy or buttons.
+4. `Backup / Migration` does not expose migration preview or project bundle execution accidentally through copy or buttons.
 
 Boundary checks:
 1. No button or copy should imply:

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -140,7 +140,7 @@ Regression checks:
 
 Boundary checks:
 1. No button or copy should imply:
-   - batch backup
+   - unscoped or implicit batch backup
    - migration apply
    - project bundle packaging
    - runtime continuation in third-party tools

--- a/docs/viewer/bulk-session-backup-qa.md
+++ b/docs/viewer/bulk-session-backup-qa.md
@@ -1,12 +1,19 @@
 # QA Report: bulk-session-backup
 
-**Date:** 2026-04-15  
-**Branch:** `feat/bulk-session-backup`  
+**Date:** 2026-04-15
+**Branch:** `feat/bulk-session-backup`
 **Repository:** `agent-storage-manager`
 
 ---
 
-## Verdict
+## Current Verdict
+
+**Pass with concerns**
+
+The initial failed browser run was retested in prod mode after a clean build and
+is no longer considered a confirmed product blocker.
+
+## Initial Verdict
 
 **Fail due runtime instability during browser verification**
 
@@ -19,13 +26,137 @@
 
 ## Triage
 
-Classification: **needs-confirmation**
+Classification: **resolved by clean prod-mode smoke retest**
 
 The observed blocker is a dev/runtime instability rather than a confirmed
 `bulk-session-backup` product logic failure. The QA agent verified several
 expected states before the app entered an unrecoverable dev-server state with a
 missing Next.js chunk. A clean-server retest is required before this can be
 classified as either a product blocker or an environment-only failure.
+
+## Clean Prod-mode Retest
+
+**Date:** 2026-04-15
+**Environment:** macOS, prod build using `pnpm build && pnpm start`,
+`http://localhost:3000`
+
+Verdict: **Pass with concerns**
+
+### Primary Smoke Checks
+
+- Top-level nav rendered:
+  - `Project Overview`
+  - `Sessions`
+  - `Assets`
+  - `Analysis`
+  - `Backup / Migration`
+- `Backup / Migration` was no longer a placeholder.
+- Workflow-first structure was present:
+  - selector
+  - workflow spine
+  - routed context
+  - result / recent operations
+- Boundary copy excluded:
+  - migration preview
+  - project bundle packaging
+  - vendor-runtime restore
+  - cloud sync
+
+### Workflow Selector / Idle Checks
+
+- Idle state rendered the workflow selector with no routed context.
+- Exactly four workflows were shown:
+  - `Session Backup`
+  - `Bulk Session Backup`
+  - `Import Backup`
+  - `Validate Package`
+- No migration preview or project bundle workflows were exposed.
+
+### Bulk Session Backup Workflow Checks
+
+- Selection:
+  - Empty state showed `No sessions selected yet.`
+  - Copy said the workflow does not invent a session set.
+  - `Add session` was disabled until session ID and source were filled.
+  - `Continue to Configuration` was disabled until at least one session was selected.
+- Multi-select:
+  - QA added two sessions: one real Codex session and one fake Windsurf session.
+  - Both rows showed source/root context and `Remove` actions.
+  - Selected count updated to 2.
+- Configuration:
+  - Source-copy opt-in was shown per session.
+  - Windsurf source-copy was disabled with explanation.
+  - `Back` and `Validate` actions were present.
+- Validation:
+  - Overall validation showed `valid`.
+  - Per-session canonical record and provenance checks were shown.
+  - Per-session eligibility showed both selected sessions as `valid`.
+  - `Proceed to Confirmation` was enabled.
+- Confirmation:
+  - Selected count was 2.
+  - Warning count was 0.
+  - Execution was described as sequential fan-out.
+  - Source-copy summary and preservation notice were visible.
+  - Copy stated the workflow does not create a batch backend API.
+- Execution and result:
+  - Both selected sessions failed in this environment.
+  - Aggregate status was `failed`.
+  - Per-session rows showed actionable errors.
+  - Backup IDs were absent for failed rows, as expected.
+  - Timestamp and `No vendor-runtime restore` boundary copy were present.
+
+### Recent Operations Checks
+
+- Compact recent-operations region appeared after execution.
+- The entry showed workflow type, status, timestamp, summary, and session count.
+- The bulk run produced one batch entry, not one entry per selected session.
+- The region read as a secondary result strip, not a persistent audit console.
+
+### Routed Handoff Checks
+
+- `Sessions -> Backup / Migration` single-session route opened the session
+  backup workflow with source/root/session prefilled and routed origin cue.
+- `Assets -> Backup / Migration` preserved bounded asset context and showed the
+  workflow selector.
+- `Analysis -> Backup / Migration` preserved issue/preservation context and
+  opened session backup.
+- `Project Overview -> Session Backup` opened session backup selection.
+- `Project Overview -> Bulk Session Backup` opened bulk selection with empty
+  explicit selection.
+- `Project Overview -> Browse backup workflows` opened idle workflow selector.
+- Navigating away cleared routed context.
+
+### Regression Checks
+
+- `Sessions` still exposed direct `Back Up Session`.
+- `Sessions`, `Assets`, and `Analysis` continued to work in their existing
+  roles.
+- Assets/Analysis routes into `Backup / Migration` did not break their source
+  pages.
+- No migration preview or project bundle execution was exposed through buttons
+  or copy.
+
+### Remaining Non-blocking Concerns
+
+- `favicon.ico` returned 404.
+- `/api/session-backups` returned 502 in prod mode without full backend runtime;
+  the workflow degraded with actionable result errors.
+- `/api/conversations/antigravity/...` returned 502 when Antigravity LS was not
+  running; the session viewer showed an error message.
+- The QA prompt previously said `batch backup` in boundary checks. This was
+  reworded to distinguish unscoped/implicit batch backup from the valid bounded
+  `Bulk Session Backup` workflow.
+
+### Suggested Follow-up Tests
+
+- Successful bulk execution with a smaller backup-eligible Codex session.
+- Partial failure batch with one eligible and one ineligible session to verify
+  aggregate `success-with-warnings`.
+- Blocked validation case to verify confirmation is blocked and `Remove blocked
+  selections` is available.
+- Dedicated import backup and validate package workflow pass.
+- Sessions multi-selection handoff after the `Sessions` UI gains real
+  multi-select.
 
 ## What Passed Before Failure
 

--- a/docs/viewer/bulk-session-backup-qa.md
+++ b/docs/viewer/bulk-session-backup-qa.md
@@ -1,0 +1,178 @@
+# QA Report: bulk-session-backup
+
+**Date:** 2026-04-15  
+**Branch:** `feat/bulk-session-backup`  
+**Repository:** `agent-storage-manager`
+
+---
+
+## Verdict
+
+**Fail due runtime instability during browser verification**
+
+## Environment
+
+- **OS**: macOS
+- **Local URL**: `http://127.0.0.1:3000`
+- **Runner**: external QA agent using browser automation
+- **Prompt**: `docs/viewer/backup-migration-foundation-qa-prompt.md`
+
+## Triage
+
+Classification: **needs-confirmation**
+
+The observed blocker is a dev/runtime instability rather than a confirmed
+`bulk-session-backup` product logic failure. The QA agent verified several
+expected states before the app entered an unrecoverable dev-server state with a
+missing Next.js chunk. A clean-server retest is required before this can be
+classified as either a product blocker or an environment-only failure.
+
+## What Passed Before Failure
+
+- Top-level shell rendered with:
+  - `Project Overview`
+  - `Sessions`
+  - `Assets`
+  - `Analysis`
+  - `Backup / Migration`
+- `Backup / Migration` idle state rendered as a workflow-first surface.
+- Idle selector showed only:
+  - `Session Backup`
+  - `Bulk Session Backup`
+  - `Import Backup`
+  - `Validate Package`
+- Boundary copy correctly excluded:
+  - migration preview
+  - project bundle packaging
+  - vendor-runtime restore
+  - cloud sync
+- `Bulk Session Backup` entry rendered at least once.
+- Bulk selection state started empty and explicit.
+- Empty bulk state said it does not invent a session set.
+- `Continue to Configuration` was disabled with no selections.
+- `Sessions` still exposed the existing direct `Back Up Session` action.
+
+## Blocking Issues Observed
+
+### Runtime instability blocked QA completion
+
+Steps:
+
+1. Open app at `http://127.0.0.1:3000`.
+2. Navigate through `Project Overview`, `Sessions`, and `Backup / Migration`.
+3. Interact with session detail and route controls.
+
+Expected:
+
+- App remains stable.
+- Shell surface changes consistently.
+- Routed handoffs remain testable.
+
+Actual:
+
+- The app entered an unrecoverable dev/runtime state.
+- Console showed:
+  - `Error: Cannot find module './522.js'`
+  - full reload / Fast Refresh unrecoverable error
+  - subsequent `_next/static/...` 404s
+  - API `502` errors on conversation fetch
+- After this, navigation state became inconsistent and reliable QA could not
+  continue.
+
+Impact:
+
+- Prevented end-to-end verification of:
+  - session-routed handoff into `Backup / Migration`
+  - bulk validation / confirmation / execution / result
+  - recent operations behavior
+  - assets / analysis routed handoffs
+
+### Surface/nav desync after runtime failure
+
+Steps:
+
+1. From `Project Overview`, click `Start bulk session backup`.
+2. Or click top nav `Backup / Migration`.
+
+Expected:
+
+- `Current Surface` and main content switch to `Backup / Migration`.
+
+Actual:
+
+- In the broken runtime state, the nav/button could become active while
+  `Current Surface` still displayed `Project Overview`.
+- Main content remained overview content.
+
+Impact:
+
+- Workflow routing could not be trusted after the runtime error occurred.
+
+## Non-blocking Concerns
+
+### favicon 404
+
+`favicon.ico` returned `404`. This is unrelated to workflow behavior but adds
+console noise.
+
+### QA confidence limited by dev-only failure mode
+
+The QA agent saw correct idle workflow copy and empty bulk selection state, but
+could not complete the full checklist after the runtime failure.
+
+## Regression Notes
+
+### Sessions
+
+- Direct `Back Up Session` remained present.
+- Session viewer loaded enough to show action controls before runtime
+  instability.
+
+### Backup / Migration
+
+- Idle selector and bounded copy looked correct.
+- Bulk empty selection state looked correct when reachable.
+
+### Assets / Analysis
+
+- Not fully verified in live routed flow because runtime failure blocked
+  trustworthy completion.
+
+### Shell routing
+
+- Initially looked correct.
+- Became unreliable after the module/chunk failure.
+
+## Required Retest
+
+Run a clean browser QA pass after resetting the local server:
+
+1. Stop the current dev server.
+2. Remove stale `.next`.
+3. Restart `pnpm dev`, or run a prod-mode smoke using `pnpm build` followed by
+   `pnpm start`.
+4. Re-run the same QA checklist.
+
+Priority retest areas:
+
+- `Project Overview -> Backup / Migration` quick routes:
+  - `Start session backup`
+  - `Start bulk session backup`
+  - `Import backup package`
+  - `Validate backup package`
+  - `Browse backup workflows`
+- `Sessions -> Backup / Migration`
+- `Assets -> Backup / Migration`
+- `Analysis -> Backup / Migration`
+- bulk workflow deep checks:
+  - one valid + one invalid selection for blocked validation
+  - remove blocked selections and continue
+  - multi-valid batch
+  - partial failure batch
+  - compact recent operations batch entry
+
+## Status Summary
+
+Current QA status is **failed due runtime instability**. The failure is not yet
+confirmed as a product logic defect. PR readiness should wait for a clean-server
+retest or an explicit decision to accept this as environment-only.

--- a/openspec/changes/bulk-session-backup/.openspec.yaml
+++ b/openspec/changes/bulk-session-backup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/bulk-session-backup/design.md
+++ b/openspec/changes/bulk-session-backup/design.md
@@ -1,0 +1,137 @@
+## Context
+
+`Backup / Migration` now has a real workflow-first foundation surface with
+single-session backup, import backup, validate package, routed handoff, and
+recent operations. Bulk session backup was explicitly deferred because it adds
+multi-select intake, mixed eligibility, source-copy variance, and partial
+failure semantics.
+
+This change builds on the existing session-backup API and backup-migration
+workflow model. It should expand the workflow surface incrementally without
+creating a new package format, a batch backend API, or a project bundle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a `bulk-session-backup` workflow to the existing `Backup / Migration`
+  workflow selector and state spine.
+- Let users select multiple sessions explicitly before validation and
+  confirmation.
+- Validate every selected session independently and surface blocking items
+  before execution.
+- Support opt-in source preservation while making per-session source-copy
+  eligibility visible.
+- Execute bulk backup through repeated use of the existing single-session
+  backup behavior.
+- Show aggregate and per-session result detail, including partial failure.
+- Keep recent operations compact while preserving a route to batch result
+  detail.
+
+**Non-Goals:**
+
+- No new backend batch backup endpoint.
+- No new grouped package format.
+- No project bundle packaging.
+- No migration preview or migration apply behavior.
+- No vendor-runtime restore behavior.
+- No cloud sync, team sharing, or background scheduled backup.
+- No replacement of the existing direct single-session backup action in
+  `Sessions`.
+
+## Decisions
+
+### Decision 1: Model bulk backup as a workflow type, not a separate page
+
+Add `bulk-session-backup` to the existing backup-migration workflow model so it
+uses the same workflow selector, workflow state labels, validation panel,
+confirmation gate, result panel, and recent operations.
+
+Alternative considered: add a separate bulk action surface inside `Sessions`.
+Rejected because it would duplicate the project-level preservation workflow and
+weaken the role of `Backup / Migration` as the workflow-first surface.
+
+### Decision 2: Execute by fan-out over existing single-session backup behavior
+
+Bulk execution should call the same single-session backup behavior once per
+eligible selected session and aggregate the results. The workflow layer owns
+batch orchestration, per-item status, and aggregate result semantics.
+
+Alternative considered: add a backend batch endpoint immediately. Rejected for
+foundation because it would require a separate API contract, batch persistence
+semantics, and more rollback behavior than the current product need requires.
+
+### Decision 3: Block execution when validation has blocking items
+
+The workflow can show warnings for mixed health, missing optional source-copy
+readiness, or fidelity differences, but it must not proceed while selected
+items have blocking validation failures. Users must remove blocked items or
+leave the workflow to repair source issues.
+
+Alternative considered: allow execution of eligible items while skipping
+blocked items. Rejected for confirmation because it makes the selected batch
+ambiguous. Partial failure remains possible during execution and is reported in
+the result.
+
+### Decision 4: Keep source-copy configuration explicit and item-aware
+
+Source backup remains opt-in. Bulk configuration may offer batch-level choices
+such as none, all eligible, or selected items, but validation must explain which
+selected sessions can actually support source-copy preservation.
+
+Alternative considered: a single global source-copy checkbox. Rejected because
+it hides mixed eligibility and creates false expectations for sessions whose
+source is unreadable or unavailable.
+
+### Decision 5: Use aggregate result plus per-session rows
+
+The result model should include one aggregate status (`success`,
+`success-with-warnings`, or `failed`) plus per-session results with backup IDs,
+warnings, or errors. Recent operations should show only the compact aggregate
+entry and route to full result detail.
+
+Alternative considered: create one recent operation per session. Rejected
+because it would turn recent operations into a noisy history list and obscure
+that the user ran one batch workflow.
+
+### Decision 6: Keep routed handoff bounded
+
+`Sessions` may route a current multi-selection into the bulk workflow when such
+selection exists. `Project Overview` may open the bulk workflow as a preservation
+quick action without requiring preselected sessions. Other surfaces should keep
+using single-session or preservation handoff unless they can provide a concrete
+session set.
+
+Alternative considered: infer session sets from analysis findings or asset
+context. Rejected because implicit selection would be hard to validate and could
+surprise users.
+
+## Risks / Trade-offs
+
+- Partial failure complexity -> Keep validation blocking strict, use explicit
+  aggregate status, and show per-session result rows.
+- UI density -> Use count summaries in the workflow spine and expandable or
+  compact rows in result detail rather than putting every detail in the header.
+- Source-copy ambiguity -> Keep source-copy opt-in and validate eligibility per
+  selected session before confirmation.
+- API efficiency -> Fan-out over single-session backup is simpler but less
+  efficient than a batch endpoint. This is acceptable for foundation and can be
+  replaced later without changing workflow semantics.
+- Selection-source ambiguity -> Require explicit selected sessions; routed
+  overview entry starts at selection instead of inventing a batch.
+
+## Migration Plan
+
+- Add the new workflow type and helper types without removing existing
+  workflows.
+- Keep existing single-session backup behavior and tests intact.
+- Add bulk workflow UI paths behind the existing `Backup / Migration` page.
+- If implementation needs rollback, remove `bulk-session-backup` from the
+  workflow descriptor list and keep the rest of the foundation surface
+  unchanged.
+
+## Open Questions
+
+None for foundation. A future change can decide whether to add a backend batch
+endpoint or grouped package format if user data size makes fan-out execution too
+slow.

--- a/openspec/changes/bulk-session-backup/proposal.md
+++ b/openspec/changes/bulk-session-backup/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The `Backup / Migration` foundation now supports real single-session backup,
+import, and package validation workflows, but preserving several sessions still
+requires repeating the single-session workflow manually. Bulk session backup is
+the next bounded follow-up because it extends an existing executable workflow
+without introducing migration, project bundle, or cloud-sync semantics.
+
+## What Changes
+
+- Add a `bulk-session-backup` workflow to the existing `Backup / Migration`
+  workflow selector and workflow spine.
+- Support explicit multi-session selection from direct `Backup / Migration`
+  entry and routed entry from `Sessions` or `Project Overview`.
+- Add per-session validation for canonical record availability, provenance,
+  and optional source-copy readiness.
+- Add batch confirmation that summarizes selected count, blocking items,
+  warnings, and source-copy choices before execution.
+- Execute bulk backup by applying the existing single-session backup behavior
+  to each selected session; this change does not introduce a new backend batch
+  endpoint or new backup package format.
+- Show aggregate and per-session result reporting, including partial failures,
+  warnings, and actionable next-step routes.
+- Extend recent operations so a completed bulk backup appears as one compact
+  batch operation with route to per-session result detail.
+- Preserve the existing direct single-session backup action and existing
+  `session-backup`, `import-backup`, and `validate-package` workflows.
+- Do not add migration preview, project bundle packaging, vendor-runtime
+  restore, cloud sync, or team collaboration behavior in this change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `backup-migration`: Adds a bounded bulk session backup workflow, multi-session
+  selection semantics, per-session validation, batch confirmation, partial
+  result reporting, and recent-operation summary behavior.
+
+## Impact
+
+- Affected UI: `src/components/BackupMigrationFoundation.tsx` and shell entry
+  points that route to `Backup / Migration`.
+- Affected model code: `src/lib/backupMigration.ts` workflow descriptors,
+  validation helpers, execution/result models, and handoff helpers.
+- Affected tests: model tests, component tests for bulk selection/validation/
+  confirmation/result states, and shell routing tests for bulk handoff.
+- Affected docs: `README.md` and `CHANGELOG.md` when implementation ships, plus
+  external QA coverage for mixed eligibility and partial failure states.
+- Tracking: GitHub Issue #53.

--- a/openspec/changes/bulk-session-backup/specs/backup-migration/spec.md
+++ b/openspec/changes/bulk-session-backup/specs/backup-migration/spec.md
@@ -77,7 +77,7 @@ The system SHALL execute eligible selected sessions as one batch workflow and re
 
 #### Scenario: Execution partially fails
 - **WHEN** at least one selected session succeeds and at least one selected session fails during execution
-- **THEN** the aggregate result status is `success-with-warnings` or another explicit partial-success status
+- **THEN** the aggregate result status is `success-with-warnings`
 - **AND** failed sessions are identified with actionable error detail
 - **AND** successful sessions remain visible rather than being hidden behind a generic failure message
 

--- a/openspec/changes/bulk-session-backup/specs/backup-migration/spec.md
+++ b/openspec/changes/bulk-session-backup/specs/backup-migration/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Bulk session backup workflow SHALL preserve multiple selected sessions
+The system SHALL provide a bounded `bulk-session-backup` workflow inside `Backup / Migration` for preserving an explicit set of selected sessions.
+
+#### Scenario: Workflow selector includes bulk session backup
+- **WHEN** the user opens `Backup / Migration` without active workflow context
+- **THEN** the workflow selector includes `Bulk Session Backup` as an available workflow
+- **AND** the workflow description frames it as preserving selected sessions
+- **AND** the description does not claim project bundle, migration, cloud sync, or vendor-runtime restore behavior
+
+#### Scenario: Bulk backup requires explicit session selection
+- **WHEN** the user starts the bulk session backup workflow without selected sessions
+- **THEN** the workflow remains in selection state
+- **AND** it explains that one or more sessions must be selected before validation
+- **AND** it does not invent a session set from project summary, analysis findings, or asset context
+
+#### Scenario: Routed Sessions handoff preselects available sessions
+- **WHEN** `Sessions` routes to `Backup / Migration` with a concrete multi-session selection
+- **THEN** the bulk session backup workflow opens with those sessions preselected
+- **AND** an origin cue identifies the source as `Sessions`
+- **AND** stale or missing sessions are shown as unresolved selection items instead of being silently dropped
+
+#### Scenario: Routed Overview handoff opens selection without invented objects
+- **WHEN** `Project Overview` routes to `Backup / Migration` for bulk preservation without concrete session IDs
+- **THEN** the bulk session backup workflow opens in selection state
+- **AND** the origin cue references the overview preservation context
+- **AND** no sessions are preselected unless object references are present in the handoff
+
+### Requirement: Bulk session backup SHALL validate each selected session before confirmation
+The system SHALL validate each selected session independently before allowing the bulk session backup workflow to proceed to confirmation.
+
+#### Scenario: All selected sessions validate
+- **WHEN** every selected session can produce a canonical session record
+- **THEN** the validation result is valid unless warnings are present
+- **AND** the validation panel shows per-session eligibility or a count summary with access to per-session detail
+
+#### Scenario: Mixed health produces warnings or blocks per session
+- **WHEN** selected sessions have mixed health, missing provenance, unreadable source-copy candidates, or unavailable canonical records
+- **THEN** the validation panel identifies the affected sessions
+- **AND** warning-level items remain visible through confirmation
+- **AND** block-level items prevent proceeding to confirmation
+
+#### Scenario: Blocked items require removal or repair
+- **WHEN** one or more selected sessions have blocking validation failures
+- **THEN** the workflow does not offer execution
+- **AND** the user can remove blocked sessions from the batch or leave the workflow to repair source issues
+- **AND** the workflow does not silently skip blocked sessions during validation
+
+#### Scenario: Source-copy eligibility remains explicit
+- **WHEN** source preservation is enabled for the batch or selected items
+- **THEN** validation checks source-copy readiness per selected session
+- **AND** sessions that cannot preserve source copies are identified before confirmation
+- **AND** source-copy behavior remains opt-in rather than the default
+
+### Requirement: Bulk session backup confirmation SHALL summarize batch risk
+The system SHALL present a batch confirmation gate before executing bulk session backup.
+
+#### Scenario: Confirmation summarizes selected batch
+- **WHEN** bulk session backup validation has no blocking items
+- **THEN** the confirmation state shows selected session count, source-copy configuration, warning count, and expected execution behavior
+- **AND** it states that the workflow will back up selected sessions through session-backup behavior
+
+#### Scenario: Confirmation preserves warnings
+- **WHEN** validation produced warning-level items
+- **THEN** those warnings remain visible or summarized in confirmation
+- **AND** the user must confirm the batch with those warnings before execution
+
+### Requirement: Bulk session backup execution SHALL report aggregate and per-session results
+The system SHALL execute eligible selected sessions as one batch workflow and report both aggregate and per-session outcomes.
+
+#### Scenario: Successful bulk execution
+- **WHEN** all selected sessions are backed up successfully
+- **THEN** the result status is `success`
+- **AND** the result shows the number of sessions backed up
+- **AND** each backed-up session has inspectable result detail, including backup identity when available
+
+#### Scenario: Execution partially fails
+- **WHEN** at least one selected session succeeds and at least one selected session fails during execution
+- **THEN** the aggregate result status is `success-with-warnings` or another explicit partial-success status
+- **AND** failed sessions are identified with actionable error detail
+- **AND** successful sessions remain visible rather than being hidden behind a generic failure message
+
+#### Scenario: Execution fully fails
+- **WHEN** no selected session is backed up successfully
+- **THEN** the aggregate result status is `failed`
+- **AND** per-session failure detail remains visible
+- **AND** the result does not claim that a usable backup was created
+
+### Requirement: Recent operations SHALL summarize bulk session backup runs
+The system SHALL record completed bulk session backup workflows as compact recent-operation entries with route to batch result detail.
+
+#### Scenario: Bulk backup appears as one recent operation
+- **WHEN** a bulk session backup workflow completes
+- **THEN** recent operations shows one entry for the batch workflow
+- **AND** the entry includes workflow type, timestamp, aggregate status, and session count
+- **AND** it does not create one recent-operation entry per selected session
+
+#### Scenario: Recent operation opens bulk result detail
+- **WHEN** the user selects a bulk session backup recent-operation entry
+- **THEN** the page shows the batch result detail with aggregate status and per-session results

--- a/openspec/changes/bulk-session-backup/tasks.md
+++ b/openspec/changes/bulk-session-backup/tasks.md
@@ -1,0 +1,52 @@
+## 1. Workflow Model
+
+- [ ] 1.1 Add `bulk-session-backup` to backup workflow types, labels, descriptors, and step definitions.
+- [ ] 1.2 Define bulk selection, per-session validation, per-session execution result, and aggregate result types.
+- [ ] 1.3 Add helper functions for bulk validation derivation, aggregate status derivation, and recent-operation creation.
+- [ ] 1.4 Ensure existing `session-backup`, `import-backup`, and `validate-package` model helpers remain backward compatible.
+
+## 2. Selection and Handoff
+
+- [ ] 2.1 Add bounded session selection state for the bulk workflow.
+- [ ] 2.2 Support direct `Backup / Migration` entry into bulk selection state with no invented preselection.
+- [ ] 2.3 Support `Sessions -> Backup / Migration` handoff with concrete selected session IDs when available.
+- [ ] 2.4 Support `Project Overview -> Backup / Migration` handoff to bulk workflow without preselected sessions unless object references exist.
+- [ ] 2.5 Show stale or missing routed session references as unresolved selection items instead of silently dropping them.
+
+## 3. Validation and Confirmation
+
+- [ ] 3.1 Validate canonical record availability per selected session.
+- [ ] 3.2 Validate provenance and source-copy readiness per selected session.
+- [ ] 3.3 Block confirmation when any selected session has block-level validation failures.
+- [ ] 3.4 Preserve warning-level validation items through confirmation.
+- [ ] 3.5 Render batch confirmation with selected count, source-copy configuration, warning count, and execution semantics.
+
+## 4. Execution and Results
+
+- [ ] 4.1 Execute eligible selected sessions through existing single-session backup behavior.
+- [ ] 4.2 Record per-session success, warning, and failure results.
+- [ ] 4.3 Derive aggregate batch status from per-session outcomes.
+- [ ] 4.4 Render batch result detail with aggregate status, session count, per-session rows, backup IDs when available, and actionable errors.
+- [ ] 4.5 Keep full-failure and partial-failure result copy explicit; do not show generic success for partial results.
+
+## 5. Recent Operations
+
+- [ ] 5.1 Add compact recent-operation entries for completed bulk session backup runs.
+- [ ] 5.2 Include workflow type, timestamp, aggregate status, and session count in the recent-operation entry.
+- [ ] 5.3 Route from a bulk recent-operation entry back to batch result detail.
+- [ ] 5.4 Ensure bulk execution does not create one recent-operation entry per selected session.
+
+## 6. Tests and QA
+
+- [ ] 6.1 Add model tests for bulk workflow descriptors, validation derivation, aggregate result derivation, and recent-operation creation.
+- [ ] 6.2 Add component tests for no-selection, selected, mixed-warning, blocked, confirmation, success, partial-failure, and full-failure states.
+- [ ] 6.3 Add shell routing tests for `Sessions` and `Project Overview` handoff into the bulk workflow.
+- [ ] 6.4 Add regression tests proving existing single-session backup, import backup, and validate package workflows still work.
+- [ ] 6.5 Prepare an external QA prompt covering bulk selection, mixed eligibility, source-copy warnings, blocked validation, partial failure, and recent operations.
+
+## 7. Documentation and Validation
+
+- [ ] 7.1 Update `README.md` if user-facing Backup / Migration behavior changes.
+- [ ] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
+- [ ] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
+- [ ] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate bulk-session-backup --strict`.

--- a/openspec/changes/bulk-session-backup/tasks.md
+++ b/openspec/changes/bulk-session-backup/tasks.md
@@ -1,52 +1,54 @@
+# Bulk Session Backup Tasks
+
 ## 1. Workflow Model
 
-- [ ] 1.1 Add `bulk-session-backup` to backup workflow types, labels, descriptors, and step definitions.
-- [ ] 1.2 Define bulk selection, per-session validation, per-session execution result, and aggregate result types.
-- [ ] 1.3 Add helper functions for bulk validation derivation, aggregate status derivation, and recent-operation creation.
-- [ ] 1.4 Ensure existing `session-backup`, `import-backup`, and `validate-package` model helpers remain backward compatible.
+- [x] 1.1 Add `bulk-session-backup` to backup workflow types, labels, descriptors, and step definitions.
+- [x] 1.2 Define bulk selection, per-session validation, per-session execution result, and aggregate result types.
+- [x] 1.3 Add helper functions for bulk validation derivation, aggregate status derivation, and recent-operation creation.
+- [x] 1.4 Ensure existing `session-backup`, `import-backup`, and `validate-package` model helpers remain backward compatible.
 
 ## 2. Selection and Handoff
 
-- [ ] 2.1 Add bounded session selection state for the bulk workflow.
-- [ ] 2.2 Support direct `Backup / Migration` entry into bulk selection state with no invented preselection.
-- [ ] 2.3 Support `Sessions -> Backup / Migration` handoff with concrete selected session IDs when available.
-- [ ] 2.4 Support `Project Overview -> Backup / Migration` handoff to bulk workflow without preselected sessions unless object references exist.
-- [ ] 2.5 Show stale or missing routed session references as unresolved selection items instead of silently dropping them.
+- [x] 2.1 Add bounded session selection state for the bulk workflow.
+- [x] 2.2 Support direct `Backup / Migration` entry into bulk selection state with no invented preselection.
+- [x] 2.3 Support `Sessions -> Backup / Migration` handoff with concrete selected session IDs when available.
+- [x] 2.4 Support `Project Overview -> Backup / Migration` handoff to bulk workflow without preselected sessions unless object references exist.
+- [x] 2.5 Show stale or missing routed session references as unresolved selection items instead of silently dropping them.
 
 ## 3. Validation and Confirmation
 
-- [ ] 3.1 Validate canonical record availability per selected session.
-- [ ] 3.2 Validate provenance and source-copy readiness per selected session.
-- [ ] 3.3 Block confirmation when any selected session has block-level validation failures.
-- [ ] 3.4 Preserve warning-level validation items through confirmation.
-- [ ] 3.5 Render batch confirmation with selected count, source-copy configuration, warning count, and execution semantics.
+- [x] 3.1 Validate canonical record availability per selected session.
+- [x] 3.2 Validate provenance and source-copy readiness per selected session.
+- [x] 3.3 Block confirmation when any selected session has block-level validation failures.
+- [x] 3.4 Preserve warning-level validation items through confirmation.
+- [x] 3.5 Render batch confirmation with selected count, source-copy configuration, warning count, and execution semantics.
 
 ## 4. Execution and Results
 
-- [ ] 4.1 Execute eligible selected sessions through existing single-session backup behavior.
-- [ ] 4.2 Record per-session success, warning, and failure results.
-- [ ] 4.3 Derive aggregate batch status from per-session outcomes.
-- [ ] 4.4 Render batch result detail with aggregate status, session count, per-session rows, backup IDs when available, and actionable errors.
-- [ ] 4.5 Keep full-failure and partial-failure result copy explicit; do not show generic success for partial results.
+- [x] 4.1 Execute eligible selected sessions through existing single-session backup behavior.
+- [x] 4.2 Record per-session success, warning, and failure results.
+- [x] 4.3 Derive aggregate batch status from per-session outcomes.
+- [x] 4.4 Render batch result detail with aggregate status, session count, per-session rows, backup IDs when available, and actionable errors.
+- [x] 4.5 Keep full-failure and partial-failure result copy explicit; do not show generic success for partial results.
 
 ## 5. Recent Operations
 
-- [ ] 5.1 Add compact recent-operation entries for completed bulk session backup runs.
-- [ ] 5.2 Include workflow type, timestamp, aggregate status, and session count in the recent-operation entry.
-- [ ] 5.3 Route from a bulk recent-operation entry back to batch result detail.
-- [ ] 5.4 Ensure bulk execution does not create one recent-operation entry per selected session.
+- [x] 5.1 Add compact recent-operation entries for completed bulk session backup runs.
+- [x] 5.2 Include workflow type, timestamp, aggregate status, and session count in the recent-operation entry.
+- [x] 5.3 Route from a bulk recent-operation entry back to batch result detail.
+- [x] 5.4 Ensure bulk execution does not create one recent-operation entry per selected session.
 
 ## 6. Tests and QA
 
-- [ ] 6.1 Add model tests for bulk workflow descriptors, validation derivation, aggregate result derivation, and recent-operation creation.
-- [ ] 6.2 Add component tests for no-selection, selected, mixed-warning, blocked, confirmation, success, partial-failure, and full-failure states.
-- [ ] 6.3 Add shell routing tests for `Sessions` and `Project Overview` handoff into the bulk workflow.
-- [ ] 6.4 Add regression tests proving existing single-session backup, import backup, and validate package workflows still work.
-- [ ] 6.5 Prepare an external QA prompt covering bulk selection, mixed eligibility, source-copy warnings, blocked validation, partial failure, and recent operations.
+- [x] 6.1 Add model tests for bulk workflow descriptors, validation derivation, aggregate result derivation, and recent-operation creation.
+- [x] 6.2 Add component tests for no-selection, selected, mixed-warning, blocked, confirmation, success, partial-failure, and full-failure states.
+- [x] 6.3 Add shell routing tests for `Sessions` and `Project Overview` handoff into the bulk workflow.
+- [x] 6.4 Add regression tests proving existing single-session backup, import backup, and validate package workflows still work.
+- [x] 6.5 Prepare an external QA prompt covering bulk selection, mixed eligibility, source-copy warnings, blocked validation, partial failure, and recent operations.
 
 ## 7. Documentation and Validation
 
-- [ ] 7.1 Update `README.md` if user-facing Backup / Migration behavior changes.
-- [ ] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
-- [ ] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
-- [ ] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate bulk-session-backup --strict`.
+- [x] 7.1 Update `README.md` if user-facing Backup / Migration behavior changes.
+- [x] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
+- [x] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
+- [x] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate bulk-session-backup --strict`.

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -7,12 +7,17 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
   addRecentOperation,
+  buildBulkSessionValidationResult,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
+  createBulkOperationSummary,
   createOperationResult,
+  dedupeSessionSelections,
+  deriveAggregateOperationStatus,
   deriveValidationResult,
   formatWorkflowStateLabel,
   formatWorkflowTypeLabel,
+  getBlockedSessionSelections,
   getNextState,
   getPreviousState,
   getStepsForWorkflow,
@@ -20,14 +25,17 @@ import {
   isTerminalState,
   normalizeBackupId,
   resolveWorkflowFromHandoff,
+  summarizeSourceCopyConfiguration,
   validateBackupPackageRemote,
   WORKFLOW_DESCRIPTORS,
+  type BackupSessionSelection,
   type BackupMigrationHandoff,
   type BackupOperationResult,
   type BackupValidationItem,
   type BackupValidationResult,
   type BackupWorkflowState,
   type BackupWorkflowType,
+  type BulkSessionExecutionResult,
   type RecentOperation,
 } from "@/lib/backupMigration";
 import type { Source } from "@/lib/types";
@@ -62,6 +70,40 @@ function buildImportValidation(backupId: string | null): BackupValidationItem[] 
 
 function buildValidatePackageValidation(backupId: string | null): BackupValidationItem[] {
   return buildImportValidation(backupId);
+}
+
+export function resolveInitialBulkSelections(handoff: BackupMigrationHandoff | null): BackupSessionSelection[] {
+  if (!handoff) return [];
+  if (handoff.sessions?.length) return dedupeSessionSelections(handoff.sessions);
+  if (handoff.workflowType === "bulk-session-backup" && handoff.sessionId) {
+    return dedupeSessionSelections([
+      {
+        sessionId: handoff.sessionId,
+        source: handoff.source,
+        rootId: handoff.rootId,
+      },
+    ]);
+  }
+  return [];
+}
+
+export function buildBulkConfirmationDetails(input: {
+  selections: BackupSessionSelection[];
+  validationResult: BackupValidationResult | null;
+}): {
+  selectedCount: number;
+  warningCount: number;
+  sourceCopySummary: string;
+  executionSemantics: string;
+} {
+  const selections = dedupeSessionSelections(input.selections);
+  return {
+    selectedCount: selections.length,
+    warningCount: input.validationResult?.warningCount ?? input.validationResult?.items.filter((item) => item.severity === "warning").length ?? 0,
+    sourceCopySummary: summarizeSourceCopyConfiguration(selections),
+    executionSemantics:
+      "This workflow executes the existing session-backup behavior once per selected session. It does not create a batch backend API or grouped package format.",
+  };
 }
 
 // ── Subcomponents ───────────────────────────────────────────────────────────
@@ -117,7 +159,7 @@ function WorkflowStepsIndicator(props: {
   );
 }
 
-function ValidationPanel(props: { result: BackupValidationResult }) {
+export function ValidationPanel(props: { result: BackupValidationResult }) {
   return (
     <Card className="p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -153,7 +195,9 @@ function ValidationPanel(props: { result: BackupValidationResult }) {
   );
 }
 
-function OperationResultPanel(props: { result: BackupOperationResult; onNewWorkflow(): void }) {
+export function OperationResultPanel(props: { result: BackupOperationResult; onNewWorkflow(): void }) {
+  const hasSessionResults = (props.result.sessionResults?.length ?? 0) > 0;
+
   return (
     <Card className="p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -180,6 +224,45 @@ function OperationResultPanel(props: { result: BackupOperationResult; onNewWorkf
             {props.result.warnings.map((warning, index) => (
               <div key={index} className="mt-1 text-xs leading-5">{warning}</div>
             ))}
+          </div>
+        ) : null}
+        {props.result.sourceCopySummary ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Source-copy configuration</div>
+            <div className="mt-1 text-xs leading-5">{props.result.sourceCopySummary}</div>
+          </div>
+        ) : null}
+        {hasSessionResults ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Per-session results</div>
+            <div className="mt-3 space-y-2">
+              {props.result.sessionResults!.map((sessionResult) => (
+                <div key={`${sessionResult.sessionId}:${sessionResult.rootId ?? "no-root"}`} className="rounded-lg border border-border/60 bg-background/40 px-3 py-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant={sessionResult.status === "success" ? "ok" : sessionResult.status === "failed" ? "warn" : "default"}>
+                        {sessionResult.status}
+                      </Badge>
+                      <span className="font-medium">{sessionResult.sessionId}</span>
+                    </div>
+                    <span className="text-xs text-muted">
+                      {sessionResult.source ?? "unknown-source"}
+                      {sessionResult.rootId ? ` / ${sessionResult.rootId}` : ""}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-xs leading-5">{sessionResult.summary}</div>
+                  {sessionResult.backupId ? <div className="mt-1 text-xs">Backup ID: {sessionResult.backupId}</div> : null}
+                  {sessionResult.error ? <div className="mt-1 text-xs text-foreground">Error: {sessionResult.error}</div> : null}
+                  {sessionResult.warnings?.length ? (
+                    <div className="mt-1 space-y-1 text-xs leading-5">
+                      {sessionResult.warnings.map((warning, index) => (
+                        <div key={index}>{warning}</div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
           </div>
         ) : null}
         <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
@@ -220,6 +303,7 @@ function RecentOperationsPanel(props: { operations: RecentOperation[]; onSelectO
               <span className="text-xs text-muted">{new Date(op.timestamp).toLocaleTimeString()}</span>
             </div>
             <div className="mt-1 text-xs text-muted">{op.summary}</div>
+            {op.sessionCount != null ? <div className="mt-1 text-[11px] text-muted">Sessions: {op.sessionCount}</div> : null}
           </button>
         ))}
       </div>
@@ -246,6 +330,12 @@ export function BackupMigrationFoundation({
   const [selectedRootId, setSelectedRootId] = useState<string | null>(handoff?.rootId ?? null);
   const [includeSourceCopy, setIncludeSourceCopy] = useState(false);
 
+  // Bulk session backup state
+  const [bulkSelections, setBulkSelections] = useState<BackupSessionSelection[]>(() => resolveInitialBulkSelections(handoff));
+  const [bulkDraftSessionId, setBulkDraftSessionId] = useState("");
+  const [bulkDraftSource, setBulkDraftSource] = useState<Source | "">("");
+  const [bulkDraftRootId, setBulkDraftRootId] = useState("");
+
   // Import / validate state
   const [backupIdInput, setBackupIdInput] = useState("");
 
@@ -263,6 +353,11 @@ export function BackupMigrationFoundation({
   // ── Derived ──
   const descriptor = activeWorkflow ? getWorkflowDescriptor(activeWorkflow) : null;
   const normalizedBackupId = normalizeBackupId(backupIdInput);
+  const dedupedBulkSelections = useMemo(() => dedupeSessionSelections(bulkSelections), [bulkSelections]);
+  const bulkConfirmationDetails = useMemo(
+    () => buildBulkConfirmationDetails({ selections: dedupedBulkSelections, validationResult }),
+    [dedupedBulkSelections, validationResult]
+  );
 
   // ── Actions ──
   const resetWorkflow = useCallback(() => {
@@ -273,6 +368,10 @@ export function BackupMigrationFoundation({
     setSelectedSource(null);
     setSelectedRootId(null);
     setIncludeSourceCopy(false);
+    setBulkSelections([]);
+    setBulkDraftSessionId("");
+    setBulkDraftSource("");
+    setBulkDraftRootId("");
     setBackupIdInput("");
     setValidationResult(null);
     setIsExecuting(false);
@@ -287,7 +386,10 @@ export function BackupMigrationFoundation({
     setOperationResult(null);
     setExecutionError(null);
     setIsExecuting(false);
-  }, []);
+    if (type === "bulk-session-backup") {
+      setBulkSelections(resolveInitialBulkSelections(activeHandoff));
+    }
+  }, [activeHandoff]);
 
   const advanceState = useCallback(() => {
     if (!activeWorkflow) return;
@@ -307,22 +409,75 @@ export function BackupMigrationFoundation({
 
   const runValidation = useCallback(async () => {
     if (!activeWorkflow) return;
-    let items: BackupValidationItem[];
     if (activeWorkflow === "session-backup") {
-      items = buildSessionBackupValidation(selectedSessionId);
+      const result = deriveValidationResult(buildSessionBackupValidation(selectedSessionId));
+      setValidationResult(result);
+      setWorkflowState("validation");
+      return;
+    }
+
+    if (activeWorkflow === "bulk-session-backup") {
+      const result = buildBulkSessionValidationResult(dedupedBulkSelections);
+      setValidationResult(result);
+      setWorkflowState("validation");
+      return;
+    }
+
+    let items: BackupValidationItem[];
+    if (!normalizedBackupId) {
+      items = activeWorkflow === "import-backup"
+        ? buildImportValidation(null)
+        : buildValidatePackageValidation(null);
     } else {
-      if (!normalizedBackupId) {
-        items = activeWorkflow === "import-backup"
-          ? buildImportValidation(null)
-          : buildValidatePackageValidation(null);
-      } else {
-        items = await validateBackupPackageRemote(fetch, normalizedBackupId);
-      }
+      items = await validateBackupPackageRemote(fetch, normalizedBackupId);
     }
     const result = deriveValidationResult(items);
     setValidationResult(result);
     setWorkflowState("validation");
-  }, [activeWorkflow, normalizedBackupId, selectedSessionId]);
+  }, [activeWorkflow, dedupedBulkSelections, normalizedBackupId, selectedSessionId]);
+
+  const addBulkSelection = useCallback(() => {
+    if (!bulkDraftSessionId.trim() || !bulkDraftSource) return;
+    setBulkSelections((prev) =>
+      dedupeSessionSelections([
+        ...prev,
+        {
+          sessionId: bulkDraftSessionId,
+          source: bulkDraftSource,
+          rootId: bulkDraftRootId || undefined,
+        },
+      ])
+    );
+    setBulkDraftSessionId("");
+    setBulkDraftSource("");
+    setBulkDraftRootId("");
+  }, [bulkDraftRootId, bulkDraftSessionId, bulkDraftSource]);
+
+  const removeBulkSelection = useCallback((selection: BackupSessionSelection) => {
+    const target = `${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`;
+    setBulkSelections((prev) =>
+      prev.filter((item) => `${item.sessionId}:${item.source ?? ""}:${item.rootId ?? ""}` !== target)
+    );
+  }, []);
+
+  const updateBulkSelectionSourceCopy = useCallback((selection: BackupSessionSelection, includeSourceCopy: boolean) => {
+    const target = `${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`;
+    setBulkSelections((prev) =>
+      prev.map((item) =>
+        `${item.sessionId}:${item.source ?? ""}:${item.rootId ?? ""}` === target
+          ? { ...item, includeSourceCopy }
+          : item
+      )
+    );
+  }, []);
+
+  const removeBlockedSelections = useCallback(() => {
+    if (!validationResult) return;
+    const blocked = new Set(getBlockedSessionSelections(validationResult).map((selection) => `${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`));
+    setBulkSelections((prev) => prev.filter((selection) => !blocked.has(`${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`)));
+    setValidationResult(null);
+    setWorkflowState("selection");
+  }, [validationResult]);
 
   const executeSessionBackup = useCallback(async () => {
     if (!selectedSessionId || !selectedSource) return;
@@ -375,6 +530,115 @@ export function BackupMigrationFoundation({
       setIsExecuting(false);
     }
   }, [selectedSessionId, selectedSource, selectedRootId, includeSourceCopy]);
+
+  const executeBulkSessionBackup = useCallback(async () => {
+    if (dedupedBulkSelections.length === 0) return;
+
+    setIsExecuting(true);
+    setExecutionError(null);
+    setWorkflowState("execution");
+
+    const validationWarningsBySelection = new Map<string, string[]>();
+    for (const entry of validationResult?.sessionResults ?? []) {
+      validationWarningsBySelection.set(
+        `${entry.session.sessionId}:${entry.session.source ?? ""}:${entry.session.rootId ?? ""}`,
+        entry.result.items.filter((item) => item.severity === "warning").map((item) => item.detail)
+      );
+    }
+
+    try {
+      const sessionResults: BulkSessionExecutionResult[] = [];
+
+      for (const selection of dedupedBulkSelections) {
+        const warningKey = `${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`;
+        const validationWarnings = validationWarningsBySelection.get(warningKey) ?? [];
+
+        if (!selection.sessionId || !selection.source) {
+          sessionResults.push({
+            sessionId: selection.sessionId || "unresolved-session",
+            source: selection.source,
+            rootId: selection.rootId,
+            status: "failed",
+            summary: "Selected session cannot be backed up because canonical identity or provenance is missing.",
+            error: "Missing canonical session ID or source provenance.",
+          });
+          continue;
+        }
+
+        try {
+          const requestBody = buildSessionBackupExecutionRequest({
+            source: selection.source,
+            sessionId: selection.sessionId,
+            rootId: selection.rootId,
+            includeSourceCopy: selection.includeSourceCopy === true,
+          });
+
+          const response = await fetch("/api/session-backups", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requestBody),
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => ({ error: "Unknown error" }));
+            throw new Error(errorData.error ?? `HTTP ${response.status}`);
+          }
+
+          const data = await response.json();
+          sessionResults.push({
+            sessionId: selection.sessionId,
+            source: selection.source,
+            rootId: selection.rootId,
+            status: validationWarnings.length ? "success-with-warnings" : "success",
+            summary: `Session ${selection.sessionId} backed up successfully.`,
+            backupId: data.backupId,
+            warnings: validationWarnings.length ? validationWarnings : undefined,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          sessionResults.push({
+            sessionId: selection.sessionId,
+            source: selection.source,
+            rootId: selection.rootId,
+            status: "failed",
+            summary: `Session ${selection.sessionId} backup failed.`,
+            warnings: validationWarnings.length ? validationWarnings : undefined,
+            error: message,
+          });
+        }
+      }
+
+      const aggregateStatus = deriveAggregateOperationStatus(sessionResults);
+      const result = createOperationResult({
+        workflowType: "bulk-session-backup",
+        status: aggregateStatus,
+        summary: createBulkOperationSummary(sessionResults),
+        sessionCount: sessionResults.length,
+        sourceCopySummary: summarizeSourceCopyConfiguration(dedupedBulkSelections),
+        warnings: sessionResults.flatMap((entry) => entry.warnings ?? []),
+        sessionResults,
+      });
+
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState(aggregateStatus === "failed" ? "failed" : "result");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setExecutionError(message);
+      const result = createOperationResult({
+        workflowType: "bulk-session-backup",
+        status: "failed",
+        summary: `Bulk session backup failed: ${message}`,
+        sessionCount: dedupedBulkSelections.length,
+        sourceCopySummary: summarizeSourceCopyConfiguration(dedupedBulkSelections),
+      });
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("failed");
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [dedupedBulkSelections, validationResult]);
 
   const executeImport = useCallback(async () => {
     if (!normalizedBackupId) return;
@@ -475,7 +739,7 @@ export function BackupMigrationFoundation({
             <h2 className="text-xl font-semibold">Backup / Migration</h2>
             <p className="max-w-3xl text-sm leading-6 text-muted">
               Choose a bounded workflow below. Each workflow follows explicit selection, validation, and result steps.
-              This foundation does not support bulk backup, migration execution, project bundle packaging, vendor-runtime restore, or cloud sync.
+              This foundation does not support migration preview, project bundle packaging, vendor-runtime restore, or cloud sync.
             </p>
           </div>
         </Card>
@@ -598,6 +862,90 @@ export function BackupMigrationFoundation({
             </Card>
           ) : null}
 
+          {workflowState === "selection" && activeWorkflow === "bulk-session-backup" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Sessions</div>
+              <div className="space-y-4">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Select one or more sessions explicitly before validation. This workflow does not invent a session set from overview, analysis, or asset context.
+                </div>
+                <div className="grid gap-3 md:grid-cols-[minmax(0,1.3fr)_180px_minmax(0,1fr)_auto]">
+                  <label className="grid gap-1 text-sm">
+                    <span className="text-xs uppercase tracking-[0.18em] text-muted">Session ID</span>
+                    <input
+                      type="text"
+                      value={bulkDraftSessionId}
+                      onChange={(e) => setBulkDraftSessionId(e.target.value)}
+                      placeholder="Enter session ID"
+                      className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                    />
+                  </label>
+                  <label className="grid gap-1 text-sm">
+                    <span className="text-xs uppercase tracking-[0.18em] text-muted">Source</span>
+                    <select
+                      value={bulkDraftSource}
+                      onChange={(e) => setBulkDraftSource((e.target.value as Source | "") ?? "")}
+                      className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                    >
+                      <option value="">Choose source</option>
+                      <option value="antigravity">Antigravity</option>
+                      <option value="windsurf">Windsurf</option>
+                      <option value="codex">Codex</option>
+                    </select>
+                  </label>
+                  <label className="grid gap-1 text-sm">
+                    <span className="text-xs uppercase tracking-[0.18em] text-muted">Root ID (optional)</span>
+                    <input
+                      type="text"
+                      value={bulkDraftRootId}
+                      onChange={(e) => setBulkDraftRootId(e.target.value)}
+                      placeholder="Optional root ID"
+                      className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                    />
+                  </label>
+                  <div className="flex items-end">
+                    <Button size="sm" onClick={addBulkSelection} disabled={!bulkDraftSessionId.trim() || !bulkDraftSource}>
+                      Add session
+                    </Button>
+                  </div>
+                </div>
+                {dedupedBulkSelections.length > 0 ? (
+                  <div className="space-y-2">
+                    {dedupedBulkSelections.map((selection) => (
+                      <div key={`${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <div className="font-medium">{selection.sessionId || "unresolved-session"}</div>
+                            <div className="text-xs text-muted">
+                              {selection.source ?? "unknown-source"}
+                              {selection.rootId ? ` / ${selection.rootId}` : ""}
+                            </div>
+                            {selection.unresolvedReason ? (
+                              <div className="mt-1 text-xs text-muted">{selection.unresolvedReason}</div>
+                            ) : null}
+                          </div>
+                          <Button size="sm" variant="outline" onClick={() => removeBulkSelection(selection)}>
+                            Remove
+                          </Button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-xl border border-amber-400/25 bg-amber-400/8 px-3 py-3 text-sm text-muted">
+                    No sessions selected yet.
+                  </div>
+                )}
+                {activeHandoff?.origin === "sessions" && dedupedBulkSelections.length > 0 ? (
+                  <div className="text-xs text-muted">Pre-selected from routed handoff.</div>
+                ) : null}
+                <Button size="sm" disabled={dedupedBulkSelections.length === 0} onClick={advanceState}>
+                  Continue to Configuration
+                </Button>
+              </div>
+            </Card>
+          ) : null}
+
           {workflowState === "selection" && (activeWorkflow === "import-backup" || activeWorkflow === "validate-package") ? (
             <Card className="p-4">
               <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Package</div>
@@ -663,10 +1011,87 @@ export function BackupMigrationFoundation({
             </Card>
           ) : null}
 
+          {workflowState === "configuration" && activeWorkflow === "bulk-session-backup" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Configure Batch</div>
+              <div className="space-y-3">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Configure source copy per selected session. Source copy remains opt-in and only eligible sessions can actually include it.
+                </div>
+                <div className="space-y-2">
+                  {dedupedBulkSelections.map((selection) => {
+                    const canSourceCopy = selection.source === "codex";
+                    return (
+                      <div key={`${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <div className="font-medium">{selection.sessionId}</div>
+                            <div className="text-xs text-muted">
+                              {selection.source ?? "unknown-source"}
+                              {selection.rootId ? ` / ${selection.rootId}` : ""}
+                            </div>
+                          </div>
+                          <label className="flex items-center gap-2 text-sm">
+                            <input
+                              type="checkbox"
+                              checked={canSourceCopy ? selection.includeSourceCopy === true : false}
+                              disabled={!canSourceCopy}
+                              onChange={(e) => updateBulkSelectionSourceCopy(selection, e.target.checked)}
+                            />
+                            <span className={!canSourceCopy ? "text-muted" : undefined}>Include source copy</span>
+                          </label>
+                        </div>
+                        {!canSourceCopy ? (
+                          <div className="mt-2 text-xs text-muted">
+                            Source copy is unavailable for this source. Backup will preserve the canonical record only.
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  {bulkConfirmationDetails.sourceCopySummary}
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={retreatState}>
+                    Back
+                  </Button>
+                  <Button size="sm" onClick={runValidation}>
+                    Validate
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
           {/* Validation */}
           {workflowState === "validation" && validationResult ? (
             <div className="space-y-4">
               <ValidationPanel result={validationResult} />
+              {activeWorkflow === "bulk-session-backup" && (validationResult.sessionResults?.length ?? 0) > 0 ? (
+                <Card className="p-4">
+                  <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Per-session eligibility</div>
+                  <div className="space-y-2">
+                    {validationResult.sessionResults!.map((entry) => (
+                      <div key={`${entry.session.sessionId}:${entry.session.source ?? ""}:${entry.session.rootId ?? ""}`} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <div>
+                            <div className="font-medium">{entry.session.sessionId || "unresolved-session"}</div>
+                            <div className="text-xs text-muted">
+                              {entry.session.source ?? "unknown-source"}
+                              {entry.session.rootId ? ` / ${entry.session.rootId}` : ""}
+                            </div>
+                          </div>
+                          <Badge variant={entry.result.status === "valid" ? "ok" : entry.result.status === "invalid" ? "warn" : "default"}>
+                            {entry.result.status}
+                          </Badge>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              ) : null}
               <div className="flex flex-wrap gap-2">
                 <Button size="sm" variant="outline" onClick={retreatState}>
                   Back
@@ -679,6 +1104,13 @@ export function BackupMigrationFoundation({
                   <Button size="sm" onClick={advanceState}>
                     Proceed to Confirmation
                   </Button>
+                ) : activeWorkflow === "bulk-session-backup" ? (
+                  <>
+                    <Button size="sm" variant="outline" onClick={removeBlockedSelections}>
+                      Remove blocked selections
+                    </Button>
+                    <div className="text-sm text-muted">Resolve blocking sessions before proceeding.</div>
+                  </>
                 ) : (
                   <div className="text-sm text-muted">Resolve blocking issues before proceeding.</div>
                 )}
@@ -704,6 +1136,30 @@ export function BackupMigrationFoundation({
                     <div className="font-medium">Import backup package {normalizedBackupId}</div>
                   </div>
                 ) : null}
+                {activeWorkflow === "bulk-session-backup" ? (
+                  <div className="space-y-3">
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                        <div className="text-xs text-muted">Selected count</div>
+                        <div className="mt-1 font-medium">{bulkConfirmationDetails.selectedCount}</div>
+                      </div>
+                      <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                        <div className="text-xs text-muted">Warnings</div>
+                        <div className="mt-1 font-medium">{bulkConfirmationDetails.warningCount}</div>
+                      </div>
+                      <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                        <div className="text-xs text-muted">Execution</div>
+                        <div className="mt-1 font-medium">Sequential fan-out</div>
+                      </div>
+                    </div>
+                    <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                      {bulkConfirmationDetails.sourceCopySummary}
+                    </div>
+                    <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                      {bulkConfirmationDetails.executionSemantics}
+                    </div>
+                  </div>
+                ) : null}
                 <div className="rounded-xl border border-amber-400/35 bg-amber-400/10 px-3 py-3 text-sm text-muted">
                   <span className="font-medium text-foreground">Preservation notice:</span>{" "}
                   {activeWorkflow === "import-backup"
@@ -722,7 +1178,7 @@ export function BackupMigrationFoundation({
                   <Button
                     size="sm"
                     disabled={isExecuting}
-                    onClick={activeWorkflow === "session-backup" ? executeSessionBackup : executeImport}
+                    onClick={activeWorkflow === "session-backup" ? executeSessionBackup : activeWorkflow === "bulk-session-backup" ? executeBulkSessionBackup : executeImport}
                   >
                     {isExecuting ? "Executing…" : "Execute"}
                   </Button>
@@ -763,6 +1219,13 @@ export function BackupMigrationFoundation({
                   <div className="text-xs text-muted">Session</div>
                   <div className="font-medium">{selectedSessionId}</div>
                   {selectedSource ? <div className="text-xs text-muted">{selectedSource}</div> : null}
+                </div>
+              ) : null}
+              {activeWorkflow === "bulk-session-backup" ? (
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-2">
+                  <div className="text-xs text-muted">Selected sessions</div>
+                  <div className="font-medium">{dedupedBulkSelections.length}</div>
+                  <div className="mt-1 text-xs text-muted">{bulkConfirmationDetails.sourceCopySummary}</div>
                 </div>
               ) : null}
               {normalizedBackupId && activeWorkflow !== "session-backup" ? (

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import AnalysisFoundation from "@/components/AnalysisFoundation";
 import AssetsFoundation from "@/components/AssetsFoundation";
 import BackupMigrationFoundation from "@/components/BackupMigrationFoundation";
-import { buildBackupHandoffInstanceKey, type BackupMigrationHandoff, type BackupWorkflowType } from "@/lib/backupMigration";
+import { buildBackupHandoffInstanceKey, type BackupMigrationHandoff, type BackupWorkflowType, type BackupSessionSelection } from "@/lib/backupMigration";
 import HomeClient, { type HomeClientAssetHandoff, type HomeClientExternalSelection, type HomeClientSessionHandoff } from "@/components/HomeClient";
 import { GlobalSearch } from "@/components/GlobalSearch";
 import { Badge } from "@/components/ui/badge";
@@ -253,10 +253,22 @@ export function buildBackupHandoffFromAnalysis(context: {
 }
 
 export function buildBackupHandoffFromSessions(context: {
-  sessionId: string;
-  source: Source;
+  sessionId?: string;
+  source?: Source;
   rootId?: string;
+  sessions?: BackupSessionSelection[];
 }): BackupMigrationHandoff {
+  if ((context.sessions?.length ?? 0) > 0) {
+    return {
+      origin: "sessions",
+      subtitle: `Back up ${context.sessions!.length} selected session${context.sessions!.length === 1 ? "" : "s"} from Sessions.`,
+      continueLabel: "Use the bulk session backup workflow to preserve the selected session set.",
+      returnLabel: "Return to Sessions for evidence review.",
+      workflowType: "bulk-session-backup",
+      sessions: context.sessions,
+    };
+  }
+
   return {
     origin: "sessions",
     subtitle: `Back up session ${context.sessionId} from Sessions.`,
@@ -272,6 +284,7 @@ export function buildBackupHandoffFromSessions(context: {
 export function buildBackupHandoffFromOverview(workflowType: BackupWorkflowType): BackupMigrationHandoff {
   const subtitles = {
     "session-backup": "Start a bounded session backup workflow from Project Overview.",
+    "bulk-session-backup": "Start a bounded bulk session backup workflow from Project Overview.",
     "import-backup": "Start a bounded import workflow from Project Overview.",
     "validate-package": "Start a bounded package validation workflow from Project Overview.",
   } satisfies Record<BackupWorkflowType, string>;
@@ -455,6 +468,14 @@ function ProjectOverviewSurface(props: {
             onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("session-backup"))}
           >
             Start session backup
+          </Button>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("bulk-session-backup"))}
+          >
+            Start bulk session backup
           </Button>
           <Button
             className="w-full justify-start"

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -2,7 +2,7 @@ import type { Source } from "@/lib/types";
 
 // ── Workflow types ──────────────────────────────────────────────────────────
 
-export const BACKUP_WORKFLOW_TYPES = ["session-backup", "import-backup", "validate-package"] as const;
+export const BACKUP_WORKFLOW_TYPES = ["session-backup", "bulk-session-backup", "import-backup", "validate-package"] as const;
 export type BackupWorkflowType = (typeof BACKUP_WORKFLOW_TYPES)[number];
 
 export const BACKUP_WORKFLOW_STATES = [
@@ -31,6 +31,23 @@ export type BackupValidationItem = {
 export type BackupValidationResult = {
   status: "valid" | "valid-with-warnings" | "invalid";
   items: BackupValidationItem[];
+  sessionResults?: BulkSessionValidationEntry[];
+  selectedCount?: number;
+  warningCount?: number;
+  blockCount?: number;
+};
+
+export type BackupSessionSelection = {
+  sessionId: string;
+  source?: Source;
+  rootId?: string;
+  includeSourceCopy?: boolean;
+  unresolvedReason?: string;
+};
+
+export type BulkSessionValidationEntry = {
+  session: BackupSessionSelection;
+  result: BackupValidationResult;
 };
 
 export type BackupPackageVerifySuccess = {
@@ -65,6 +82,19 @@ export type BackupOperationResult = {
   backupId?: string;
   sessionCount?: number;
   warnings?: string[];
+  sourceCopySummary?: string;
+  sessionResults?: BulkSessionExecutionResult[];
+};
+
+export type BulkSessionExecutionResult = {
+  sessionId: string;
+  source?: Source;
+  rootId?: string;
+  status: BackupOperationStatus;
+  summary: string;
+  backupId?: string;
+  warnings?: string[];
+  error?: string;
 };
 
 export type SessionBackupExecutionRequest = {
@@ -89,6 +119,7 @@ export type BackupMigrationHandoff = {
   returnLabel?: string;
   workflowType?: BackupWorkflowType;
   sessionId?: string;
+  sessions?: BackupSessionSelection[];
   source?: Source;
   rootId?: string;
   assetId?: string;
@@ -115,6 +146,12 @@ export const WORKFLOW_DESCRIPTORS: BackupWorkflowDescriptor[] = [
     stepsLabel: ["Select session", "Configure", "Validate", "Confirm", "Execute", "Result"],
   },
   {
+    type: "bulk-session-backup",
+    label: "Bulk Session Backup",
+    description: "Preserve an explicit set of selected sessions. Each selected session is validated independently before batch confirmation.",
+    stepsLabel: ["Select sessions", "Configure", "Validate", "Confirm", "Execute", "Result"],
+  },
+  {
     type: "import-backup",
     label: "Import Backup",
     description: "Import an existing session-backup package. Validates schema, integrity, and provenance before acceptance.",
@@ -137,6 +174,7 @@ export function getWorkflowDescriptor(type: BackupWorkflowType): BackupWorkflowD
 export function formatWorkflowTypeLabel(type: BackupWorkflowType): string {
   const labels: Record<BackupWorkflowType, string> = {
     "session-backup": "Session Backup",
+    "bulk-session-backup": "Bulk Session Backup",
     "import-backup": "Import Backup",
     "validate-package": "Validate Package",
   };
@@ -160,6 +198,7 @@ export function formatWorkflowStateLabel(state: BackupWorkflowState): string {
 export function getStepsForWorkflow(type: BackupWorkflowType): BackupWorkflowState[] {
   switch (type) {
     case "session-backup":
+    case "bulk-session-backup":
       return ["selection", "configuration", "validation", "confirmation", "execution", "result"];
     case "import-backup":
       return ["selection", "validation", "confirmation", "execution", "result"];
@@ -206,6 +245,195 @@ export function deriveValidationResult(items: BackupValidationItem[]): BackupVal
 
 export function canProceedFromValidation(result: BackupValidationResult): boolean {
   return result.status !== "invalid";
+}
+
+export function normalizeSessionSelection(input: BackupSessionSelection): BackupSessionSelection {
+  return {
+    sessionId: input.sessionId.trim(),
+    source: input.source,
+    rootId: input.rootId?.trim() || undefined,
+    includeSourceCopy: input.includeSourceCopy === true,
+    unresolvedReason: input.unresolvedReason?.trim() || undefined,
+  };
+}
+
+export function formatSessionSelectionLabel(selection: BackupSessionSelection): string {
+  const normalized = normalizeSessionSelection(selection);
+  const sourceLabel = normalized.source ?? "unknown-source";
+  const sessionLabel = normalized.sessionId || "unresolved-session";
+  return normalized.rootId ? `${sourceLabel}:${sessionLabel}:${normalized.rootId}` : `${sourceLabel}:${sessionLabel}`;
+}
+
+export function dedupeSessionSelections(selections: BackupSessionSelection[]): BackupSessionSelection[] {
+  const seen = new Set<string>();
+  const deduped: BackupSessionSelection[] = [];
+
+  for (const selection of selections.map(normalizeSessionSelection)) {
+    const key = formatSessionSelectionLabel(selection);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(selection);
+  }
+
+  return deduped;
+}
+
+export function summarizeSourceCopyConfiguration(selections: BackupSessionSelection[]): string {
+  const normalized = dedupeSessionSelections(selections);
+  const requestedCount = normalized.filter((selection) => selection.includeSourceCopy).length;
+
+  if (normalized.length === 0 || requestedCount === 0) {
+    return "Canonical record only. Source copy is not requested for this batch.";
+  }
+
+  return `Source copy requested for ${requestedCount} of ${normalized.length} selected session${normalized.length === 1 ? "" : "s"}.`;
+}
+
+function buildBulkValidationItemsForSelection(selection: BackupSessionSelection): BackupValidationItem[] {
+  const normalized = normalizeSessionSelection(selection);
+  const items: BackupValidationItem[] = [];
+
+  if (!normalized.sessionId) {
+    items.push({
+      id: "v-session-id-missing",
+      label: "Canonical record availability",
+      severity: "block",
+      detail: "This selected item has no canonical session ID. Remove it from the batch or repair the source selection.",
+    });
+  } else if (normalized.unresolvedReason) {
+    items.push({
+      id: "v-canonical-unavailable",
+      label: "Canonical record availability",
+      severity: "block",
+      detail: normalized.unresolvedReason,
+    });
+  } else {
+    items.push({
+      id: "v-canonical-available",
+      label: "Canonical record availability",
+      severity: "ok",
+      detail: `Canonical record for ${normalized.sessionId} is available for backup packaging.`,
+    });
+  }
+
+  if (!normalized.source) {
+    items.push({
+      id: "v-provenance-missing",
+      label: "Provenance",
+      severity: "block",
+      detail: "Source provenance is missing for this selected session. Remove it from the batch or route it again from Sessions with explicit source context.",
+    });
+  } else {
+    items.push({
+      id: "v-provenance-present",
+      label: "Provenance",
+      severity: "ok",
+      detail: normalized.rootId
+        ? `Source ${normalized.source} / root ${normalized.rootId} is traceable.`
+        : `Source ${normalized.source} is traceable.`,
+    });
+  }
+
+  if (normalized.includeSourceCopy) {
+    if (normalized.source === "codex" && !normalized.unresolvedReason && normalized.sessionId) {
+      items.push({
+        id: "v-source-copy-ready",
+        label: "Source-copy readiness",
+        severity: "ok",
+        detail: "Source copy can be requested for this Codex session backup.",
+      });
+    } else {
+      items.push({
+        id: "v-source-copy-unavailable",
+        label: "Source-copy readiness",
+        severity: "warning",
+        detail: "Source copy remains opt-in and is unavailable for this selected session. The batch can continue with canonical-record backup only.",
+      });
+    }
+  }
+
+  return items;
+}
+
+export function buildBulkSessionValidationResult(selections: BackupSessionSelection[]): BackupValidationResult {
+  const normalizedSelections = dedupeSessionSelections(selections);
+
+  if (normalizedSelections.length === 0) {
+    return {
+      status: "invalid",
+      items: [
+        {
+          id: "v-no-bulk-selection",
+          label: "No sessions selected",
+          severity: "block",
+          detail: "Select one or more sessions before validation.",
+        },
+      ],
+      sessionResults: [],
+      selectedCount: 0,
+      warningCount: 0,
+      blockCount: 1,
+    };
+  }
+
+  const sessionResults = normalizedSelections.map((selection) => {
+    const items = buildBulkValidationItemsForSelection(selection);
+    return {
+      session: selection,
+      result: deriveValidationResult(items),
+    } satisfies BulkSessionValidationEntry;
+  });
+
+  const items = sessionResults.flatMap((entry) =>
+    entry.result.items.map((item) => ({
+      ...item,
+      id: `${formatSessionSelectionLabel(entry.session)}:${item.id}`,
+      label: `${entry.session.sessionId || "unresolved session"} — ${item.label}`,
+    }))
+  );
+  const warningCount = items.filter((item) => item.severity === "warning").length;
+  const blockCount = items.filter((item) => item.severity === "block").length;
+
+  return {
+    ...deriveValidationResult(items),
+    sessionResults,
+    selectedCount: normalizedSelections.length,
+    warningCount,
+    blockCount,
+  };
+}
+
+export function getBlockedSessionSelections(result: BackupValidationResult): BackupSessionSelection[] {
+  return (result.sessionResults ?? [])
+    .filter((entry) => entry.result.status === "invalid")
+    .map((entry) => entry.session);
+}
+
+export function deriveAggregateOperationStatus(results: BulkSessionExecutionResult[]): BackupOperationStatus {
+  if (results.length === 0) return "failed";
+
+  const successCount = results.filter((result) => result.status === "success").length;
+  const failedCount = results.filter((result) => result.status === "failed").length;
+  const warnedCount = results.filter((result) => result.status === "success-with-warnings").length;
+
+  if (successCount === 0 && warnedCount === 0) return "failed";
+  if (failedCount > 0 || warnedCount > 0) return "success-with-warnings";
+  return "success";
+}
+
+export function createBulkOperationSummary(results: BulkSessionExecutionResult[]): string {
+  const successCount = results.filter((result) => result.status !== "failed").length;
+  const failedCount = results.filter((result) => result.status === "failed").length;
+
+  if (results.length === 0 || successCount === 0) {
+    return `Bulk session backup failed for ${results.length} selected session${results.length === 1 ? "" : "s"}.`;
+  }
+
+  if (failedCount > 0) {
+    return `Backed up ${successCount} of ${results.length} selected session${results.length === 1 ? "" : "s"}.`;
+  }
+
+  return `Backed up ${results.length} selected session${results.length === 1 ? "" : "s"} successfully.`;
 }
 
 export function buildPackageValidationItems(input: {
@@ -273,6 +501,8 @@ export function createOperationResult(input: {
   backupId?: string;
   sessionCount?: number;
   warnings?: string[];
+  sourceCopySummary?: string;
+  sessionResults?: BulkSessionExecutionResult[];
 }): BackupOperationResult {
   operationCounter += 1;
   return {
@@ -284,6 +514,8 @@ export function createOperationResult(input: {
     backupId: input.backupId,
     sessionCount: input.sessionCount,
     warnings: input.warnings,
+    sourceCopySummary: input.sourceCopySummary,
+    sessionResults: input.sessionResults,
   };
 }
 
@@ -375,6 +607,7 @@ export function resolveWorkflowFromHandoff(
   }
 
   // Infer from context
+  if ((handoff.sessions?.length ?? 0) > 1) return "bulk-session-backup";
   if (handoff.sessionId) return "session-backup";
   if (handoff.origin === "overview") return null; // overview routes to selector
   if (handoff.findingId && handoff.preservationWarning) return "session-backup";
@@ -390,6 +623,7 @@ export function buildBackupHandoffInstanceKey(handoff: BackupMigrationHandoff | 
     handoff.origin,
     handoff.workflowType ?? "no-workflow",
     handoff.sessionId ?? "no-session",
+    handoff.sessions?.map(formatSessionSelectionLabel).join("|") ?? "no-sessions",
     handoff.source ?? "no-source",
     handoff.rootId ?? "no-root",
     handoff.assetId ?? "no-asset",

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import {
   addRecentOperation,
+  buildBulkSessionValidationResult,
   buildPackageValidationItems,
   buildBackupHandoffInstanceKey,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
+  createBulkOperationSummary,
   createOperationResult,
+  dedupeSessionSelections,
+  deriveAggregateOperationStatus,
   deriveValidationResult,
   formatWorkflowStateLabel,
   formatWorkflowTypeLabel,
@@ -38,6 +42,7 @@ describe("getWorkflowDescriptor", () => {
 describe("formatWorkflowTypeLabel", () => {
   it("returns a human-readable label", () => {
     expect(formatWorkflowTypeLabel("session-backup")).toBe("Session Backup");
+    expect(formatWorkflowTypeLabel("bulk-session-backup")).toBe("Bulk Session Backup");
     expect(formatWorkflowTypeLabel("import-backup")).toBe("Import Backup");
     expect(formatWorkflowTypeLabel("validate-package")).toBe("Validate Package");
   });
@@ -55,6 +60,11 @@ describe("formatWorkflowStateLabel", () => {
 describe("getStepsForWorkflow", () => {
   it("returns steps for session-backup", () => {
     const steps = getStepsForWorkflow("session-backup");
+    expect(steps).toEqual(["selection", "configuration", "validation", "confirmation", "execution", "result"]);
+  });
+
+  it("returns steps for bulk-session-backup", () => {
+    const steps = getStepsForWorkflow("bulk-session-backup");
     expect(steps).toEqual(["selection", "configuration", "validation", "confirmation", "execution", "result"]);
   });
 
@@ -167,6 +177,99 @@ describe("createOperationResult", () => {
     const r1 = createOperationResult({ workflowType: "session-backup", status: "success", summary: "A" });
     const r2 = createOperationResult({ workflowType: "import-backup", status: "failed", summary: "B" });
     expect(r1.id).not.toBe(r2.id);
+  });
+
+  it("retains bulk metadata when provided", () => {
+    const result = createOperationResult({
+      workflowType: "bulk-session-backup",
+      status: "success-with-warnings",
+      summary: "Backed up 2 of 3 selected sessions.",
+      sessionCount: 3,
+      sourceCopySummary: "Source copy requested for 1 of 3 selected sessions.",
+      sessionResults: [
+        {
+          sessionId: "session-1",
+          source: "codex",
+          status: "success",
+          summary: "Session session-1 backed up successfully.",
+        },
+      ],
+    });
+
+    expect(result.workflowType).toBe("bulk-session-backup");
+    expect(result.sessionCount).toBe(3);
+    expect(result.sourceCopySummary).toContain("Source copy requested");
+    expect(result.sessionResults).toHaveLength(1);
+  });
+});
+
+describe("bulk session backup helpers", () => {
+  it("dedupes repeated session selections", () => {
+    expect(
+      dedupeSessionSelections([
+        { sessionId: "session-1", source: "codex", rootId: "root-a" },
+        { sessionId: "session-1", source: "codex", rootId: "root-a" },
+        { sessionId: "session-2", source: "windsurf" },
+      ])
+    ).toEqual([
+      { sessionId: "session-1", source: "codex", rootId: "root-a", includeSourceCopy: false, unresolvedReason: undefined },
+      { sessionId: "session-2", source: "windsurf", rootId: undefined, includeSourceCopy: false, unresolvedReason: undefined },
+    ]);
+  });
+
+  it("builds invalid validation result when no sessions are selected", () => {
+    const result = buildBulkSessionValidationResult([]);
+    expect(result.status).toBe("invalid");
+    expect(result.selectedCount).toBe(0);
+    expect(result.blockCount).toBe(1);
+  });
+
+  it("surfaces warnings and blocks per selected session", () => {
+    const result = buildBulkSessionValidationResult([
+      { sessionId: "session-1", source: "codex", includeSourceCopy: true },
+      { sessionId: "session-2", source: "windsurf", includeSourceCopy: true },
+      { sessionId: "", unresolvedReason: "Canonical record is missing." },
+    ]);
+
+    expect(result.status).toBe("invalid");
+    expect(result.selectedCount).toBe(3);
+    expect(result.warningCount).toBeGreaterThan(0);
+    expect(result.blockCount).toBeGreaterThan(0);
+    expect(result.sessionResults).toHaveLength(3);
+  });
+
+  it("derives aggregate success-with-warnings for mixed batch results", () => {
+    expect(
+      deriveAggregateOperationStatus([
+        { sessionId: "session-1", status: "success", summary: "ok" },
+        { sessionId: "session-2", status: "failed", summary: "failed" },
+      ])
+    ).toBe("success-with-warnings");
+  });
+
+  it("derives full failure when every session fails", () => {
+    expect(
+      deriveAggregateOperationStatus([
+        { sessionId: "session-1", status: "failed", summary: "failed" },
+        { sessionId: "session-2", status: "failed", summary: "failed" },
+      ])
+    ).toBe("failed");
+  });
+
+  it("creates aggregate batch summaries", () => {
+    expect(
+      createBulkOperationSummary([
+        { sessionId: "session-1", status: "success", summary: "ok" },
+        { sessionId: "session-2", status: "success", summary: "ok" },
+      ])
+    ).toContain("2 selected sessions successfully");
+
+    expect(
+      createBulkOperationSummary([
+        { sessionId: "session-1", status: "success", summary: "ok" },
+        { sessionId: "session-2", status: "failed", summary: "failed" },
+      ])
+    ).toContain("1 of 2 selected sessions");
   });
 });
 
@@ -361,6 +464,18 @@ describe("resolveWorkflowFromHandoff", () => {
     expect(resolveWorkflowFromHandoff(handoff)).toBe("session-backup");
   });
 
+  it("infers bulk-session-backup when routed sessions are present", () => {
+    const handoff: BackupMigrationHandoff = {
+      origin: "sessions",
+      subtitle: "Bulk backup routed from Sessions.",
+      sessions: [
+        { sessionId: "session-1", source: "codex" },
+        { sessionId: "session-2", source: "windsurf" },
+      ],
+    };
+    expect(resolveWorkflowFromHandoff(handoff)).toBe("bulk-session-backup");
+  });
+
   it("infers session-backup from preservation finding", () => {
     const handoff: BackupMigrationHandoff = {
       origin: "analysis",
@@ -396,6 +511,23 @@ describe("buildBackupHandoffInstanceKey", () => {
       origin: "analysis",
       subtitle: "Test",
       findingId: "finding-1",
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it("changes when bulk routed session sets change", () => {
+    const first = buildBackupHandoffInstanceKey({
+      origin: "sessions",
+      subtitle: "Bulk backup routed from Sessions.",
+      workflowType: "bulk-session-backup",
+      sessions: [{ sessionId: "session-1", source: "codex" }],
+    });
+    const second = buildBackupHandoffInstanceKey({
+      origin: "sessions",
+      subtitle: "Bulk backup routed from Sessions.",
+      workflowType: "bulk-session-backup",
+      sessions: [{ sessionId: "session-2", source: "codex" }],
     });
 
     expect(first).not.toBe(second);

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { BackupMigrationFoundation } from "@/components/BackupMigrationFoundation";
+import {
+  BackupMigrationFoundation,
+  buildBulkConfirmationDetails,
+  resolveInitialBulkSelections,
+  OperationResultPanel,
+  ValidationPanel,
+} from "@/components/BackupMigrationFoundation";
 import type { BackupMigrationHandoff } from "@/lib/backupMigration";
 
 function renderBackupMigrationFoundation(handoff: BackupMigrationHandoff | null) {
@@ -15,6 +21,64 @@ function renderBackupMigrationFoundation(handoff: BackupMigrationHandoff | null)
   );
 }
 
+function renderValidationPanel() {
+  return renderToStaticMarkup(
+    <ValidationPanel
+      result={{
+        status: "invalid",
+        items: [
+          {
+            id: "session-1-warning",
+            label: "session-1 — Source-copy readiness",
+            severity: "warning",
+            detail: "Source copy is unavailable for this selected session.",
+          },
+          {
+            id: "session-2-block",
+            label: "session-2 — Canonical record availability",
+            severity: "block",
+            detail: "Canonical record is missing.",
+          },
+        ],
+      }}
+    />
+  );
+}
+
+function renderOperationResultPanel() {
+  return renderToStaticMarkup(
+    <OperationResultPanel
+      result={{
+        id: "op-bulk-1",
+        workflowType: "bulk-session-backup",
+        status: "success-with-warnings",
+        timestamp: "2026-04-15T12:00:00Z",
+        summary: "Backed up 1 of 2 selected sessions.",
+        sessionCount: 2,
+        sourceCopySummary: "Source copy requested for 1 of 2 selected sessions.",
+        sessionResults: [
+          {
+            sessionId: "session-1",
+            source: "codex",
+            rootId: "root-a",
+            status: "success",
+            summary: "Session session-1 backed up successfully.",
+            backupId: "backup-1",
+          },
+          {
+            sessionId: "session-2",
+            source: "windsurf",
+            status: "failed",
+            summary: "Session session-2 backup failed.",
+            error: "Canonical record could not be read.",
+          },
+        ],
+      }}
+      onNewWorkflow={vi.fn()}
+    />
+  );
+}
+
 describe("BackupMigrationFoundation", () => {
   it("renders idle workflow selector without unimplemented workflows", () => {
     const html = renderBackupMigrationFoundation(null);
@@ -22,9 +86,10 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("Backup / Migration");
     expect(html).toContain("Choose a bounded workflow below.");
     expect(html).toContain("Start Session Backup");
+    expect(html).toContain("Start Bulk Session Backup");
     expect(html).toContain("Start Import Backup");
     expect(html).toContain("Start Validate Package");
-    expect(html).toContain("does not support bulk backup, migration execution, project bundle packaging");
+    expect(html).toContain("does not support migration preview, project bundle packaging, vendor-runtime restore, or cloud sync");
   });
 
   it("renders routed session-backup workflow with prefilling context", () => {
@@ -76,5 +141,85 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("Validate Package");
     expect(html).toContain("Select Package");
     expect(html).not.toContain("Choose a bounded workflow below.");
+  });
+
+  it("renders routed bulk-session-backup workflow with preselected sessions", () => {
+    const html = renderBackupMigrationFoundation({
+      origin: "sessions",
+      subtitle: "Back up 2 selected sessions from Sessions.",
+      workflowType: "bulk-session-backup",
+      sessions: [
+        { sessionId: "session-1", source: "codex", rootId: "root-a" },
+        { sessionId: "session-2", source: "windsurf" },
+      ],
+      continueLabel: "Use the bulk session backup workflow to preserve the selected session set.",
+      returnLabel: "Return to Sessions for evidence review.",
+    });
+
+    expect(html).toContain("Bulk Session Backup");
+    expect(html).toContain("Select Sessions");
+    expect(html).toContain("session-1");
+    expect(html).toContain("session-2");
+    expect(html).toContain("Pre-selected from routed handoff.");
+  });
+});
+
+describe("BackupMigrationFoundation helpers", () => {
+  it("resolves initial bulk selections from routed handoff sessions", () => {
+    expect(
+      resolveInitialBulkSelections({
+        origin: "sessions",
+        subtitle: "Back up 2 selected sessions from Sessions.",
+        workflowType: "bulk-session-backup",
+        sessions: [
+          { sessionId: "session-1", source: "codex", rootId: "root-a" },
+          { sessionId: "session-1", source: "codex", rootId: "root-a" },
+          { sessionId: "session-2", source: "windsurf" },
+        ],
+      })
+    ).toEqual([
+      { sessionId: "session-1", source: "codex", rootId: "root-a", includeSourceCopy: false, unresolvedReason: undefined },
+      { sessionId: "session-2", source: "windsurf", rootId: undefined, includeSourceCopy: false, unresolvedReason: undefined },
+    ]);
+  });
+
+  it("builds bulk confirmation details with count, warning count, and execution semantics", () => {
+    const details = buildBulkConfirmationDetails({
+      selections: [
+        { sessionId: "session-1", source: "codex", includeSourceCopy: true },
+        { sessionId: "session-2", source: "windsurf" },
+      ],
+      validationResult: {
+        status: "valid-with-warnings",
+        items: [{ id: "warning-1", label: "Source-copy readiness", severity: "warning", detail: "Unavailable for session-2." }],
+        warningCount: 1,
+      },
+    });
+
+    expect(details.selectedCount).toBe(2);
+    expect(details.warningCount).toBe(1);
+    expect(details.sourceCopySummary).toContain("1 of 2 selected sessions");
+    expect(details.executionSemantics).toContain("existing session-backup behavior once per selected session");
+  });
+});
+
+describe("BackupMigrationFoundation panels", () => {
+  it("renders blocked and warning validation items for bulk selection", () => {
+    const html = renderValidationPanel();
+
+    expect(html).toContain("Validation");
+    expect(html).toContain("invalid");
+    expect(html).toContain("Source-copy readiness");
+    expect(html).toContain("Canonical record availability");
+  });
+
+  it("renders partial-failure bulk result details with per-session rows", () => {
+    const html = renderOperationResultPanel();
+
+    expect(html).toContain("Operation Result");
+    expect(html).toContain("Backed up 1 of 2 selected sessions.");
+    expect(html).toContain("Per-session results");
+    expect(html).toContain("backup-1");
+    expect(html).toContain("Canonical record could not be read.");
   });
 });

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -321,6 +321,25 @@ describe("backup handoff builders", () => {
     expect(handoff.subtitle).toContain("session-1");
   });
 
+  it("builds a sessions handoff for explicit multi-session selection", () => {
+    const handoff = buildBackupHandoffFromSessions({
+      sessions: [
+        { sessionId: "session-1", source: "codex", rootId: "root-a" },
+        { sessionId: "session-2", source: "windsurf" },
+      ],
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "sessions",
+      workflowType: "bulk-session-backup",
+      sessions: [
+        { sessionId: "session-1", source: "codex", rootId: "root-a" },
+        { sessionId: "session-2", source: "windsurf" },
+      ],
+    });
+    expect(handoff.subtitle).toContain("2 selected sessions");
+  });
+
   it("builds an assets handoff without carrying asset-viewer state", () => {
     const handoff = buildBackupHandoffFromAssets({
       assetId: "asset-skill-global-generated",
@@ -361,5 +380,17 @@ describe("backup handoff builders", () => {
     });
     expect(handoff).not.toHaveProperty("sessionId");
     expect(handoff.subtitle).toContain("import workflow");
+  });
+
+  it("builds an overview handoff for bulk session backup without invented sessions", () => {
+    const handoff = buildBackupHandoffFromOverview("bulk-session-backup");
+
+    expect(handoff).toMatchObject({
+      origin: "overview",
+      workflowType: "bulk-session-backup",
+    });
+    expect(handoff).not.toHaveProperty("sessionId");
+    expect(handoff).not.toHaveProperty("sessions");
+    expect(handoff.subtitle).toContain("bulk session backup workflow");
   });
 });


### PR DESCRIPTION
## Summary

- Add bounded `bulk-session-backup` workflow to `Backup / Migration`.
- Support explicit multi-session selection, per-session validation, batch confirmation, aggregate result reporting, and compact recent operations.
- Reuse the existing single-session backup execution path for sequential fan-out; no new batch backend API or grouped package format.
- Add compatible handoff support for explicit `Sessions` multi-session sets and `Project Overview` entry into selection state.
- Preserve existing single-session backup, import backup, and validate package workflows.

## Scope Boundaries

- No migration preview.
- No project bundle packaging.
- No vendor-runtime restore.
- No cloud sync.
- No replacement of the existing `Sessions` direct single-session backup action.

## Validation

- `pnpm test`
- `pnpm build`
- `OPENSPEC_TELEMETRY=0 openspec validate bulk-session-backup --strict`
- GitHub CI passed after implementation and review-fix commits.

## External QA

- External browser QA is recorded in `docs/viewer/bulk-session-backup-qa.md`.
- Initial dev-server run failed due runtime/chunk instability and was classified as needs-confirmation.
- Clean prod-mode smoke retest passed with concerns.
- Remaining concerns are non-blocking environment/follow-up items: favicon 404, expected 502s when full local runtimes are unavailable, and future tests for successful/partial bulk execution with eligible fixtures.

Closes #53 when merged and archived.