### PR TITLE
feat: implement bounded migration preview workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-04-15` — Migration preview workflow
+  - Added a bounded `migration preview` workflow to `Backup / Migration` with explicit source context, target context, and bounded scope state flow (`selection -> configuration -> validation -> result`)
+  - Added preview-only classification and aggregate reporting for `portable`, `degraded`, `unsupported`, and `blocked` items, plus recent-operation entries that route back to preview detail without implying migration apply
+  - Added routed handoff into migration preview from `Project Overview`, `Assets`, and `Analysis` without inventing missing source, target, or scope fields
+
 - `2026-04-15` — Bulk session backup
   - Added a bounded `bulk session backup` workflow to `Backup / Migration` with explicit multi-session selection, per-session validation, batch confirmation, and aggregate plus per-session result reporting
   - Reused the existing single-session backup execution path for batch fan-out and kept recent operations compact with one entry per bulk run

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - `Sessions` contains the existing viewer, source diagnostics, URL deep links, search selection, and direct session backup behavior
   - `Assets` provides a bounded reusable context assets foundation for rules, memory, skills, commands, and unknown asset fragments
   - `Analysis` provides a bounded interpretation-and-routing foundation for local context findings
-  - `Backup / Migration` remains a bounded foundation surface until full project-level workflows are implemented
+  - `Backup / Migration` provides bounded workflow-first backup and migration-preview surfaces without turning into a generic tools drawer or migration apply UI
 - Assets foundation:
   - local-first reusable context asset model with subtype, scope, source, status, provenance, optional body summary, and in-effect/usage metadata
   - subtype/scope/source/status filtering with asset summary, inventory, selected detail, provenance, and in-effect/usage regions
@@ -109,10 +109,11 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - verify/import flows are available through `/api/session-backups`, `/api/session-backups/import`, and `/api/session-backups/[backupId]`
   - v1 `Source Backup` is opt-in and currently supports copy-only source preservation for Codex sessions only
 - Backup / Migration workflows:
-  - `Backup / Migration` now provides bounded `session backup`, `bulk session backup`, `import backup`, and `validate package` workflows
+  - `Backup / Migration` now provides bounded `session backup`, `bulk session backup`, `import backup`, `validate package`, and `migration preview` workflows
   - bulk session backup requires explicit session selection, validates each selected session independently, and fans out through the existing single-session backup execution path
   - bulk results show aggregate status plus per-session detail, while recent operations record one compact batch entry instead of one entry per session
-  - the foundation still does not implement migration preview, project bundle packaging, vendor-runtime restore, or cloud sync
+  - migration preview requires explicit source context, target context, and bounded scope, and ends at preview-only validation/result states without migration apply or bundle generation
+  - the foundation still does not implement migration apply, project bundle packaging, vendor-runtime restore, or cloud sync
 
 For detailed view semantics and cross-source alignment notes, see `docs/viewer/trajectory-view.md`.
 

--- a/docs/dev/feature-follow-up-priority.md
+++ b/docs/dev/feature-follow-up-priority.md
@@ -29,9 +29,10 @@ Execution tracking still belongs in GitHub Issues.
 This is the current primary line because `bulk-session-backup` has shipped and
 been archived, leaving migration preview as the next P1 follow-up.
 
-## 2. Explicitly Deferred Follow-Ups
+## 2. Completed or Deferred Follow-Ups
 
-These items were deliberately excluded from `backup-migration-foundation`.
+These items were deliberately excluded from `backup-migration-foundation`. Items
+listed as shipped are preserved for history, not as active deferred work.
 
 ### P1: Bulk Session Backup
 
@@ -46,20 +47,6 @@ Why it is next-tier priority:
 
 - it extends an already real workflow instead of creating a new product area
 - it is valuable once the single-session workflow has stabilized
-
-### P1: Migration Preview
-
-- Issue: `#54 Track migration preview follow-up`
-- Status: active proposal
-- Why it was deferred:
-  - preview-only behavior risks fake-authority UX
-  - needs clearer portability semantics before implementation
-  - should not ship as a seed-only shell mixed into the first workflow page
-
-Why it is next-tier priority:
-
-- it naturally belongs under `Backup / Migration`
-- it can reuse the workflow spine once foundation is stable
 
 ### P2: Project Bundle Foundation
 

--- a/docs/dev/feature-follow-up-priority.md
+++ b/docs/dev/feature-follow-up-priority.md
@@ -1,9 +1,9 @@
 # Feature Follow-Up Priority
 
-Updated: 2026-04-13
+Updated: 2026-04-15
 
-This document is the control-thread view of what should happen after the current
-`backup-migration-foundation` implementation line.
+This document is the control-thread view of follow-up sequencing after the
+`Backup / Migration` foundation line.
 
 It is not a roadmap or implementation spec. It exists to:
 
@@ -15,22 +15,19 @@ Execution tracking still belongs in GitHub Issues.
 
 ## 1. Current In-Flight Line
 
-### P0: Backup / Migration Foundation
+### P1: Migration Preview
 
-- Issue: `#50 Track backup / migration foundation`
-- Status: active
+- Issue: `#54 Track migration preview follow-up`
+- Status: active proposal
 - Goal:
-  - replace the `Backup / Migration` placeholder with a bounded workflow-first
-    foundation
-  - support:
-    - `session-backup`
-    - `import-backup`
-    - `validate-package`
-    - routed handoff
-    - recent operations
+  - add a preview-only portability workflow under `Backup / Migration`
+  - require explicit source, target, and scope context
+  - classify selected items as portable, degraded, unsupported, or blocked
+  - stop at preview result with no migration apply, project bundle packaging, or
+    vendor-runtime restore
 
-This is the current primary line because it closes the last top-level
-placeholder in the project shell.
+This is the current primary line because `bulk-session-backup` has shipped and
+been archived, leaving migration preview as the next P1 follow-up.
 
 ## 2. Explicitly Deferred Follow-Ups
 
@@ -39,6 +36,7 @@ These items were deliberately excluded from `backup-migration-foundation`.
 ### P1: Bulk Session Backup
 
 - Issue: `#53 Track bulk session backup follow-up`
+- Status: shipped and archived
 - Why it was deferred:
   - not required to replace the placeholder
   - increases workflow-state complexity sharply
@@ -52,6 +50,7 @@ Why it is next-tier priority:
 ### P1: Migration Preview
 
 - Issue: `#54 Track migration preview follow-up`
+- Status: active proposal
 - Why it was deferred:
   - preview-only behavior risks fake-authority UX
   - needs clearer portability semantics before implementation
@@ -78,22 +77,18 @@ Why it is lower priority than the other two:
 
 ## 3. Candidate Feature-Line Priority
 
-Assuming `backup-migration-foundation` merges cleanly, the recommended priority
-order is:
+Assuming `migration-preview` merges cleanly, the recommended next priority order
+is:
 
-1. `bulk-session-backup`
-2. `migration-preview`
-3. `project-bundle-foundation`
+1. `project-bundle-foundation`
+2. `privacy-redaction`
 
 Reasoning:
 
-- `bulk-session-backup` is the most direct extension of already-real workflow
-  behavior and has the least product ambiguity.
-- `migration-preview` fits the same page and model family, but still needs more
-  semantic precision than bulk backup.
-- `project-bundle-foundation` is strategically important, but it deserves a
-  narrower dedicated line rather than being rushed in immediately after the
-  current workflow page lands.
+- `project-bundle-foundation` becomes the next natural `Backup / Migration`
+  expansion after migration preview clarifies portability boundaries.
+- `privacy-redaction` cuts across diagnostics, exports, backups, and review
+  tooling; it remains important but should not be mixed into migration preview.
 
 ## 4. Other Open Work
 
@@ -110,11 +105,9 @@ Reason:
 
 ## 5. Recommended Decision Rule
 
-Once the current `backup-migration-foundation` PR is merged:
+Once the current `migration-preview` PR is merged:
 
-- choose `bulk-session-backup` next if the current workflow page is functionally
-  stable and the team wants the fastest incremental expansion
-- choose `migration-preview` next if portability / compatibility semantics have
-  become the dominant product question
-- choose `project-bundle-foundation` next only if the product conversation is
-  ready to commit to bundle boundaries and packaging promises
+- choose `project-bundle-foundation` next if the product conversation is ready
+  to commit to bundle boundaries and packaging promises
+- choose `privacy-redaction` next if sensitive diagnostics, exports, or package
+  contents become the dominant risk before more portability features

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -3,10 +3,10 @@
 Use this prompt with an external QA agent that can operate the local app through a browser.
 
 ```text
-You are QA-ing the `bulk-session-backup` implementation for the local-first Agent Storage Manager project.
+You are QA-ing the `migration-preview` and `bulk-session-backup` implementation for the local-first Agent Storage Manager project.
 
 Repository: <repo-path>
-Branch under test: feat/bulk-session-backup
+Branch under test: feat/migration-preview
 
 Goal:
 Verify that the new `Backup / Migration` page behaves as a bounded workflow-first foundation surface. It should support:
@@ -14,12 +14,13 @@ Verify that the new `Backup / Migration` page behaves as a bounded workflow-firs
 - bulk session backup
 - import backup
 - validate package
+- migration preview
 - routed handoff from `Project Overview`, `Sessions`, `Assets`, and `Analysis`
 - compact recent operations
 
 It must not behave like:
 - a generic tools drawer
-- a migration preview surface
+- a migration apply surface
 - a project bundle implementation
 - a vendor runtime restore UI
 
@@ -41,8 +42,7 @@ Primary smoke checks:
    - validation-oriented state
    - result / recent operations region
 6. Confirm copy clearly states bounded foundation behavior and does not imply:
-   - bulk backup
-   - migration preview
+   - migration apply
    - project bundle execution
    - vendor-runtime restore
 
@@ -53,7 +53,8 @@ Workflow selector / idle checks:
    - bulk session backup
    - import backup
    - validate package
-3. Confirm `migration preview` and `project bundle` are not presented as active workflows.
+   - migration preview
+3. Confirm `project bundle` is not presented as an active workflow.
 
 Session backup workflow checks:
 1. Enter the `session backup` workflow from `Backup / Migration`.
@@ -109,17 +110,45 @@ Validate package workflow checks:
    - invalid
 4. Confirm validation result is still clearly a workflow result, not an editor or generic inspector.
 
+Migration preview workflow checks:
+1. Enter the `migration preview` workflow from `Backup / Migration`.
+2. Confirm the workflow follows this bounded path only:
+   - selection
+   - configuration
+   - validation
+   - result
+3. Confirm no confirmation or execution step appears for migration preview.
+4. Confirm preview requires explicit:
+   - source context
+   - target context
+   - bounded scope
+5. Confirm missing fields remain visible and editable instead of being silently inferred.
+6. Confirm bounded scope choices include:
+   - sessions
+   - reusable context assets
+   - project-context subset
+7. Confirm validation and result copy clearly state `preview only` and never imply migration apply, object writing, or bundle generation.
+8. Confirm result output distinguishes item classifications:
+   - portable
+   - degraded
+   - unsupported
+   - blocked
+9. Confirm aggregate counts are shown for all four preview classifications.
+10. Confirm degraded / unsupported / blocked rows offer inspection or repair-oriented follow-up wording without executing work inline.
+
 Routed handoff checks:
 1. From `Sessions`, if available, route into `Backup / Migration` for a selected session.
 2. Confirm `Backup / Migration` opens the `session backup` workflow with the session prefilled and a compact origin cue.
 3. If `Sessions` exposes explicit multi-selection under this branch, route that selection into `Backup / Migration`.
 4. Confirm the destination opens `bulk session backup` with the selected sessions prefilled and no silently dropped entries.
 5. From `Assets`, trigger a route into `Backup / Migration` if available.
-6. Confirm the destination page preserves bounded asset context but does not embed the full Assets page.
+6. Confirm the destination page may open migration preview with explicit asset scope context only, while missing source product or target context remains editable.
 7. From `Analysis`, trigger a preservation-oriented route into `Backup / Migration` if available.
-8. Confirm issue context is preserved and workflow identity remains primary.
-9. From `Project Overview`, trigger a route into single backup, bulk backup, import, and validation if available.
-10. Confirm routed context opens the correct workflow and degrades safely if context is incomplete.
+8. Confirm preservation-oriented analysis routes still open `session backup` and preserve the issue/preservation warning context.
+9. From `Analysis`, trigger a migration-preview route into `Backup / Migration` if available.
+10. Confirm migration-preview analysis routes open `migration preview`, preserve issue context, and do not invent missing source or target.
+11. From `Project Overview`, trigger a route into single backup, bulk backup, import, validation, and migration preview if available.
+12. Confirm routed context opens the correct workflow and degrades safely to selection/configuration if preview context is incomplete.
 
 Recent operations checks:
 1. After completing or simulating at least one workflow, confirm a compact recent-operations region appears.
@@ -129,14 +158,16 @@ Recent operations checks:
    - timestamp or recency indicator
    - status
    - session count for bulk runs
+   - selected preview scope for migration preview runs
 3. Confirm it reads as a secondary result/history strip, not a persistent audit console.
 4. Confirm a bulk run produces one recent-operation entry for the batch, not one entry per selected session.
+5. Confirm a migration preview entry routes back to preview detail and does not claim migration was applied.
 
 Regression checks:
 1. `Sessions` still works as before, including existing viewer behavior and direct session backup.
 2. `Assets` and `Analysis` routing into `Backup / Migration` does not break their own page roles.
 3. Top-level navigation away from `Backup / Migration` clears stale routed workflow context when appropriate.
-4. `Backup / Migration` does not expose migration preview or project bundle execution accidentally through copy or buttons.
+4. `Backup / Migration` does not expose migration apply or project bundle execution accidentally through copy or buttons.
 
 Boundary checks:
 1. No button or copy should imply:

--- a/docs/viewer/migration-preview-qa.md
+++ b/docs/viewer/migration-preview-qa.md
@@ -1,0 +1,53 @@
+# Migration Preview QA
+
+Date: 2026-04-16
+Branch: `feat/migration-preview`
+Environment: macOS, Playwright CLI (Chromium), `http://localhost:3000`
+Verdict: Pass
+
+## Scope
+
+This QA pass covered the `migration-preview` workflow added to `Backup / Migration`, including workflow selector visibility, preview-only state flow, explicit source/target/scope requirements, routed handoff, recent operations, and regression checks for neighboring surfaces.
+
+## Result
+
+All tested checks passed. No blocking issues or non-blocking concerns were reported.
+
+## Key Verified Behavior
+
+- `Backup / Migration` exposes five bounded workflows: session backup, bulk session backup, import backup, validate package, and migration preview.
+- `migration-preview` follows only `selection -> configuration -> validation -> result`.
+- The workflow does not show confirmation or execution steps.
+- Source context, target context, and bounded scope remain explicit and editable.
+- Missing fields are not silently inferred from routed context.
+- Result output distinguishes `portable`, `degraded`, `unsupported`, and `blocked` classifications.
+- Aggregate counts are shown for all four classifications.
+- Result copy states preview-only behavior and does not imply migration apply, object writing, or bundle generation.
+- Recent operations show migration preview entries with selected preview scope and do not claim migration was applied.
+- `Assets -> Migration Preview` prefills asset scope without inventing source product or target context.
+- `Analysis` preservation routes still open session backup.
+- `Analysis` migration-preview routes open migration preview and preserve issue context without inventing missing fields.
+- Project Overview routes to each workflow correctly.
+- Sessions, Assets, and Analysis retained their existing page roles.
+
+## Evidence Excerpt
+
+The QA run verified the result state copy:
+
+```text
+Operation Result: preview-clear
+Preview only: 1 sessions checked — 1 portable, 0 degraded, 0 unsupported, 0 blocked.
+
+Preview only. This result compares explicit source, target, and bounded scope
+without applying migration, generating bundles, or writing migrated objects.
+
+No runtime restore or apply. Preview results are advisory compatibility findings only.
+They do not write objects, reopen third-party runtimes, or create backup packages.
+```
+
+## Suggested Follow-Up Tests
+
+- Use real local sessions and backup packages for end-to-end data-path validation.
+- Construct mixed `degraded` / `unsupported` / `blocked` preview results and verify inspection/repair wording.
+- Stress bulk session backup with a larger explicit selection set.
+- Check responsive layout for the workflow spine on narrow screens.

--- a/docs/viewer/migration-preview-qa.md
+++ b/docs/viewer/migration-preview-qa.md
@@ -36,7 +36,7 @@ The QA run verified the result state copy:
 
 ```text
 Operation Result: preview-clear
-Preview only: 1 sessions checked — 1 portable, 0 degraded, 0 unsupported, 0 blocked.
+Preview only: 1 session checked — 1 portable, 0 degraded, 0 unsupported, 0 blocked.
 
 Preview only. This result compares explicit source, target, and bounded scope
 without applying migration, generating bundles, or writing migrated objects.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,24 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone"
+  output: "standalone",
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.watchOptions = {
+        ...config.watchOptions,
+        ignored: [
+          '**/node_modules/**',
+          '**/.agent/**',
+          '**/.agents/**',
+          '**/.codex/**',
+          '**/.github/**',
+          '**/.windsurf/**',
+          '**/.git/**',
+          '**/output/**',
+        ],
+      };
+    }
+    return config;
+  }
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,18 +3,23 @@ const nextConfig = {
   output: "standalone",
   webpack: (config, { dev }) => {
     if (dev) {
+      const existingIgnored = config.watchOptions?.ignored;
+      const ignored = [
+        ...(Array.isArray(existingIgnored) ? existingIgnored : existingIgnored ? [existingIgnored] : []),
+        "**/.next/**",
+        "**/node_modules/**",
+        "**/.agent/**",
+        "**/.agents/**",
+        "**/.codex/**",
+        "**/.github/**",
+        "**/.windsurf/**",
+        "**/.git/**",
+        "**/output/**",
+      ];
+
       config.watchOptions = {
         ...config.watchOptions,
-        ignored: [
-          '**/node_modules/**',
-          '**/.agent/**',
-          '**/.agents/**',
-          '**/.codex/**',
-          '**/.github/**',
-          '**/.windsurf/**',
-          '**/.git/**',
-          '**/output/**',
-        ],
+        ignored,
       };
     }
     return config;
@@ -22,4 +27,3 @@ const nextConfig = {
 };
 
 export default nextConfig;
-

--- a/openspec/changes/migration-preview/.openspec.yaml
+++ b/openspec/changes/migration-preview/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migration-preview/design.md
+++ b/openspec/changes/migration-preview/design.md
@@ -1,0 +1,132 @@
+## Context
+
+`Backup / Migration` now supports executable preservation workflows: single
+session backup, bulk session backup, import backup, validate package, routed
+handoff, and recent operations. Migration preview was deliberately deferred
+because a preview-only workflow can easily overstate portability if it looks
+like an apply-capable migration engine.
+
+This change adds a bounded preview workflow. It should help users understand
+what would be portable, degraded, unsupported, or blocked before taking action,
+while explicitly avoiding migration apply, package generation, runtime restore,
+or cross-machine transfer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `migration-preview` to the existing `Backup / Migration` workflow model.
+- Require explicit source context and target context before preview.
+- Support a bounded preview scope covering sessions, reusable context assets,
+  or a project-context subset.
+- Produce preview results with exact classifications:
+  `portable`, `degraded`, `unsupported`, and `blocked`.
+- Show warnings and blocking reasons without applying any migration.
+- Support routed entry from `Assets`, `Analysis`, and `Project Overview` when
+  context is explicit enough.
+- Record completed migration previews as compact recent operations.
+
+**Non-Goals:**
+
+- No migration apply.
+- No writing migrated objects.
+- No project bundle packaging.
+- No export/import package generation.
+- No vendor-runtime restore or continuation.
+- No cloud sync, team sharing, or cross-machine transfer.
+- No automatic inference of source/target context from vague summary text.
+- No guarantee that preview results are exhaustive beyond the selected source,
+  target, and scope.
+
+## Decisions
+
+### Decision 1: Add preview as a workflow type, not a separate page
+
+`migration-preview` should use the same workflow selector, workflow spine,
+validation panel, result panel, and recent operations model as other
+`Backup / Migration` workflows.
+
+Alternative considered: add a standalone migration page. Rejected because the
+product already defines `Backup / Migration` as the workflow home for
+preservation and portability work.
+
+### Decision 2: Stop at result; do not include confirmation or execution
+
+The preview state path should be:
+Idle -> Selection -> Configuration -> Validation -> Result.
+
+Validation and preview generation are one bounded operation. There is no
+confirmation step because no state-changing apply occurs, and no execution step
+because preview does not write migrated output.
+
+Alternative considered: reuse the full confirmation/execution path. Rejected
+because that would imply migration apply readiness.
+
+### Decision 3: Use explicit source, target, and scope context
+
+The preview should require explicit source context, target context, and preview
+scope. Routed handoff can prefill these fields only when the originating
+surface supplies concrete context.
+
+Alternative considered: infer target from asset subtype or finding category.
+Rejected because implicit mapping would create fake authority and surprise
+users.
+
+### Decision 4: Use preview classifications instead of success/failure only
+
+Each preview item should be classified as `portable`, `degraded`,
+`unsupported`, or `blocked`. The aggregate preview result can summarize counts,
+but it should preserve item-level detail.
+
+Alternative considered: only show valid/invalid. Rejected because migration
+preview needs to distinguish reduced fidelity from complete incompatibility.
+
+### Decision 5: Keep preview rules local and representative in foundation
+
+Foundation can use deterministic local compatibility rules derived from the
+selected source, target, object type, provenance, and metadata completeness. It
+does not need a full adapter engine or remote runtime inspection.
+
+Alternative considered: create a generalized migration mapping engine now.
+Rejected because this first slice exists to define safe UX semantics and avoid
+overcommitting to migration capability.
+
+### Decision 6: Recent operations records previews as preview results
+
+Completed migration previews should appear as compact recent-operation entries
+with workflow type, timestamp, aggregate preview status, scope, and route to
+preview detail.
+
+Alternative considered: do not record previews because no state changed.
+Rejected because users still need to return to the compatibility result during
+the same page session.
+
+## Risks / Trade-offs
+
+- Fake-authority risk -> Use preview-only copy, explicit source/target/scope,
+  and no apply or package actions.
+- Inconclusive previews -> Represent uncertainty as `degraded` or `blocked`
+  with actionable reasons instead of pretending complete compatibility.
+- UI density -> Summarize counts in the result header and keep item detail in a
+  preview table/list.
+- Target taxonomy churn -> Keep target choices bounded and local to foundation;
+  future adapter work can expand options without changing the preview-only
+  workflow contract.
+- Routed context ambiguity -> Degrade to selection/configuration instead of
+  silently filling missing source or target fields.
+
+## Migration Plan
+
+- Add the new workflow type and preview helper types without changing existing
+  backup/import/validate behavior.
+- Add preview UI states behind `Backup / Migration`.
+- Add route builders for explicit preview entry from `Project Overview`,
+  `Assets`, and `Analysis`.
+- If rollback is needed, remove `migration-preview` from the workflow
+  descriptor list while leaving existing workflows untouched.
+
+## Open Questions
+
+None for foundation. Future changes may define richer adapter-specific target
+profiles or turn preview results into migration apply inputs, but those are out
+of scope here.

--- a/openspec/changes/migration-preview/design.md
+++ b/openspec/changes/migration-preview/design.md
@@ -78,6 +78,20 @@ Each preview item should be classified as `portable`, `degraded`,
 `unsupported`, or `blocked`. The aggregate preview result can summarize counts,
 but it should preserve item-level detail.
 
+An item is `degraded` when the target can accept the object but with measurably
+reduced fidelity. An item is `unsupported` when the target has no recognized
+mapping for that object class, regardless of source quality. If multiple
+classifications could apply, the precedence is `blocked` -> `unsupported` ->
+`degraded` -> `portable`.
+
+Aggregate preview status uses preview-specific values rather than backup
+operation success values:
+
+- `preview-clear`: all previewed items are portable
+- `preview-with-concerns`: one or more items are degraded and none are
+  unsupported or blocked
+- `preview-with-blockers`: one or more items are unsupported or blocked
+
 Alternative considered: only show valid/invalid. Rejected because migration
 preview needs to distinguish reduced fidelity from complete incompatibility.
 

--- a/openspec/changes/migration-preview/proposal.md
+++ b/openspec/changes/migration-preview/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+`Backup / Migration` now supports executable preservation workflows, but users
+still cannot inspect portability risk before deciding whether context should be
+moved into another product-readable shape. Migration preview is the next
+bounded workflow because it reuses the existing workflow spine while explicitly
+stopping at compatibility preview rather than migration apply.
+
+## What Changes
+
+- Add a `migration-preview` workflow to `Backup / Migration`.
+- Support explicit source context and target context selection before preview.
+- Support bounded scope selection for previewing portability of sessions,
+  reusable context assets, or a project-context subset.
+- Run preview-only compatibility checks that classify selected items as
+  portable, degraded, unsupported, or blocked.
+- Show validation and preview results without executing migration, writing
+  migrated objects, or claiming vendor-runtime restoration.
+- Support routed entry from `Assets`, `Analysis`, and `Project Overview` when
+  those surfaces provide explicit source, target, or issue context.
+- Record completed migration previews as compact recent-operation entries with
+  route to preview result detail.
+- Do not add migration apply, project bundle packaging, vendor-runtime restore,
+  cloud sync, or cross-machine transfer behavior in this change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `backup-migration`: Adds a preview-only migration workflow, source/target
+  context semantics, portability classification, routed preview entry, and
+  recent-operation summary behavior.
+
+## Impact
+
+- Affected UI: `src/components/BackupMigrationFoundation.tsx` workflow selector,
+  workflow body, validation panel, result panel, and recent operations.
+- Affected model code: `src/lib/backupMigration.ts` workflow descriptors,
+  preview context types, compatibility result helpers, and handoff mapping.
+- Affected shell code: `ProjectShellClient` route builders for overview,
+  assets, and analysis migration-preview entry.
+- Affected tests: model tests, component tests for preview states, and shell
+  routing tests for preview handoff.
+- Affected docs: `README.md`, `CHANGELOG.md`, and external QA prompt when the
+  implementation ships.
+- Tracking: GitHub Issue #54.

--- a/openspec/changes/migration-preview/specs/backup-migration/spec.md
+++ b/openspec/changes/migration-preview/specs/backup-migration/spec.md
@@ -15,7 +15,7 @@ The system SHALL provide a bounded `migration-preview` workflow inside `Backup /
 - **AND** it does not show confirmation or execution steps for migration apply
 - **AND** it does not write migrated objects, generate a project bundle, or restore any third-party runtime state
 
-### Requirement: Migration preview SHALL require explicit source target and scope
+### Requirement: Migration preview SHALL require explicit source, target, and scope
 The system SHALL require explicit source context, target context, and preview scope before generating a migration preview.
 
 #### Scenario: Missing source context blocks preview
@@ -27,6 +27,11 @@ The system SHALL require explicit source context, target context, and preview sc
 - **WHEN** the user starts migration preview without explicit target context
 - **THEN** the workflow remains in configuration state
 - **AND** it explains that target context is required before preview
+
+#### Scenario: Missing scope blocks preview
+- **WHEN** the user starts migration preview with explicit source and target context but no preview scope
+- **THEN** the workflow remains in configuration state
+- **AND** it explains that a bounded preview scope is required before preview
 
 #### Scenario: Scope remains bounded
 - **WHEN** the user configures migration preview scope
@@ -40,6 +45,8 @@ The system SHALL require explicit source context, target context, and preview sc
 
 ### Requirement: Migration preview SHALL classify portability outcomes
 The system SHALL classify previewed items as `portable`, `degraded`, `unsupported`, or `blocked`.
+
+The preview classification SHALL use exactly these values: `portable`, `degraded`, `unsupported`, `blocked`. No other classification values are valid for migration preview results. When multiple classifications could apply, precedence SHALL be `blocked` before `unsupported` before `degraded` before `portable`.
 
 #### Scenario: Portable item
 - **WHEN** a selected item has recognized source metadata, target mapping, and required canonical data
@@ -59,7 +66,7 @@ The system SHALL classify previewed items as `portable`, `degraded`, `unsupporte
 #### Scenario: Blocked item
 - **WHEN** a selected item is missing required canonical data, source context, target context, or provenance
 - **THEN** the preview classifies the item as `blocked`
-- **AND** it gives an actionable reason before any migration apply is implied
+- **AND** it gives an actionable reason such as which data is missing or which source needs repair
 
 ### Requirement: Migration preview result SHALL summarize aggregate risk and item detail
 The system SHALL show a migration preview result with aggregate counts and item-level compatibility detail.
@@ -69,10 +76,21 @@ The system SHALL show a migration preview result with aggregate counts and item-
 - **THEN** the result shows counts for portable, degraded, unsupported, and blocked items
 - **AND** it states that the result is a preview only
 
+#### Scenario: Empty preview scope produces no-result state
+- **WHEN** the configured preview scope resolves to zero previewable items
+- **THEN** the workflow shows an explicit empty-scope message instead of an empty result table
+- **AND** it routes the user back to scope configuration
+
 #### Scenario: Preview result preserves item detail
 - **WHEN** migration preview includes more than one item
 - **THEN** the result shows item-level classifications and explanations
 - **AND** it does not collapse degraded, unsupported, or blocked items into a generic success message
+
+#### Scenario: Preview result uses preview-specific aggregate status
+- **WHEN** migration preview completes
+- **THEN** the aggregate preview status is `preview-clear` when all previewed items are portable
+- **AND** the aggregate preview status is `preview-with-concerns` when any item is degraded and no item is unsupported or blocked
+- **AND** the aggregate preview status is `preview-with-blockers` when any item is unsupported or blocked
 
 #### Scenario: Preview result offers repair routes
 - **WHEN** preview result contains degraded, unsupported, or blocked items

--- a/openspec/changes/migration-preview/specs/backup-migration/spec.md
+++ b/openspec/changes/migration-preview/specs/backup-migration/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Migration preview workflow SHALL be preview-only
+The system SHALL provide a bounded `migration-preview` workflow inside `Backup / Migration` that previews portability and compatibility without applying migration.
+
+#### Scenario: Workflow selector includes migration preview
+- **WHEN** the user opens `Backup / Migration` without active workflow context
+- **THEN** the workflow selector includes `Migration Preview` as an available workflow
+- **AND** the workflow description frames it as compatibility preview before action
+- **AND** the description does not claim migration apply, project bundle packaging, vendor-runtime restore, cloud sync, or cross-machine transfer
+
+#### Scenario: Preview workflow stops at result
+- **WHEN** the user completes the migration preview workflow
+- **THEN** the workflow ends in a preview result state
+- **AND** it does not show confirmation or execution steps for migration apply
+- **AND** it does not write migrated objects, generate a project bundle, or restore any third-party runtime state
+
+### Requirement: Migration preview SHALL require explicit source target and scope
+The system SHALL require explicit source context, target context, and preview scope before generating a migration preview.
+
+#### Scenario: Missing source context blocks preview
+- **WHEN** the user starts migration preview without explicit source context
+- **THEN** the workflow remains in selection or configuration state
+- **AND** it explains that source context is required before preview
+
+#### Scenario: Missing target context blocks preview
+- **WHEN** the user starts migration preview without explicit target context
+- **THEN** the workflow remains in configuration state
+- **AND** it explains that target context is required before preview
+
+#### Scenario: Scope remains bounded
+- **WHEN** the user configures migration preview scope
+- **THEN** the workflow allows only bounded preview scopes such as sessions, reusable context assets, or project-context subset
+- **AND** it does not imply whole-machine, cloud, team, or third-party runtime migration
+
+#### Scenario: Routed context can prefill only explicit fields
+- **WHEN** `Assets`, `Analysis`, or `Project Overview` routes to migration preview with explicit source, target, or scope context
+- **THEN** the preview workflow pre-fills only the fields provided by the handoff
+- **AND** missing fields remain visible and user-editable rather than being silently inferred
+
+### Requirement: Migration preview SHALL classify portability outcomes
+The system SHALL classify previewed items as `portable`, `degraded`, `unsupported`, or `blocked`.
+
+#### Scenario: Portable item
+- **WHEN** a selected item has recognized source metadata, target mapping, and required canonical data
+- **THEN** the preview classifies the item as `portable`
+- **AND** it explains the target shape expected by the preview
+
+#### Scenario: Degraded item
+- **WHEN** a selected item is readable but loses fidelity, provenance, source-copy detail, or target-specific semantics
+- **THEN** the preview classifies the item as `degraded`
+- **AND** it explains what will be lost or weakened
+
+#### Scenario: Unsupported item
+- **WHEN** a selected item belongs to a known object class that has no target mapping in this preview
+- **THEN** the preview classifies the item as `unsupported`
+- **AND** it explains that preview cannot claim portability for that item
+
+#### Scenario: Blocked item
+- **WHEN** a selected item is missing required canonical data, source context, target context, or provenance
+- **THEN** the preview classifies the item as `blocked`
+- **AND** it gives an actionable reason before any migration apply is implied
+
+### Requirement: Migration preview result SHALL summarize aggregate risk and item detail
+The system SHALL show a migration preview result with aggregate counts and item-level compatibility detail.
+
+#### Scenario: Preview result summarizes counts
+- **WHEN** migration preview completes
+- **THEN** the result shows counts for portable, degraded, unsupported, and blocked items
+- **AND** it states that the result is a preview only
+
+#### Scenario: Preview result preserves item detail
+- **WHEN** migration preview includes more than one item
+- **THEN** the result shows item-level classifications and explanations
+- **AND** it does not collapse degraded, unsupported, or blocked items into a generic success message
+
+#### Scenario: Preview result offers repair routes
+- **WHEN** preview result contains degraded, unsupported, or blocked items
+- **THEN** the result offers routes to inspect source sessions, assets, or analysis findings when relevant
+- **AND** it does not offer a migration apply action
+
+### Requirement: Recent operations SHALL summarize migration preview runs
+The system SHALL record completed migration preview workflows as compact recent-operation entries with route to preview result detail.
+
+#### Scenario: Migration preview appears as recent operation
+- **WHEN** a migration preview workflow completes
+- **THEN** recent operations shows one entry for the preview run
+- **AND** the entry includes workflow type, timestamp, aggregate preview status, and selected scope
+- **AND** it does not claim that migration was applied
+
+#### Scenario: Recent operation opens migration preview detail
+- **WHEN** the user selects a migration preview recent-operation entry
+- **THEN** the page shows the preview result detail with aggregate counts and item-level classifications

--- a/openspec/changes/migration-preview/tasks.md
+++ b/openspec/changes/migration-preview/tasks.md
@@ -1,56 +1,56 @@
 ## 1. Workflow Model
 
-- [ ] 1.1 Add `migration-preview` to backup workflow types, labels, descriptors, and step definitions.
-- [ ] 1.2 Define migration preview source context, target context, and preview scope types.
-- [ ] 1.3 Define preview item, closed classification enum, and preview-specific aggregate result status types.
-- [ ] 1.4 Add helper functions for preview validation, item classification, aggregate count derivation, and recent-operation creation.
-- [ ] 1.5 Ensure existing backup/import/validate/bulk workflow helpers remain backward compatible.
+- [x] 1.1 Add `migration-preview` to backup workflow types, labels, descriptors, and step definitions.
+- [x] 1.2 Define migration preview source context, target context, and preview scope types.
+- [x] 1.3 Define preview item, closed classification enum, and preview-specific aggregate result status types.
+- [x] 1.4 Add helper functions for preview validation, item classification, aggregate count derivation, and recent-operation creation.
+- [x] 1.5 Ensure existing backup/import/validate/bulk workflow helpers remain backward compatible.
 
 ## 2. Selection and Configuration
 
-- [ ] 2.1 Add migration preview selection/configuration state to `BackupMigrationFoundation`.
-- [ ] 2.2 Require explicit source context before preview can proceed.
-- [ ] 2.3 Require explicit target context before preview can proceed.
-- [ ] 2.4 Support bounded preview scope choices for sessions, reusable context assets, and project-context subset.
-- [ ] 2.5 Keep missing source, target, and scope fields visible and user-editable.
-- [ ] 2.6 Update idle-state description copy in `BackupMigrationFoundation` to include migration preview and remove the migration-preview exclusion statement.
+- [x] 2.1 Add migration preview selection/configuration state to `BackupMigrationFoundation`.
+- [x] 2.2 Require explicit source context before preview can proceed.
+- [x] 2.3 Require explicit target context before preview can proceed.
+- [x] 2.4 Support bounded preview scope choices for sessions, reusable context assets, and project-context subset.
+- [x] 2.5 Keep missing source, target, and scope fields visible and user-editable.
+- [x] 2.6 Update idle-state description copy in `BackupMigrationFoundation` to include migration preview and remove the migration-preview exclusion statement.
 
 ## 3. Preview Validation and Result
 
-- [ ] 3.1 Validate source context, target context, canonical source data availability, and metadata completeness before preview result.
-- [ ] 3.2 Classify preview items as `portable`, `degraded`, `unsupported`, or `blocked`.
-- [ ] 3.3 Render aggregate counts for all preview classifications.
-- [ ] 3.4 Render item-level preview detail with explanations.
-- [ ] 3.5 Ensure result copy says preview-only and never offers migration apply.
-- [ ] 3.6 Offer repair or inspection routes for degraded, unsupported, or blocked items when relevant.
+- [x] 3.1 Validate source context, target context, canonical source data availability, and metadata completeness before preview result.
+- [x] 3.2 Classify preview items as `portable`, `degraded`, `unsupported`, or `blocked`.
+- [x] 3.3 Render aggregate counts for all preview classifications.
+- [x] 3.4 Render item-level preview detail with explanations.
+- [x] 3.5 Ensure result copy says preview-only and never offers migration apply.
+- [x] 3.6 Offer repair or inspection routes for degraded, unsupported, or blocked items when relevant.
 
 ## 4. Routed Handoff
 
-- [ ] 4.1 Extend backup-migration handoff types to carry migration preview source, target, and scope context after task 1.1 adds `migration-preview` to `BackupWorkflowType`.
-- [ ] 4.2 Add `Project Overview -> Migration Preview` route that opens preview selection/configuration without invented context.
-- [ ] 4.3 Add `Assets -> Migration Preview` route that may prefill explicit asset source/scope context only.
-- [ ] 4.4 Add `Analysis -> Migration Preview` route that preserves issue context but does not infer missing source or target.
-- [ ] 4.5 Ensure stale or incomplete preview handoff degrades to selection/configuration instead of broken result state.
+- [x] 4.1 Extend backup-migration handoff types to carry migration preview source, target, and scope context after task 1.1 adds `migration-preview` to `BackupWorkflowType`.
+- [x] 4.2 Add `Project Overview -> Migration Preview` route that opens preview selection/configuration without invented context.
+- [x] 4.3 Add `Assets -> Migration Preview` route that may prefill explicit asset source/scope context only.
+- [x] 4.4 Add `Analysis -> Migration Preview` route that preserves issue context but does not infer missing source or target.
+- [x] 4.5 Ensure stale or incomplete preview handoff degrades to selection/configuration instead of broken result state.
 
 ## 5. Recent Operations
 
-- [ ] 5.1 Record completed migration previews as compact recent-operation entries.
-- [ ] 5.2 Include workflow type, timestamp, aggregate preview status, and selected scope in recent operations.
-- [ ] 5.3 Route from a migration-preview recent operation back to preview result detail.
-- [ ] 5.4 Ensure recent-operation copy does not claim migration was applied.
+- [x] 5.1 Record completed migration previews as compact recent-operation entries.
+- [x] 5.2 Include workflow type, timestamp, aggregate preview status, and selected scope in recent operations.
+- [x] 5.3 Route from a migration-preview recent operation back to preview result detail.
+- [x] 5.4 Ensure recent-operation copy does not claim migration was applied.
 
 ## 6. Tests and QA
 
-- [ ] 6.1 Add model tests for migration preview workflow descriptors, validation, classification, aggregate counts, and recent-operation summary.
-- [ ] 6.2 Add component tests for missing source, missing target, valid preview, degraded preview, unsupported preview, blocked preview, and result states.
-- [ ] 6.3 Add shell routing tests for overview, assets, and analysis handoff into migration preview.
-- [ ] 6.4 Add regression tests proving existing backup/import/validate/bulk workflows still work.
-- [ ] 6.5 Prepare an external QA prompt covering preview-only boundary, source/target/scope configuration, classification results, routed handoff, and recent operations.
+- [x] 6.1 Add model tests for migration preview workflow descriptors, validation, classification, aggregate counts, and recent-operation summary.
+- [x] 6.2 Add component tests for missing source, missing target, valid preview, degraded preview, unsupported preview, blocked preview, and result states.
+- [x] 6.3 Add shell routing tests for overview, assets, and analysis handoff into migration preview.
+- [x] 6.4 Add regression tests proving existing backup/import/validate/bulk workflows still work.
+- [x] 6.5 Prepare an external QA prompt covering preview-only boundary, source/target/scope configuration, classification results, routed handoff, and recent operations.
 
 ## 7. Documentation and Validation
 
-- [ ] 7.1 Update `README.md` if user-facing Backup / Migration behavior changes.
-- [ ] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
-- [ ] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
-- [ ] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate migration-preview --strict`.
-- [ ] 7.5 Update `docs/viewer/backup-migration-foundation-qa-prompt.md` to include migration preview smoke checks and remove the migration-preview exclusion assertion.
+- [x] 7.1 Update `README.md` if user-facing Backup / Migration behavior changes.
+- [x] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
+- [x] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
+- [x] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate migration-preview --strict`.
+- [x] 7.5 Update `docs/viewer/backup-migration-foundation-qa-prompt.md` to include migration preview smoke checks and remove the migration-preview exclusion assertion.

--- a/openspec/changes/migration-preview/tasks.md
+++ b/openspec/changes/migration-preview/tasks.md
@@ -1,0 +1,53 @@
+## 1. Workflow Model
+
+- [ ] 1.1 Add `migration-preview` to backup workflow types, labels, descriptors, and step definitions.
+- [ ] 1.2 Define migration preview source context, target context, preview scope, preview item, classification, and aggregate result types.
+- [ ] 1.3 Add helper functions for preview validation, item classification, aggregate count derivation, and recent-operation creation.
+- [ ] 1.4 Ensure existing backup/import/validate/bulk workflow helpers remain backward compatible.
+
+## 2. Selection and Configuration
+
+- [ ] 2.1 Add migration preview selection/configuration state to `BackupMigrationFoundation`.
+- [ ] 2.2 Require explicit source context before preview can proceed.
+- [ ] 2.3 Require explicit target context before preview can proceed.
+- [ ] 2.4 Support bounded preview scope choices for sessions, reusable context assets, and project-context subset.
+- [ ] 2.5 Keep missing source, target, and scope fields visible and user-editable.
+
+## 3. Preview Validation and Result
+
+- [ ] 3.1 Validate source context, target context, canonical basis, and metadata completeness before preview result.
+- [ ] 3.2 Classify preview items as `portable`, `degraded`, `unsupported`, or `blocked`.
+- [ ] 3.3 Render aggregate counts for all preview classifications.
+- [ ] 3.4 Render item-level preview detail with explanations.
+- [ ] 3.5 Ensure result copy says preview-only and never offers migration apply.
+- [ ] 3.6 Offer repair or inspection routes for degraded, unsupported, or blocked items when relevant.
+
+## 4. Routed Handoff
+
+- [ ] 4.1 Extend backup-migration handoff types to carry migration preview source, target, and scope context.
+- [ ] 4.2 Add `Project Overview -> Migration Preview` route that opens preview selection/configuration without invented context.
+- [ ] 4.3 Add `Assets -> Migration Preview` route that may prefill explicit asset source/scope context only.
+- [ ] 4.4 Add `Analysis -> Migration Preview` route that preserves issue context but does not infer missing source or target.
+- [ ] 4.5 Ensure stale or incomplete preview handoff degrades to selection/configuration instead of broken result state.
+
+## 5. Recent Operations
+
+- [ ] 5.1 Record completed migration previews as compact recent-operation entries.
+- [ ] 5.2 Include workflow type, timestamp, aggregate preview status, and selected scope in recent operations.
+- [ ] 5.3 Route from a migration-preview recent operation back to preview result detail.
+- [ ] 5.4 Ensure recent-operation copy does not claim migration was applied.
+
+## 6. Tests and QA
+
+- [ ] 6.1 Add model tests for migration preview workflow descriptors, validation, classification, aggregate counts, and recent-operation summary.
+- [ ] 6.2 Add component tests for missing source, missing target, valid preview, degraded preview, unsupported preview, blocked preview, and result states.
+- [ ] 6.3 Add shell routing tests for overview, assets, and analysis handoff into migration preview.
+- [ ] 6.4 Add regression tests proving existing backup/import/validate/bulk workflows still work.
+- [ ] 6.5 Prepare an external QA prompt covering preview-only boundary, source/target/scope configuration, classification results, routed handoff, and recent operations.
+
+## 7. Documentation and Validation
+
+- [ ] 7.1 Update `README.md` if user-facing Backup / Migration behavior changes.
+- [ ] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
+- [ ] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
+- [ ] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate migration-preview --strict`.

--- a/openspec/changes/migration-preview/tasks.md
+++ b/openspec/changes/migration-preview/tasks.md
@@ -1,9 +1,10 @@
 ## 1. Workflow Model
 
 - [ ] 1.1 Add `migration-preview` to backup workflow types, labels, descriptors, and step definitions.
-- [ ] 1.2 Define migration preview source context, target context, preview scope, preview item, classification, and aggregate result types.
-- [ ] 1.3 Add helper functions for preview validation, item classification, aggregate count derivation, and recent-operation creation.
-- [ ] 1.4 Ensure existing backup/import/validate/bulk workflow helpers remain backward compatible.
+- [ ] 1.2 Define migration preview source context, target context, and preview scope types.
+- [ ] 1.3 Define preview item, closed classification enum, and preview-specific aggregate result status types.
+- [ ] 1.4 Add helper functions for preview validation, item classification, aggregate count derivation, and recent-operation creation.
+- [ ] 1.5 Ensure existing backup/import/validate/bulk workflow helpers remain backward compatible.
 
 ## 2. Selection and Configuration
 
@@ -12,10 +13,11 @@
 - [ ] 2.3 Require explicit target context before preview can proceed.
 - [ ] 2.4 Support bounded preview scope choices for sessions, reusable context assets, and project-context subset.
 - [ ] 2.5 Keep missing source, target, and scope fields visible and user-editable.
+- [ ] 2.6 Update idle-state description copy in `BackupMigrationFoundation` to include migration preview and remove the migration-preview exclusion statement.
 
 ## 3. Preview Validation and Result
 
-- [ ] 3.1 Validate source context, target context, canonical basis, and metadata completeness before preview result.
+- [ ] 3.1 Validate source context, target context, canonical source data availability, and metadata completeness before preview result.
 - [ ] 3.2 Classify preview items as `portable`, `degraded`, `unsupported`, or `blocked`.
 - [ ] 3.3 Render aggregate counts for all preview classifications.
 - [ ] 3.4 Render item-level preview detail with explanations.
@@ -24,7 +26,7 @@
 
 ## 4. Routed Handoff
 
-- [ ] 4.1 Extend backup-migration handoff types to carry migration preview source, target, and scope context.
+- [ ] 4.1 Extend backup-migration handoff types to carry migration preview source, target, and scope context after task 1.1 adds `migration-preview` to `BackupWorkflowType`.
 - [ ] 4.2 Add `Project Overview -> Migration Preview` route that opens preview selection/configuration without invented context.
 - [ ] 4.3 Add `Assets -> Migration Preview` route that may prefill explicit asset source/scope context only.
 - [ ] 4.4 Add `Analysis -> Migration Preview` route that preserves issue context but does not infer missing source or target.
@@ -51,3 +53,4 @@
 - [ ] 7.2 Update `CHANGELOG.md` under `## Unreleased` when implementation ships.
 - [ ] 7.3 Run targeted tests for backup-migration model helpers, `BackupMigrationFoundation`, and shell routing.
 - [ ] 7.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate migration-preview --strict`.
+- [ ] 7.5 Update `docs/viewer/backup-migration-foundation-qa-prompt.md` to include migration preview smoke checks and remove the migration-preview exclusion assertion.

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -39,7 +39,7 @@ import type { Source } from "@/lib/types";
 export type AnalysisFoundationProps = {
   handoff: AnalysisHandoff | null;
   onOpenAssets(handoff: AssetsHandoff): void;
-  onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string }): void;
+  onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string; backupWorkflowType?: AnalysisRoute["backupWorkflowType"] }): void;
   onOpenOverview(): void;
   onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
   loadingDelayMs?: number;
@@ -122,7 +122,7 @@ function RouteButton(props: {
   route: AnalysisRoute;
   navigationHandoff: AnalysisHandoff | null;
   onOpenAssets(handoff: AssetsHandoff): void;
-  onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string }): void;
+  onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string; backupWorkflowType?: AnalysisRoute["backupWorkflowType"] }): void;
   onOpenOverview(): void;
   onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
 }) {
@@ -168,6 +168,7 @@ function RouteButton(props: {
             title: props.finding.title,
             preservationWarning: props.route.preservationWarning ?? props.finding.preservationWarning,
             routeLabel: props.route.label,
+            backupWorkflowType: props.route.backupWorkflowType,
           })
         }
       >

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -493,16 +493,6 @@ export function BackupMigrationFoundation({
     () => buildBulkConfirmationDetails({ selections: dedupedBulkSelections, validationResult }),
     [dedupedBulkSelections, validationResult]
   );
-  const previewItems = useMemo(() => {
-    if (!previewSourceContext.product || !previewSourceContext.kind || !previewTargetContext.profile || !previewScope.kind) {
-      return [];
-    }
-    return buildMigrationPreviewItems({
-      sourceContext: previewSourceContext,
-      targetContext: previewTargetContext,
-      scope: previewScope,
-    });
-  }, [previewScope, previewSourceContext, previewTargetContext]);
 
   // ── Actions ──
   const resetWorkflow = useCallback(() => {

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -8,13 +8,21 @@ import { Card } from "@/components/ui/card";
 import {
   addRecentOperation,
   buildBulkSessionValidationResult,
+  buildMigrationPreviewItems,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
+  createMigrationPreviewOperationResult,
   createBulkOperationSummary,
   createOperationResult,
   dedupeSessionSelections,
   deriveAggregateOperationStatus,
+  deriveMigrationPreviewValidationResult,
   deriveValidationResult,
+  formatMigrationPreviewClassificationLabel,
+  formatMigrationPreviewScopeLabel,
+  formatMigrationPreviewSourceKindLabel,
+  formatMigrationPreviewSourceProductLabel,
+  formatMigrationPreviewTargetProfileLabel,
   formatWorkflowStateLabel,
   formatWorkflowTypeLabel,
   getBlockedSessionSelections,
@@ -36,6 +44,13 @@ import {
   type BackupWorkflowState,
   type BackupWorkflowType,
   type BulkSessionExecutionResult,
+  type MigrationPreviewScope,
+  type MigrationPreviewScopeKind,
+  type MigrationPreviewSourceContext,
+  type MigrationPreviewSourceKind,
+  type MigrationPreviewSourceProduct,
+  type MigrationPreviewTargetContext,
+  type MigrationPreviewTargetProfile,
   type RecentOperation,
 } from "@/lib/backupMigration";
 import type { Source } from "@/lib/types";
@@ -70,6 +85,33 @@ function buildImportValidation(backupId: string | null): BackupValidationItem[] 
 
 function buildValidatePackageValidation(backupId: string | null): BackupValidationItem[] {
   return buildImportValidation(backupId);
+}
+
+function deriveInitialPreviewSourceContext(handoff: BackupMigrationHandoff | null): MigrationPreviewSourceContext {
+  return handoff?.migrationPreviewSourceContext ?? {};
+}
+
+function deriveInitialPreviewTargetContext(handoff: BackupMigrationHandoff | null): MigrationPreviewTargetContext {
+  return handoff?.migrationPreviewTargetContext ?? {};
+}
+
+function deriveInitialPreviewScope(handoff: BackupMigrationHandoff | null): MigrationPreviewScope {
+  return handoff?.migrationPreviewScope ?? { itemRefs: [] };
+}
+
+function buildPreviewRepairLabel(target?: string): string {
+  if (target === "sessions") return "Inspect source sessions";
+  if (target === "assets") return "Inspect source assets";
+  if (target === "analysis") return "Review analysis context";
+  return "Return to overview context";
+}
+
+function isPreviewReadyForResult(input: {
+  sourceContext: MigrationPreviewSourceContext;
+  targetContext: MigrationPreviewTargetContext;
+  scope: MigrationPreviewScope;
+}): boolean {
+  return Boolean(input.sourceContext.product && input.sourceContext.kind && input.targetContext.profile && input.scope.kind);
 }
 
 export function resolveInitialBulkSelections(handoff: BackupMigrationHandoff | null): BackupSessionSelection[] {
@@ -195,8 +237,9 @@ export function ValidationPanel(props: { result: BackupValidationResult }) {
   );
 }
 
-export function OperationResultPanel(props: { result: BackupOperationResult; onNewWorkflow(): void }) {
+export function OperationResultPanel(props: { result: BackupOperationResult; onNewWorkflow(): void; onReconfigurePreview?(): void }) {
   const hasSessionResults = (props.result.sessionResults?.length ?? 0) > 0;
+  const hasPreviewItems = (props.result.previewItems?.length ?? 0) > 0;
 
   return (
     <Card className="p-4">
@@ -232,6 +275,40 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
             <div className="mt-1 text-xs leading-5">{props.result.sourceCopySummary}</div>
           </div>
         ) : null}
+        {props.result.workflowType === "migration-preview" ? (
+          <div className="rounded-xl border border-accent/35 bg-accent/8 px-3 py-3 text-sm text-muted">
+            <span className="font-medium text-foreground">Preview only.</span>{" "}
+            This result compares explicit source, target, and bounded scope without applying migration, generating bundles, or writing migrated objects.
+          </div>
+        ) : null}
+        {props.result.previewCounts ? (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {(["portable", "degraded", "unsupported", "blocked"] as const).map((classification) => (
+              <div key={classification} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                <div className="text-xs text-muted">{formatMigrationPreviewClassificationLabel(classification)}</div>
+                <div className="mt-1 font-medium">{props.result.previewCounts?.[classification] ?? 0}</div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {props.result.previewSourceContext || props.result.previewTargetContext || props.result.previewScope ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Preview context</div>
+            {props.result.previewSourceContext?.product && props.result.previewSourceContext.kind ? (
+              <div className="mt-1 text-xs leading-5">
+                Source: {formatMigrationPreviewSourceProductLabel(props.result.previewSourceContext.product)} / {formatMigrationPreviewSourceKindLabel(props.result.previewSourceContext.kind)}
+              </div>
+            ) : null}
+            {props.result.previewTargetContext?.profile ? (
+              <div className="mt-1 text-xs leading-5">Target: {formatMigrationPreviewTargetProfileLabel(props.result.previewTargetContext.profile)}</div>
+            ) : null}
+            {props.result.previewScope?.kind ? (
+              <div className="mt-1 text-xs leading-5">
+                Scope: {formatMigrationPreviewScopeLabel(props.result.previewScope.kind)} ({props.result.previewScope.itemRefs.length})
+              </div>
+            ) : null}
+          </div>
+        ) : null}
         {hasSessionResults ? (
           <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
             <div className="font-medium text-foreground">Per-session results</div>
@@ -265,12 +342,53 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
             </div>
           </div>
         ) : null}
-        <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
-          <span className="font-medium text-foreground">No vendor-runtime restore.</span>{" "}
-          Imported or backed-up sessions are product-readable only. They will not reopen inside a third-party agent runtime or private source store.
-        </div>
+        {props.result.workflowType === "migration-preview" && props.result.previewScope?.kind && !hasPreviewItems ? (
+          <div className="rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-3 text-sm text-muted">
+            No previewable {formatMigrationPreviewScopeLabel(props.result.previewScope.kind).toLowerCase()} were available. Return to scope configuration to refine the bounded preview set.
+          </div>
+        ) : null}
+        {hasPreviewItems ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Preview item detail</div>
+            <div className="mt-3 space-y-2">
+              {props.result.previewItems!.map((item) => (
+                <div key={item.id} className="rounded-lg border border-border/60 bg-background/40 px-3 py-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant={item.classification === "portable" ? "ok" : item.classification === "degraded" ? "default" : "warn"}>
+                        {item.classification}
+                      </Badge>
+                      <span className="font-medium">{item.label}</span>
+                    </div>
+                    <span className="text-xs text-muted">{formatMigrationPreviewScopeLabel(item.scopeKind)}</span>
+                  </div>
+                  <div className="mt-1 text-xs leading-5">{item.detail}</div>
+                  {item.classification !== "portable" ? (
+                    <div className="mt-1 text-xs text-muted">{buildPreviewRepairLabel(item.repairTarget)}</div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {props.result.workflowType === "migration-preview" ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <span className="font-medium text-foreground">No runtime restore or apply.</span>{" "}
+            Preview results are advisory compatibility findings only. They do not write objects, reopen third-party runtimes, or create backup packages.
+          </div>
+        ) : (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <span className="font-medium text-foreground">No vendor-runtime restore.</span>{" "}
+            Imported or backed-up sessions are product-readable only. They will not reopen inside a third-party agent runtime or private source store.
+          </div>
+        )}
       </div>
       <div className="mt-4 flex flex-wrap gap-2">
+        {props.result.workflowType === "migration-preview" ? (
+          <Button size="sm" variant="outline" onClick={props.onReconfigurePreview}>
+            Return to scope configuration
+          </Button>
+        ) : null}
         <Button size="sm" variant="outline" onClick={props.onNewWorkflow}>
           Start another workflow
         </Button>
@@ -304,6 +422,11 @@ function RecentOperationsPanel(props: { operations: RecentOperation[]; onSelectO
             </div>
             <div className="mt-1 text-xs text-muted">{op.summary}</div>
             {op.sessionCount != null ? <div className="mt-1 text-[11px] text-muted">Sessions: {op.sessionCount}</div> : null}
+            {op.workflowType === "migration-preview" && op.previewScope?.kind ? (
+              <div className="mt-1 text-[11px] text-muted">
+                Scope: {formatMigrationPreviewScopeLabel(op.previewScope.kind)} ({op.previewScope.itemRefs.length})
+              </div>
+            ) : null}
           </button>
         ))}
       </div>
@@ -339,6 +462,12 @@ export function BackupMigrationFoundation({
   // Import / validate state
   const [backupIdInput, setBackupIdInput] = useState("");
 
+  // Migration preview state
+  const [previewSourceContext, setPreviewSourceContext] = useState<MigrationPreviewSourceContext>(() => deriveInitialPreviewSourceContext(handoff));
+  const [previewTargetContext, setPreviewTargetContext] = useState<MigrationPreviewTargetContext>(() => deriveInitialPreviewTargetContext(handoff));
+  const [previewScope, setPreviewScope] = useState<MigrationPreviewScope>(() => deriveInitialPreviewScope(handoff));
+  const [previewScopeDraft, setPreviewScopeDraft] = useState(deriveInitialPreviewScope(handoff).itemRefs.join("\n"));
+
   // Validation
   const [validationResult, setValidationResult] = useState<BackupValidationResult | null>(null);
 
@@ -358,6 +487,16 @@ export function BackupMigrationFoundation({
     () => buildBulkConfirmationDetails({ selections: dedupedBulkSelections, validationResult }),
     [dedupedBulkSelections, validationResult]
   );
+  const previewItems = useMemo(() => {
+    if (!previewSourceContext.product || !previewSourceContext.kind || !previewTargetContext.profile || !previewScope.kind) {
+      return [];
+    }
+    return buildMigrationPreviewItems({
+      sourceContext: previewSourceContext,
+      targetContext: previewTargetContext,
+      scope: previewScope,
+    });
+  }, [previewScope, previewSourceContext, previewTargetContext]);
 
   // ── Actions ──
   const resetWorkflow = useCallback(() => {
@@ -373,6 +512,10 @@ export function BackupMigrationFoundation({
     setBulkDraftSource("");
     setBulkDraftRootId("");
     setBackupIdInput("");
+    setPreviewSourceContext({});
+    setPreviewTargetContext({});
+    setPreviewScope({ itemRefs: [] });
+    setPreviewScopeDraft("");
     setValidationResult(null);
     setIsExecuting(false);
     setExecutionError(null);
@@ -388,6 +531,15 @@ export function BackupMigrationFoundation({
     setIsExecuting(false);
     if (type === "bulk-session-backup") {
       setBulkSelections(resolveInitialBulkSelections(activeHandoff));
+    }
+    if (type === "migration-preview") {
+      const initialSource = deriveInitialPreviewSourceContext(activeHandoff);
+      const initialTarget = deriveInitialPreviewTargetContext(activeHandoff);
+      const initialScope = deriveInitialPreviewScope(activeHandoff);
+      setPreviewSourceContext(initialSource);
+      setPreviewTargetContext(initialTarget);
+      setPreviewScope(initialScope);
+      setPreviewScopeDraft(initialScope.itemRefs.join("\n"));
     }
   }, [activeHandoff]);
 
@@ -423,6 +575,25 @@ export function BackupMigrationFoundation({
       return;
     }
 
+    if (activeWorkflow === "migration-preview") {
+      const nextScope: MigrationPreviewScope = {
+        ...previewScope,
+        itemRefs: previewScopeDraft
+          .split("\n")
+          .map((item) => item.trim())
+          .filter(Boolean),
+      };
+      setPreviewScope(nextScope);
+      const result = deriveMigrationPreviewValidationResult({
+        sourceContext: previewSourceContext,
+        targetContext: previewTargetContext,
+        scope: nextScope,
+      });
+      setValidationResult(result);
+      setWorkflowState("validation");
+      return;
+    }
+
     let items: BackupValidationItem[];
     if (!normalizedBackupId) {
       items = activeWorkflow === "import-backup"
@@ -434,7 +605,7 @@ export function BackupMigrationFoundation({
     const result = deriveValidationResult(items);
     setValidationResult(result);
     setWorkflowState("validation");
-  }, [activeWorkflow, dedupedBulkSelections, normalizedBackupId, selectedSessionId]);
+  }, [activeWorkflow, dedupedBulkSelections, normalizedBackupId, previewScope, previewScopeDraft, previewSourceContext, previewTargetContext, selectedSessionId]);
 
   const addBulkSelection = useCallback(() => {
     if (!bulkDraftSessionId.trim() || !bulkDraftSource) return;
@@ -709,11 +880,55 @@ export function BackupMigrationFoundation({
     setWorkflowState("result");
   }, [validationResult]);
 
+  const finishMigrationPreview = useCallback(() => {
+    const nextScope: MigrationPreviewScope = {
+      ...previewScope,
+      itemRefs: previewScopeDraft
+        .split("\n")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    };
+    setPreviewScope(nextScope);
+
+    const items =
+      previewSourceContext.product && previewSourceContext.kind && previewTargetContext.profile && nextScope.kind
+        ? buildMigrationPreviewItems({
+            sourceContext: previewSourceContext,
+            targetContext: previewTargetContext,
+            scope: nextScope,
+          })
+        : [];
+
+    const result = createMigrationPreviewOperationResult({
+      sourceContext: previewSourceContext,
+      targetContext: previewTargetContext,
+      scope: nextScope,
+      items,
+      issueLabel: activeHandoff?.issueLabel,
+    });
+    setOperationResult(result);
+    setRecentOperations((prev) => addRecentOperation(prev, result));
+    setWorkflowState("result");
+  }, [activeHandoff?.issueLabel, previewScope, previewScopeDraft, previewSourceContext, previewTargetContext]);
+
   const handleSelectRecentOperation = useCallback((op: RecentOperation) => {
     setOperationResult(op);
     setActiveWorkflow(op.workflowType);
+    if (op.workflowType === "migration-preview") {
+      setPreviewSourceContext(op.previewSourceContext ?? {});
+      setPreviewTargetContext(op.previewTargetContext ?? {});
+      setPreviewScope(op.previewScope ?? { itemRefs: [] });
+      setPreviewScopeDraft((op.previewScope?.itemRefs ?? []).join("\n"));
+    }
     setWorkflowState("result");
   }, []);
+
+  const reopenMigrationPreviewConfiguration = useCallback(() => {
+    if (activeWorkflow !== "migration-preview") return;
+    setOperationResult(null);
+    setValidationResult(null);
+    setWorkflowState("configuration");
+  }, [activeWorkflow]);
 
   // ── Auto-prefill from handoff ──
   const prefillSessionId = useMemo(() => handoff?.sessionId ?? null, [handoff]);
@@ -739,7 +954,7 @@ export function BackupMigrationFoundation({
             <h2 className="text-xl font-semibold">Backup / Migration</h2>
             <p className="max-w-3xl text-sm leading-6 text-muted">
               Choose a bounded workflow below. Each workflow follows explicit selection, validation, and result steps.
-              This foundation does not support migration preview, project bundle packaging, vendor-runtime restore, or cloud sync.
+              This foundation does not support migration apply, project bundle packaging, vendor-runtime restore, or cloud sync.
             </p>
           </div>
         </Card>
@@ -779,7 +994,7 @@ export function BackupMigrationFoundation({
           </div>
         </Card>
 
-        <OperationResultPanel result={operationResult} onNewWorkflow={resetWorkflow} />
+        <OperationResultPanel result={operationResult} onNewWorkflow={resetWorkflow} onReconfigurePreview={reopenMigrationPreviewConfiguration} />
 
         <RecentOperationsPanel operations={recentOperations} onSelectOperation={handleSelectRecentOperation} />
       </div>
@@ -856,6 +1071,59 @@ export function BackupMigrationFoundation({
                   <div className="text-xs text-muted">Pre-filled from routed handoff.</div>
                 ) : null}
                 <Button size="sm" disabled={!selectedSessionId || !selectedSource} onClick={advanceState}>
+                  Continue to Configuration
+                </Button>
+              </div>
+            </Card>
+          ) : null}
+
+          {workflowState === "selection" && activeWorkflow === "migration-preview" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Source Context</div>
+              <div className="space-y-3">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Preview requires explicit source context. Routed handoff can prefill only fields that were explicitly provided.
+                </div>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Source product</span>
+                  <select
+                    value={previewSourceContext.product ?? ""}
+                    onChange={(e) => setPreviewSourceContext((prev) => ({ ...prev, product: (e.target.value as MigrationPreviewSourceProduct) || undefined }))}
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  >
+                    <option value="">Choose source product</option>
+                    <option value="antigravity">Antigravity</option>
+                    <option value="windsurf">Windsurf</option>
+                    <option value="codex">Codex</option>
+                    <option value="imported">Imported</option>
+                    <option value="generated">Generated</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Source context type</span>
+                  <select
+                    value={previewSourceContext.kind ?? ""}
+                    onChange={(e) => setPreviewSourceContext((prev) => ({ ...prev, kind: (e.target.value as MigrationPreviewSourceKind) || undefined }))}
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  >
+                    <option value="">Choose source context</option>
+                    <option value="session-evidence">Session evidence</option>
+                    <option value="context-asset">Reusable context asset</option>
+                    <option value="analysis-context">Analysis context</option>
+                    <option value="project-overview">Project overview</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Source label (optional)</span>
+                  <input
+                    type="text"
+                    value={previewSourceContext.label ?? ""}
+                    onChange={(e) => setPreviewSourceContext((prev) => ({ ...prev, label: e.target.value || undefined }))}
+                    placeholder="Keep explicit routed/source wording visible"
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                <Button size="sm" onClick={advanceState}>
                   Continue to Configuration
                 </Button>
               </div>
@@ -1065,6 +1333,64 @@ export function BackupMigrationFoundation({
             </Card>
           ) : null}
 
+          {workflowState === "configuration" && activeWorkflow === "migration-preview" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Configure Preview</div>
+              <div className="space-y-3">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Keep source, target, and scope explicit. This workflow is preview only and does not apply migration or generate bundles.
+                </div>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Target context</span>
+                  <select
+                    value={previewTargetContext.profile ?? ""}
+                    onChange={(e) => setPreviewTargetContext((prev) => ({ ...prev, profile: (e.target.value as MigrationPreviewTargetProfile) || undefined }))}
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  >
+                    <option value="">Choose target context</option>
+                    <option value="session-backup-package">Session backup package</option>
+                    <option value="reusable-context-assets">Reusable context assets</option>
+                    <option value="project-context-subset">Project-context subset</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Preview scope</span>
+                  <select
+                    value={previewScope.kind ?? ""}
+                    onChange={(e) => setPreviewScope((prev) => ({ ...prev, kind: (e.target.value as MigrationPreviewScopeKind) || undefined }))}
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  >
+                    <option value="">Choose bounded scope</option>
+                    <option value="sessions">Sessions</option>
+                    <option value="assets">Reusable context assets</option>
+                    <option value="project-context">Project-context subset</option>
+                  </select>
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Scope item refs</span>
+                  <textarea
+                    value={previewScopeDraft}
+                    onChange={(e) => setPreviewScopeDraft(e.target.value)}
+                    placeholder="One explicit session / asset / project-context ref per line"
+                    rows={6}
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                <div className="text-xs leading-5 text-muted">
+                  Empty scope remains visible and leads to an explicit no-result preview state so you can return here and refine the bounded scope.
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={retreatState}>
+                    Back
+                  </Button>
+                  <Button size="sm" onClick={runValidation}>
+                    Validate Preview
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
           {/* Validation */}
           {workflowState === "validation" && validationResult ? (
             <div className="space-y-4">
@@ -1100,6 +1426,18 @@ export function BackupMigrationFoundation({
                   <Button size="sm" onClick={finishValidateOnly}>
                     Complete Validation
                   </Button>
+                ) : activeWorkflow === "migration-preview" ? (
+                  isPreviewReadyForResult({
+                    sourceContext: previewSourceContext,
+                    targetContext: previewTargetContext,
+                    scope: previewScope,
+                  }) ? (
+                    <Button size="sm" onClick={finishMigrationPreview}>
+                      Open Preview Result
+                    </Button>
+                  ) : (
+                    <div className="text-sm text-muted">Source, target, and scope must remain explicit before preview result can open.</div>
+                  )
                 ) : canProceedFromValidation(validationResult) ? (
                   <Button size="sm" onClick={advanceState}>
                     Proceed to Confirmation
@@ -1226,6 +1564,24 @@ export function BackupMigrationFoundation({
                   <div className="text-xs text-muted">Selected sessions</div>
                   <div className="font-medium">{dedupedBulkSelections.length}</div>
                   <div className="mt-1 text-xs text-muted">{bulkConfirmationDetails.sourceCopySummary}</div>
+                </div>
+              ) : null}
+              {activeWorkflow === "migration-preview" ? (
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-2">
+                  <div className="text-xs text-muted">Preview context</div>
+                  <div className="font-medium">
+                    {previewSourceContext.product && previewSourceContext.kind
+                      ? `${formatMigrationPreviewSourceProductLabel(previewSourceContext.product)} / ${formatMigrationPreviewSourceKindLabel(previewSourceContext.kind)}`
+                      : "Source still required"}
+                  </div>
+                  <div className="mt-1 text-xs text-muted">
+                    {previewTargetContext.profile ? formatMigrationPreviewTargetProfileLabel(previewTargetContext.profile) : "Target still required"}
+                  </div>
+                  <div className="mt-1 text-xs text-muted">
+                    {previewScope.kind
+                      ? `${formatMigrationPreviewScopeLabel(previewScope.kind)} (${previewScope.itemRefs.length || previewScopeDraft.split("\n").map((item) => item.trim()).filter(Boolean).length})`
+                      : "Scope still required"}
+                  </div>
                 </div>
               ) : null}
               {normalizedBackupId && activeWorkflow !== "session-backup" ? (

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -114,6 +114,13 @@ function isPreviewReadyForResult(input: {
   return Boolean(input.sourceContext.product && input.sourceContext.kind && input.targetContext.profile && input.scope.kind);
 }
 
+function parsePreviewScopeDraft(draft: string): string[] {
+  return draft
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 function getOperationStatusBadgeVariant(status: BackupOperationResult["status"]): "default" | "ok" | "warn" {
   if (status === "success" || status === "preview-clear") return "ok";
   if (status === "failed" || status === "preview-with-blockers") return "warn";
@@ -390,7 +397,7 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
         )}
       </div>
       <div className="mt-4 flex flex-wrap gap-2">
-        {props.result.workflowType === "migration-preview" ? (
+        {props.result.workflowType === "migration-preview" && props.onReconfigurePreview ? (
           <Button size="sm" variant="outline" onClick={props.onReconfigurePreview}>
             Return to scope configuration
           </Button>
@@ -574,10 +581,7 @@ export function BackupMigrationFoundation({
     if (activeWorkflow === "migration-preview") {
       const nextScope: MigrationPreviewScope = {
         ...previewScope,
-        itemRefs: previewScopeDraft
-          .split("\n")
-          .map((item) => item.trim())
-          .filter(Boolean),
+        itemRefs: parsePreviewScopeDraft(previewScopeDraft),
       };
       setPreviewScope(nextScope);
       const result = deriveMigrationPreviewValidationResult({
@@ -879,10 +883,7 @@ export function BackupMigrationFoundation({
   const finishMigrationPreview = useCallback(() => {
     const nextScope: MigrationPreviewScope = {
       ...previewScope,
-      itemRefs: previewScopeDraft
-        .split("\n")
-        .map((item) => item.trim())
-        .filter(Boolean),
+      itemRefs: parsePreviewScopeDraft(previewScopeDraft),
     };
     setPreviewScope(nextScope);
 

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -114,6 +114,12 @@ function isPreviewReadyForResult(input: {
   return Boolean(input.sourceContext.product && input.sourceContext.kind && input.targetContext.profile && input.scope.kind);
 }
 
+export function resolveMigrationPreviewInvalidWorkflowState(input: {
+  sourceContext: MigrationPreviewSourceContext;
+}): BackupWorkflowState {
+  return input.sourceContext.product && input.sourceContext.kind ? "configuration" : "selection";
+}
+
 function parsePreviewScopeDraft(draft: string): string[] {
   return draft
     .split("\n")
@@ -590,6 +596,10 @@ export function BackupMigrationFoundation({
         scope: nextScope,
       });
       setValidationResult(result);
+      if (result.status === "invalid") {
+        setWorkflowState(resolveMigrationPreviewInvalidWorkflowState({ sourceContext: previewSourceContext }));
+        return;
+      }
       setWorkflowState("validation");
       return;
     }
@@ -1386,6 +1396,10 @@ export function BackupMigrationFoundation({
                 </div>
               </div>
             </Card>
+          ) : null}
+
+          {activeWorkflow === "migration-preview" && workflowState !== "validation" && validationResult?.status === "invalid" ? (
+            <ValidationPanel result={validationResult} />
           ) : null}
 
           {/* Validation */}

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -114,6 +114,12 @@ function isPreviewReadyForResult(input: {
   return Boolean(input.sourceContext.product && input.sourceContext.kind && input.targetContext.profile && input.scope.kind);
 }
 
+function getOperationStatusBadgeVariant(status: BackupOperationResult["status"]): "default" | "ok" | "warn" {
+  if (status === "success" || status === "preview-clear") return "ok";
+  if (status === "failed" || status === "preview-with-blockers") return "warn";
+  return "default";
+}
+
 export function resolveInitialBulkSelections(handoff: BackupMigrationHandoff | null): BackupSessionSelection[] {
   if (!handoff) return [];
   if (handoff.sessions?.length) return dedupeSessionSelections(handoff.sessions);
@@ -245,7 +251,7 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
     <Card className="p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="text-xs uppercase tracking-[0.18em] text-muted">Operation Result</div>
-        <Badge variant={props.result.status === "success" ? "ok" : props.result.status === "failed" ? "warn" : "default"}>
+        <Badge variant={getOperationStatusBadgeVariant(props.result.status)}>
           {props.result.status}
         </Badge>
       </div>
@@ -413,7 +419,7 @@ function RecentOperationsPanel(props: { operations: RecentOperation[]; onSelectO
           >
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
-                <Badge variant={op.status === "success" ? "ok" : op.status === "failed" ? "warn" : "default"}>
+                <Badge variant={getOperationStatusBadgeVariant(op.status)}>
                   {op.status}
                 </Badge>
                 <span className="font-medium">{formatWorkflowTypeLabel(op.workflowType)}</span>

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -227,11 +227,21 @@ export function buildBackupHandoffFromAssets(context: {
 }): BackupMigrationHandoff {
   return {
     origin: "assets",
-    subtitle: `Prepare bounded backup or migration work${context.subtype ? ` for ${context.subtype} assets` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}.`,
-    continueLabel: "Workflow execution belongs to Backup / Migration.",
+    subtitle: `Preview bounded migration scope${context.subtype ? ` for ${context.subtype} assets` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}.`,
+    continueLabel: "Only explicit asset source and scope context are prefilled here. Source and target remain editable if they were not supplied by the route.",
     returnLabel: "Return to Assets for object-level review.",
     assetId: context.assetId,
     assetSubtype: context.subtype,
+    workflowType: "migration-preview",
+    migrationPreviewSourceContext: {
+      kind: "context-asset",
+      label: context.assetId ?? context.subtype,
+    },
+    migrationPreviewScope: {
+      kind: "assets",
+      itemRefs: context.assetId ? [context.assetId] : [],
+      label: context.subtype ? `${context.subtype} asset scope` : undefined,
+    },
   };
 }
 
@@ -240,15 +250,34 @@ export function buildBackupHandoffFromAnalysis(context: {
   title: string;
   preservationWarning?: string;
   routeLabel?: string;
+  backupWorkflowType?: "session-backup" | "migration-preview";
 }): BackupMigrationHandoff {
+  if (context.backupWorkflowType !== "migration-preview") {
+    return {
+      origin: "analysis",
+      subtitle: `${context.routeLabel ?? "Recommended route"} for ${context.title}.`,
+      continueLabel: context.preservationWarning ?? "Backup / Migration owns workflow validation and execution.",
+      returnLabel: "Return to Analysis for grouped interpretation.",
+      findingId: context.findingId,
+      preservationWarning: context.preservationWarning,
+      issueLabel: context.title,
+      workflowType: "session-backup",
+    };
+  }
+
   return {
     origin: "analysis",
-    subtitle: `${context.routeLabel ?? "Recommended route"} for ${context.title}.`,
-    continueLabel: context.preservationWarning ?? "Backup / Migration owns workflow validation and execution.",
+    subtitle: `${context.routeLabel ?? "Migration preview"} for ${context.title}.`,
+    continueLabel: context.preservationWarning ?? "Analysis issue context is preserved, but missing source or target must still be entered explicitly before preview can complete.",
     returnLabel: "Return to Analysis for grouped interpretation.",
     findingId: context.findingId,
     preservationWarning: context.preservationWarning,
-    workflowType: "session-backup",
+    issueLabel: context.title,
+    workflowType: "migration-preview",
+    migrationPreviewSourceContext: {
+      kind: "analysis-context",
+      label: context.title,
+    },
   };
 }
 
@@ -287,6 +316,7 @@ export function buildBackupHandoffFromOverview(workflowType: BackupWorkflowType)
     "bulk-session-backup": "Start a bounded bulk session backup workflow from Project Overview.",
     "import-backup": "Start a bounded import workflow from Project Overview.",
     "validate-package": "Start a bounded package validation workflow from Project Overview.",
+    "migration-preview": "Start a bounded migration preview workflow from Project Overview.",
   } satisfies Record<BackupWorkflowType, string>;
 
   return {
@@ -295,6 +325,7 @@ export function buildBackupHandoffFromOverview(workflowType: BackupWorkflowType)
     continueLabel: "Workflow execution belongs to Backup / Migration.",
     returnLabel: "Return to Project Overview.",
     workflowType,
+    migrationPreviewSourceContext: workflowType === "migration-preview" ? { kind: "project-overview" } : undefined,
   };
 }
 
@@ -493,6 +524,14 @@ function ProjectOverviewSurface(props: {
           >
             Validate backup package
           </Button>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("migration-preview"))}
+          >
+            Open migration preview
+          </Button>
           <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => props.onNavigate("backup")}>
             Browse backup workflows
           </Button>
@@ -659,6 +698,7 @@ export default function ProjectShellClient() {
     title: string;
     preservationWarning?: string;
     routeLabel?: string;
+    backupWorkflowType?: "session-backup" | "migration-preview";
   }) => {
     leaveSessionsSurface();
     setAssetsHandoff(null);

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -235,7 +235,7 @@ export function buildBackupHandoffFromAssets(context: {
     workflowType: "migration-preview",
     migrationPreviewSourceContext: {
       kind: "context-asset",
-      label: context.assetId ?? context.subtype,
+      label: context.assetId,
     },
     migrationPreviewScope: {
       kind: "assets",

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -28,6 +28,7 @@ export type AnalysisRoute = {
   target: AnalysisRouteTarget;
   label: string;
   reason: string;
+  backupWorkflowType?: "session-backup" | "migration-preview";
   sessionId?: string;
   source?: Source;
   rootId?: string;
@@ -167,7 +168,15 @@ export function createAnalysisFindingSeeds(): AnalysisFinding[] {
           target: "backup",
           label: "Preserve in Backup / Migration",
           reason: "Preserve source evidence before changing backup or migration state.",
+          backupWorkflowType: "session-backup",
           preservationWarning: "Preserve before destructive cleanup or migration changes.",
+        },
+        {
+          target: "backup",
+          label: "Preview migration compatibility",
+          reason: "Preview portability before changing backup or migration state.",
+          backupWorkflowType: "migration-preview",
+          preservationWarning: "Preview before destructive cleanup or migration changes.",
         },
         {
           target: "sessions",

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -544,8 +544,9 @@ export function createMigrationPreviewSummary(input: {
   counts: MigrationPreviewAggregateCounts;
 }): string {
   const normalizedScope = normalizeMigrationPreviewScope(input.scope);
-  const scopeLabel = normalizedScope.kind ? formatMigrationPreviewScopeLabel(normalizedScope.kind).toLowerCase() : "items";
   const total = Object.values(input.counts).reduce((sum, count) => sum + count, 0);
+  const pluralScopeLabel = normalizedScope.kind ? formatMigrationPreviewScopeLabel(normalizedScope.kind).toLowerCase() : "items";
+  const scopeLabel = total === 1 && pluralScopeLabel.endsWith("s") ? pluralScopeLabel.slice(0, -1) : pluralScopeLabel;
 
   return `Preview only: ${total} ${scopeLabel} checked — ${input.counts.portable} portable, ${input.counts.degraded} degraded, ${input.counts.unsupported} unsupported, ${input.counts.blocked} blocked.`;
 }

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -456,13 +456,28 @@ export function classifyMigrationPreviewItem(input: {
   sourceRef: string;
 }): MigrationPreviewItem {
   const normalizedRef = input.sourceRef.trim();
+  const repairTarget = deriveMigrationPreviewRepairTarget(input.scopeKind, input.sourceContext.kind);
+  const targetProfile = input.targetContext.profile;
+
+  if (!targetProfile) {
+    return {
+      id: `${input.scopeKind}:${normalizedRef}`,
+      label: normalizedRef,
+      scopeKind: input.scopeKind,
+      sourceRef: normalizedRef,
+      classification: "blocked",
+      detail: `Preview only: ${normalizedRef} is blocked because the target profile is incomplete and the migration preview cannot classify its destination.`,
+      repairTarget,
+      repairLabel: `Inspect in ${repairTarget}`,
+    };
+  }
+
   const classification = deriveMigrationPreviewClassification({
     scopeKind: input.scopeKind,
     sourceRef: normalizedRef,
-    targetProfile: input.targetContext.profile!,
+    targetProfile,
   });
-  const repairTarget = deriveMigrationPreviewRepairTarget(input.scopeKind, input.sourceContext.kind);
-  const targetLabel = formatMigrationPreviewTargetProfileLabel(input.targetContext.profile!);
+  const targetLabel = formatMigrationPreviewTargetProfileLabel(targetProfile);
 
   return {
     id: `${input.scopeKind}:${normalizedRef}`,

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -983,7 +983,7 @@ export function buildBackupHandoffInstanceKey(handoff: BackupMigrationHandoff | 
     handoff.migrationPreviewSourceContext?.kind ?? "no-preview-source-kind",
     handoff.migrationPreviewTargetContext?.profile ?? "no-preview-target-profile",
     handoff.migrationPreviewScope?.kind ?? "no-preview-scope-kind",
-    handoff.migrationPreviewScope?.itemRefs.join("|") ?? "no-preview-scope-items",
+    handoff.migrationPreviewScope?.itemRefs?.join("|") ?? "no-preview-scope-items",
     handoff.subtitle,
   ].join(":");
 }

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -2,7 +2,7 @@ import type { Source } from "@/lib/types";
 
 // ── Workflow types ──────────────────────────────────────────────────────────
 
-export const BACKUP_WORKFLOW_TYPES = ["session-backup", "bulk-session-backup", "import-backup", "validate-package"] as const;
+export const BACKUP_WORKFLOW_TYPES = ["session-backup", "bulk-session-backup", "import-backup", "validate-package", "migration-preview"] as const;
 export type BackupWorkflowType = (typeof BACKUP_WORKFLOW_TYPES)[number];
 
 export const BACKUP_WORKFLOW_STATES = [
@@ -16,6 +16,56 @@ export const BACKUP_WORKFLOW_STATES = [
   "failed",
 ] as const;
 export type BackupWorkflowState = (typeof BACKUP_WORKFLOW_STATES)[number];
+
+export const MIGRATION_PREVIEW_SOURCE_PRODUCTS = ["antigravity", "windsurf", "codex", "imported", "generated"] as const;
+export type MigrationPreviewSourceProduct = (typeof MIGRATION_PREVIEW_SOURCE_PRODUCTS)[number];
+
+export const MIGRATION_PREVIEW_SOURCE_KINDS = ["session-evidence", "context-asset", "analysis-context", "project-overview"] as const;
+export type MigrationPreviewSourceKind = (typeof MIGRATION_PREVIEW_SOURCE_KINDS)[number];
+
+export const MIGRATION_PREVIEW_TARGET_PROFILES = ["session-backup-package", "reusable-context-assets", "project-context-subset"] as const;
+export type MigrationPreviewTargetProfile = (typeof MIGRATION_PREVIEW_TARGET_PROFILES)[number];
+
+export const MIGRATION_PREVIEW_SCOPE_KINDS = ["sessions", "assets", "project-context"] as const;
+export type MigrationPreviewScopeKind = (typeof MIGRATION_PREVIEW_SCOPE_KINDS)[number];
+
+export const MIGRATION_PREVIEW_CLASSIFICATIONS = ["portable", "degraded", "unsupported", "blocked"] as const;
+export type MigrationPreviewClassification = (typeof MIGRATION_PREVIEW_CLASSIFICATIONS)[number];
+
+export const MIGRATION_PREVIEW_AGGREGATE_STATUSES = ["preview-clear", "preview-with-concerns", "preview-with-blockers"] as const;
+export type MigrationPreviewAggregateStatus = (typeof MIGRATION_PREVIEW_AGGREGATE_STATUSES)[number];
+
+export type MigrationPreviewSourceContext = {
+  product?: MigrationPreviewSourceProduct;
+  kind?: MigrationPreviewSourceKind;
+  label?: string;
+};
+
+export type MigrationPreviewTargetContext = {
+  profile?: MigrationPreviewTargetProfile;
+  label?: string;
+};
+
+export type MigrationPreviewScope = {
+  kind?: MigrationPreviewScopeKind;
+  itemRefs: string[];
+  label?: string;
+};
+
+export type MigrationPreviewRepairTarget = "sessions" | "assets" | "analysis" | "overview";
+
+export type MigrationPreviewItem = {
+  id: string;
+  label: string;
+  scopeKind: MigrationPreviewScopeKind;
+  sourceRef: string;
+  classification: MigrationPreviewClassification;
+  detail: string;
+  repairTarget?: MigrationPreviewRepairTarget;
+  repairLabel?: string;
+};
+
+export type MigrationPreviewAggregateCounts = Record<MigrationPreviewClassification, number>;
 
 // ── Validation ──────────────────────────────────────────────────────────────
 
@@ -72,11 +122,12 @@ export type BackupPackageVerifyResponse = BackupPackageVerifySuccess | BackupPac
 // ── Operation result ────────────────────────────────────────────────────────
 
 export type BackupOperationStatus = "success" | "success-with-warnings" | "failed";
+export type OperationResultStatus = BackupOperationStatus | MigrationPreviewAggregateStatus;
 
 export type BackupOperationResult = {
   id: string;
   workflowType: BackupWorkflowType;
-  status: BackupOperationStatus;
+  status: OperationResultStatus;
   timestamp: string;
   summary: string;
   backupId?: string;
@@ -84,6 +135,12 @@ export type BackupOperationResult = {
   warnings?: string[];
   sourceCopySummary?: string;
   sessionResults?: BulkSessionExecutionResult[];
+  previewSourceContext?: MigrationPreviewSourceContext;
+  previewTargetContext?: MigrationPreviewTargetContext;
+  previewScope?: MigrationPreviewScope;
+  previewCounts?: MigrationPreviewAggregateCounts;
+  previewItems?: MigrationPreviewItem[];
+  issueLabel?: string;
 };
 
 export type BulkSessionExecutionResult = {
@@ -127,6 +184,9 @@ export type BackupMigrationHandoff = {
   findingId?: string;
   preservationWarning?: string;
   issueLabel?: string;
+  migrationPreviewSourceContext?: MigrationPreviewSourceContext;
+  migrationPreviewTargetContext?: MigrationPreviewTargetContext;
+  migrationPreviewScope?: MigrationPreviewScope;
 };
 
 // ── Workflow descriptor ─────────────────────────────────────────────────────
@@ -163,6 +223,12 @@ export const WORKFLOW_DESCRIPTORS: BackupWorkflowDescriptor[] = [
     description: "Run trust and compatibility checks on a backup package without importing it.",
     stepsLabel: ["Select package", "Validate", "Result"],
   },
+  {
+    type: "migration-preview",
+    label: "Migration Preview",
+    description: "Preview only: compare explicit source, target, and bounded scope before any migration action.",
+    stepsLabel: ["Select source", "Configure preview", "Validate", "Result"],
+  },
 ];
 
 // ── Helper functions ────────────────────────────────────────────────────────
@@ -177,6 +243,7 @@ export function formatWorkflowTypeLabel(type: BackupWorkflowType): string {
     "bulk-session-backup": "Bulk Session Backup",
     "import-backup": "Import Backup",
     "validate-package": "Validate Package",
+    "migration-preview": "Migration Preview",
   };
   return labels[type];
 }
@@ -204,6 +271,8 @@ export function getStepsForWorkflow(type: BackupWorkflowType): BackupWorkflowSta
       return ["selection", "validation", "confirmation", "execution", "result"];
     case "validate-package":
       return ["selection", "validation", "result"];
+    case "migration-preview":
+      return ["selection", "configuration", "validation", "result"];
   }
 }
 
@@ -229,6 +298,240 @@ export function getPreviousState(
 
 export function isTerminalState(state: BackupWorkflowState): boolean {
   return state === "result" || state === "failed";
+}
+
+// ── Migration preview formatting and helper functions ───────────────────────
+
+export function formatMigrationPreviewSourceProductLabel(product: MigrationPreviewSourceProduct): string {
+  if (product === "antigravity") return "Antigravity";
+  if (product === "windsurf") return "Windsurf";
+  if (product === "codex") return "Codex";
+  return product.charAt(0).toUpperCase() + product.slice(1);
+}
+
+export function formatMigrationPreviewSourceKindLabel(kind: MigrationPreviewSourceKind): string {
+  const labels: Record<MigrationPreviewSourceKind, string> = {
+    "session-evidence": "Session evidence",
+    "context-asset": "Reusable context asset",
+    "analysis-context": "Analysis context",
+    "project-overview": "Project overview",
+  };
+  return labels[kind];
+}
+
+export function formatMigrationPreviewTargetProfileLabel(profile: MigrationPreviewTargetProfile): string {
+  const labels: Record<MigrationPreviewTargetProfile, string> = {
+    "session-backup-package": "Session backup package",
+    "reusable-context-assets": "Reusable context assets",
+    "project-context-subset": "Project-context subset",
+  };
+  return labels[profile];
+}
+
+export function formatMigrationPreviewScopeLabel(kind: MigrationPreviewScopeKind): string {
+  const labels: Record<MigrationPreviewScopeKind, string> = {
+    sessions: "Sessions",
+    assets: "Reusable context assets",
+    "project-context": "Project-context subset",
+  };
+  return labels[kind];
+}
+
+export function formatMigrationPreviewClassificationLabel(classification: MigrationPreviewClassification): string {
+  const labels: Record<MigrationPreviewClassification, string> = {
+    portable: "Portable",
+    degraded: "Degraded",
+    unsupported: "Unsupported",
+    blocked: "Blocked",
+  };
+  return labels[classification];
+}
+
+export function normalizeMigrationPreviewScope(scope?: MigrationPreviewScope | null): MigrationPreviewScope {
+  const itemRefs = Array.from(new Set((scope?.itemRefs ?? []).map((item) => item.trim()).filter(Boolean)));
+
+  return {
+    kind: scope?.kind,
+    itemRefs,
+    label: scope?.label?.trim() || undefined,
+  };
+}
+
+export function deriveMigrationPreviewValidationResult(input: {
+  sourceContext?: MigrationPreviewSourceContext | null;
+  targetContext?: MigrationPreviewTargetContext | null;
+  scope?: MigrationPreviewScope | null;
+}): BackupValidationResult {
+  const normalizedScope = normalizeMigrationPreviewScope(input.scope);
+  const items: BackupValidationItem[] = [];
+
+  if (!input.sourceContext?.product || !input.sourceContext.kind) {
+    items.push({
+      id: "v-preview-source-required",
+      label: "Source context",
+      severity: "block",
+      detail: "Explicit source context is required before preview. Choose the source product and source context type.",
+    });
+  } else {
+    items.push({
+      id: "v-preview-source-ok",
+      label: "Source context",
+      severity: "ok",
+      detail: `${formatMigrationPreviewSourceProductLabel(input.sourceContext.product)} / ${formatMigrationPreviewSourceKindLabel(input.sourceContext.kind)} is explicitly selected for preview.`,
+    });
+  }
+
+  if (!input.targetContext?.profile) {
+    items.push({
+      id: "v-preview-target-required",
+      label: "Target context",
+      severity: "block",
+      detail: "Explicit target context is required before preview. Choose the target profile to compare against.",
+    });
+  } else {
+    items.push({
+      id: "v-preview-target-ok",
+      label: "Target context",
+      severity: "ok",
+      detail: `${formatMigrationPreviewTargetProfileLabel(input.targetContext.profile)} is selected as the preview target.`,
+    });
+  }
+
+  if (!normalizedScope.kind) {
+    items.push({
+      id: "v-preview-scope-required",
+      label: "Preview scope",
+      severity: "block",
+      detail: "A bounded preview scope is required before preview. Choose sessions, reusable context assets, or a project-context subset.",
+    });
+  } else if (normalizedScope.itemRefs.length === 0) {
+    items.push({
+      id: "v-preview-scope-empty",
+      label: "Preview scope",
+      severity: "warning",
+      detail: `No previewable ${formatMigrationPreviewScopeLabel(normalizedScope.kind).toLowerCase()} are currently listed. Return to scope configuration to continue.`,
+    });
+  } else {
+    items.push({
+      id: "v-preview-scope-ok",
+      label: "Preview scope",
+      severity: "ok",
+      detail: `${normalizedScope.itemRefs.length} ${formatMigrationPreviewScopeLabel(normalizedScope.kind).toLowerCase()} selected for preview-only classification.`,
+    });
+  }
+
+  return deriveValidationResult(items);
+}
+
+function deriveMigrationPreviewRepairTarget(scopeKind: MigrationPreviewScopeKind, sourceKind?: MigrationPreviewSourceKind): MigrationPreviewRepairTarget {
+  if (scopeKind === "sessions") return "sessions";
+  if (scopeKind === "assets") return "assets";
+  if (sourceKind === "analysis-context") return "analysis";
+  return "overview";
+}
+
+function deriveMigrationPreviewClassification(input: {
+  scopeKind: MigrationPreviewScopeKind;
+  sourceRef: string;
+  targetProfile: MigrationPreviewTargetProfile;
+}): MigrationPreviewClassification {
+  const normalizedRef = input.sourceRef.trim().toLowerCase();
+  const isBlocked = ["missing", "orphaned", "unresolved", "unknown-imported", "unavailable"].some((token) => normalizedRef.includes(token));
+  const isUnsupported = ["unsupported", "skill"].some((token) => normalizedRef.includes(token)) ||
+    (input.targetProfile === "session-backup-package" && input.scopeKind === "assets" && normalizedRef.includes("command"));
+  const isDegraded = ["stale", "memory", "project-context"].some((token) => normalizedRef.includes(token)) ||
+    input.scopeKind === "project-context" ||
+    input.targetProfile === "project-context-subset";
+
+  if (isBlocked) return "blocked";
+  if (isUnsupported) return "unsupported";
+  if (isDegraded) return "degraded";
+  return "portable";
+}
+
+export function classifyMigrationPreviewItem(input: {
+  sourceContext: MigrationPreviewSourceContext;
+  targetContext: MigrationPreviewTargetContext;
+  scopeKind: MigrationPreviewScopeKind;
+  sourceRef: string;
+}): MigrationPreviewItem {
+  const normalizedRef = input.sourceRef.trim();
+  const classification = deriveMigrationPreviewClassification({
+    scopeKind: input.scopeKind,
+    sourceRef: normalizedRef,
+    targetProfile: input.targetContext.profile!,
+  });
+  const repairTarget = deriveMigrationPreviewRepairTarget(input.scopeKind, input.sourceContext.kind);
+  const targetLabel = formatMigrationPreviewTargetProfileLabel(input.targetContext.profile!);
+
+  return {
+    id: `${input.scopeKind}:${normalizedRef}`,
+    label: normalizedRef,
+    scopeKind: input.scopeKind,
+    sourceRef: normalizedRef,
+    classification,
+    detail:
+      classification === "portable"
+        ? `Preview only: ${normalizedRef} maps cleanly into ${targetLabel} with recognized metadata.`
+        : classification === "degraded"
+          ? `Preview only: ${normalizedRef} can be represented in ${targetLabel}, but fidelity or contextual detail will be reduced.`
+          : classification === "unsupported"
+            ? `Preview only: ${normalizedRef} has no supported mapping into ${targetLabel} in this bounded preview.`
+            : `Preview only: ${normalizedRef} is blocked because canonical data, provenance, or required source detail is incomplete.`,
+    repairTarget,
+    repairLabel: classification === "portable" ? undefined : `Inspect in ${repairTarget}`,
+  };
+}
+
+export function deriveMigrationPreviewCounts(items: MigrationPreviewItem[]): MigrationPreviewAggregateCounts {
+  return items.reduce<MigrationPreviewAggregateCounts>(
+    (counts, item) => {
+      counts[item.classification] += 1;
+      return counts;
+    },
+    {
+      portable: 0,
+      degraded: 0,
+      unsupported: 0,
+      blocked: 0,
+    }
+  );
+}
+
+export function deriveMigrationPreviewAggregateStatus(items: MigrationPreviewItem[]): MigrationPreviewAggregateStatus {
+  const counts = deriveMigrationPreviewCounts(items);
+  if (counts.unsupported > 0 || counts.blocked > 0) return "preview-with-blockers";
+  if (counts.degraded > 0) return "preview-with-concerns";
+  return "preview-clear";
+}
+
+export function buildMigrationPreviewItems(input: {
+  sourceContext: MigrationPreviewSourceContext;
+  targetContext: MigrationPreviewTargetContext;
+  scope: MigrationPreviewScope;
+}): MigrationPreviewItem[] {
+  const normalizedScope = normalizeMigrationPreviewScope(input.scope);
+  if (!normalizedScope.kind) return [];
+
+  return normalizedScope.itemRefs.map((sourceRef) =>
+    classifyMigrationPreviewItem({
+      sourceContext: input.sourceContext,
+      targetContext: input.targetContext,
+      scopeKind: normalizedScope.kind!,
+      sourceRef,
+    })
+  );
+}
+
+export function createMigrationPreviewSummary(input: {
+  scope: MigrationPreviewScope;
+  counts: MigrationPreviewAggregateCounts;
+}): string {
+  const normalizedScope = normalizeMigrationPreviewScope(input.scope);
+  const scopeLabel = normalizedScope.kind ? formatMigrationPreviewScopeLabel(normalizedScope.kind).toLowerCase() : "items";
+  const total = Object.values(input.counts).reduce((sum, count) => sum + count, 0);
+
+  return `Preview only: ${total} ${scopeLabel} checked — ${input.counts.portable} portable, ${input.counts.degraded} degraded, ${input.counts.unsupported} unsupported, ${input.counts.blocked} blocked.`;
 }
 
 // ── Validation helpers ──────────────────────────────────────────────────────
@@ -490,19 +793,23 @@ export function buildPackageValidationItems(input: {
   ];
 }
 
-// ── Operation result helpers ────────────────────────────────────────────────
-
 let operationCounter = 0;
 
 export function createOperationResult(input: {
   workflowType: BackupWorkflowType;
-  status: BackupOperationStatus;
+  status: OperationResultStatus;
   summary: string;
   backupId?: string;
   sessionCount?: number;
   warnings?: string[];
   sourceCopySummary?: string;
   sessionResults?: BulkSessionExecutionResult[];
+  previewSourceContext?: MigrationPreviewSourceContext;
+  previewTargetContext?: MigrationPreviewTargetContext;
+  previewScope?: MigrationPreviewScope;
+  previewCounts?: MigrationPreviewAggregateCounts;
+  previewItems?: MigrationPreviewItem[];
+  issueLabel?: string;
 }): BackupOperationResult {
   operationCounter += 1;
   return {
@@ -516,7 +823,34 @@ export function createOperationResult(input: {
     warnings: input.warnings,
     sourceCopySummary: input.sourceCopySummary,
     sessionResults: input.sessionResults,
+    previewSourceContext: input.previewSourceContext,
+    previewTargetContext: input.previewTargetContext,
+    previewScope: input.previewScope,
+    previewCounts: input.previewCounts,
+    previewItems: input.previewItems,
+    issueLabel: input.issueLabel,
   };
+}
+
+export function createMigrationPreviewOperationResult(input: {
+  sourceContext: MigrationPreviewSourceContext;
+  targetContext: MigrationPreviewTargetContext;
+  scope: MigrationPreviewScope;
+  items: MigrationPreviewItem[];
+  issueLabel?: string;
+}): BackupOperationResult {
+  const counts = deriveMigrationPreviewCounts(input.items);
+  return createOperationResult({
+    workflowType: "migration-preview",
+    status: deriveMigrationPreviewAggregateStatus(input.items),
+    summary: createMigrationPreviewSummary({ scope: input.scope, counts }),
+    previewSourceContext: input.sourceContext,
+    previewTargetContext: input.targetContext,
+    previewScope: normalizeMigrationPreviewScope(input.scope),
+    previewCounts: counts,
+    previewItems: input.items,
+    issueLabel: input.issueLabel,
+  });
 }
 
 export function buildSessionBackupExecutionRequest(input: {
@@ -585,8 +919,6 @@ export async function validateBackupPackageRemote(
   }
 }
 
-// ── Recent operations ───────────────────────────────────────────────────────
-
 export function addRecentOperation(
   operations: RecentOperation[],
   operation: RecentOperation,
@@ -594,8 +926,6 @@ export function addRecentOperation(
 ): RecentOperation[] {
   return [operation, ...operations].slice(0, maxCount);
 }
-
-// ── Handoff consumption ─────────────────────────────────────────────────────
 
 export function resolveWorkflowFromHandoff(
   handoff: BackupMigrationHandoff | null
@@ -606,10 +936,12 @@ export function resolveWorkflowFromHandoff(
     return handoff.workflowType;
   }
 
-  // Infer from context
+  if (handoff.migrationPreviewSourceContext || handoff.migrationPreviewTargetContext || handoff.migrationPreviewScope) {
+    return "migration-preview";
+  }
   if ((handoff.sessions?.length ?? 0) > 1) return "bulk-session-backup";
   if (handoff.sessionId) return "session-backup";
-  if (handoff.origin === "overview") return null; // overview routes to selector
+  if (handoff.origin === "overview") return null;
   if (handoff.findingId && handoff.preservationWarning) return "session-backup";
 
   return null;
@@ -631,6 +963,11 @@ export function buildBackupHandoffInstanceKey(handoff: BackupMigrationHandoff | 
     handoff.findingId ?? "no-finding",
     handoff.issueLabel ?? "no-issue",
     handoff.preservationWarning ?? "no-preservation-warning",
+    handoff.migrationPreviewSourceContext?.product ?? "no-preview-source-product",
+    handoff.migrationPreviewSourceContext?.kind ?? "no-preview-source-kind",
+    handoff.migrationPreviewTargetContext?.profile ?? "no-preview-target-profile",
+    handoff.migrationPreviewScope?.kind ?? "no-preview-scope-kind",
+    handoff.migrationPreviewScope?.itemRefs.join("|") ?? "no-preview-scope-items",
     handoff.subtitle,
   ].join(":");
 }

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -514,6 +514,7 @@ export function deriveMigrationPreviewCounts(items: MigrationPreviewItem[]): Mig
 }
 
 export function deriveMigrationPreviewAggregateStatus(items: MigrationPreviewItem[]): MigrationPreviewAggregateStatus {
+  if (items.length === 0) return "preview-with-concerns";
   const counts = deriveMigrationPreviewCounts(items);
   if (counts.unsupported > 0 || counts.blocked > 0) return "preview-with-blockers";
   if (counts.degraded > 0) return "preview-with-concerns";

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -365,7 +365,7 @@ export function deriveMigrationPreviewValidationResult(input: {
   const normalizedScope = normalizeMigrationPreviewScope(input.scope);
   const items: BackupValidationItem[] = [];
 
-  if (!input.sourceContext?.product || !input.sourceContext.kind) {
+  if (!input.sourceContext?.product || !input.sourceContext?.kind) {
     items.push({
       id: "v-preview-source-required",
       label: "Source context",

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -116,6 +116,10 @@ describe("migration preview model tests", () => {
     expect(deriveMigrationPreviewAggregateStatus(items)).toBe("preview-with-blockers");
   });
 
+  it("treats empty migration preview results as concerns instead of clear", () => {
+    expect(deriveMigrationPreviewAggregateStatus([])).toBe("preview-with-concerns");
+  });
+
   it("creates migration preview operation results with preview-only summary metadata", () => {
     const items = buildMigrationPreviewItems({
       sourceContext: { product: "codex", kind: "context-asset" },

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -120,6 +120,21 @@ describe("migration preview model tests", () => {
     expect(deriveMigrationPreviewAggregateStatus([])).toBe("preview-with-concerns");
   });
 
+  it("uses singular scope label for one-item migration preview summaries", () => {
+    const result = createMigrationPreviewOperationResult({
+      sourceContext: { product: "codex", kind: "session-evidence" },
+      targetContext: { profile: "reusable-context-assets" },
+      scope: { kind: "sessions", itemRefs: ["session-001"] },
+      items: buildMigrationPreviewItems({
+        sourceContext: { product: "codex", kind: "session-evidence" },
+        targetContext: { profile: "reusable-context-assets" },
+        scope: { kind: "sessions", itemRefs: ["session-001"] },
+      }),
+    });
+
+    expect(result.summary).toContain("1 session checked");
+  });
+
   it("creates migration preview operation results with preview-only summary metadata", () => {
     const items = buildMigrationPreviewItems({
       sourceContext: { product: "codex", kind: "context-asset" },

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -137,6 +137,18 @@ describe("migration preview model tests", () => {
     expect(result.issueLabel).toBe("asset migration review");
   });
 
+  it("blocks preview item classification when target profile is missing", () => {
+    const items = buildMigrationPreviewItems({
+      sourceContext: { product: "codex", kind: "context-asset" },
+      targetContext: {},
+      scope: { kind: "assets", itemRefs: ["asset-rule-project-codex"] },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]!.classification).toBe("blocked");
+    expect(items[0]!.detail).toContain("target profile is incomplete");
+  });
+
   it("resolves migration-preview workflow from handoff", () => {
     const handoff: BackupMigrationHandoff = {
       origin: "analysis",

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -3,16 +3,21 @@ import { describe, expect, it } from "vitest";
 import {
   addRecentOperation,
   buildBulkSessionValidationResult,
+  buildMigrationPreviewItems,
   buildPackageValidationItems,
   buildBackupHandoffInstanceKey,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
+  createMigrationPreviewOperationResult,
   createBulkOperationSummary,
   createOperationResult,
   dedupeSessionSelections,
   deriveAggregateOperationStatus,
+  deriveMigrationPreviewAggregateStatus,
+  deriveMigrationPreviewValidationResult,
   deriveValidationResult,
   formatWorkflowStateLabel,
+  formatMigrationPreviewClassificationLabel,
   formatWorkflowTypeLabel,
   getNextState,
   getPreviousState,
@@ -37,6 +42,113 @@ describe("getWorkflowDescriptor", () => {
       expect(descriptor.stepsLabel.length).toBeGreaterThan(0);
     }
   });
+
+  it("retains migration preview metadata when provided", () => {
+    const result = createOperationResult({
+      workflowType: "migration-preview",
+      status: "preview-with-concerns",
+      summary: "Preview only: 2 assets checked.",
+      previewSourceContext: { product: "codex", kind: "context-asset" },
+      previewTargetContext: { profile: "reusable-context-assets" },
+      previewScope: { kind: "assets", itemRefs: ["asset-1", "asset-2"] },
+      previewCounts: { portable: 1, degraded: 1, unsupported: 0, blocked: 0 },
+    });
+
+    expect(result.workflowType).toBe("migration-preview");
+    expect(result.status).toBe("preview-with-concerns");
+    expect(result.previewScope?.itemRefs).toEqual(["asset-1", "asset-2"]);
+    expect(result.previewCounts?.degraded).toBe(1);
+  });
+});
+
+describe("migration preview model tests", () => {
+  it("returns the correct workflow label for migration-preview", () => {
+    expect(formatWorkflowTypeLabel("migration-preview")).toBe("Migration Preview");
+  });
+
+  it("returns the correct steps for migration-preview", () => {
+    expect(getStepsForWorkflow("migration-preview")).toEqual(["selection", "configuration", "validation", "result"]);
+  });
+
+  it("builds invalid preview validation when explicit fields are missing", () => {
+    const result = deriveMigrationPreviewValidationResult({
+      sourceContext: {},
+      targetContext: {},
+      scope: { itemRefs: [] },
+    });
+
+    expect(result.status).toBe("invalid");
+    expect(result.items.map((item) => item.label)).toEqual(["Source context", "Target context", "Preview scope"]);
+  });
+
+  it("builds warning preview validation when scope kind exists but no items are listed", () => {
+    const result = deriveMigrationPreviewValidationResult({
+      sourceContext: { product: "codex", kind: "context-asset" },
+      targetContext: { profile: "reusable-context-assets" },
+      scope: { kind: "assets", itemRefs: [] },
+    });
+
+    expect(result.status).toBe("valid-with-warnings");
+    expect(result.items.some((item) => item.id === "v-preview-scope-empty")).toBe(true);
+  });
+
+  it("classifies preview items with blocked precedence over degraded and unsupported", () => {
+    const items = buildMigrationPreviewItems({
+      sourceContext: { product: "windsurf", kind: "context-asset" },
+      targetContext: { profile: "reusable-context-assets" },
+      scope: {
+        kind: "assets",
+        itemRefs: ["asset-memory-user-windsurf", "asset-skill-global-generated", "asset-command-project-antigravity", "missing-asset-ref"],
+      },
+    });
+
+    expect(items.map((item) => item.classification)).toEqual(["degraded", "unsupported", "portable", "blocked"]);
+    expect(formatMigrationPreviewClassificationLabel(items[0]!.classification)).toBe("Degraded");
+  });
+
+  it("derives blocker aggregate status when any preview item is unsupported or blocked", () => {
+    const items = buildMigrationPreviewItems({
+      sourceContext: { product: "codex", kind: "context-asset" },
+      targetContext: { profile: "reusable-context-assets" },
+      scope: { kind: "assets", itemRefs: ["asset-skill-global-generated"] },
+    });
+
+    expect(deriveMigrationPreviewAggregateStatus(items)).toBe("preview-with-blockers");
+  });
+
+  it("creates migration preview operation results with preview-only summary metadata", () => {
+    const items = buildMigrationPreviewItems({
+      sourceContext: { product: "codex", kind: "context-asset" },
+      targetContext: { profile: "reusable-context-assets" },
+      scope: { kind: "assets", itemRefs: ["asset-rule-project-codex", "asset-memory-user-windsurf"] },
+    });
+
+    const result = createMigrationPreviewOperationResult({
+      sourceContext: { product: "codex", kind: "context-asset" },
+      targetContext: { profile: "reusable-context-assets" },
+      scope: { kind: "assets", itemRefs: ["asset-rule-project-codex", "asset-memory-user-windsurf"] },
+      items,
+      issueLabel: "asset migration review",
+    });
+
+    expect(result.status).toBe("preview-with-concerns");
+    expect(result.summary).toContain("Preview only");
+    expect(result.previewItems).toHaveLength(2);
+    expect(result.issueLabel).toBe("asset migration review");
+  });
+
+  it("resolves migration-preview workflow from handoff", () => {
+    const handoff: BackupMigrationHandoff = {
+      origin: "analysis",
+      subtitle: "Migration preview for stale memory.",
+      workflowType: "migration-preview",
+      migrationPreviewSourceContext: { product: "windsurf", kind: "analysis-context" },
+      migrationPreviewTargetContext: { profile: "reusable-context-assets" },
+      migrationPreviewScope: { kind: "assets", itemRefs: ["asset-memory-user-windsurf"] },
+    };
+
+    expect(resolveWorkflowFromHandoff(handoff)).toBe("migration-preview");
+  });
 });
 
 describe("formatWorkflowTypeLabel", () => {
@@ -45,6 +157,7 @@ describe("formatWorkflowTypeLabel", () => {
     expect(formatWorkflowTypeLabel("bulk-session-backup")).toBe("Bulk Session Backup");
     expect(formatWorkflowTypeLabel("import-backup")).toBe("Import Backup");
     expect(formatWorkflowTypeLabel("validate-package")).toBe("Validate Package");
+    expect(formatWorkflowTypeLabel("migration-preview")).toBe("Migration Preview");
   });
 });
 
@@ -76,6 +189,11 @@ describe("getStepsForWorkflow", () => {
   it("returns steps for validate-package", () => {
     const steps = getStepsForWorkflow("validate-package");
     expect(steps).toEqual(["selection", "validation", "result"]);
+  });
+
+  it("returns steps for migration-preview", () => {
+    const steps = getStepsForWorkflow("migration-preview");
+    expect(steps).toEqual(["selection", "configuration", "validation", "result"]);
   });
 });
 

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -118,6 +118,37 @@ function renderMigrationPreviewResultPanel() {
   );
 }
 
+function renderMigrationPreviewBlockerResultPanel() {
+  return renderToStaticMarkup(
+    <OperationResultPanel
+      result={{
+        id: "op-preview-blocked",
+        workflowType: "migration-preview",
+        status: "preview-with-blockers",
+        timestamp: "2026-04-15T13:00:00Z",
+        summary: "Preview only: 1 reusable context assets checked — 0 portable, 0 degraded, 0 unsupported, 1 blocked.",
+        previewSourceContext: { product: "codex", kind: "context-asset" },
+        previewTargetContext: { profile: "reusable-context-assets" },
+        previewScope: { kind: "assets", itemRefs: ["missing-asset-ref"] },
+        previewCounts: { portable: 0, degraded: 0, unsupported: 0, blocked: 1 },
+        previewItems: [
+          {
+            id: "assets:missing-asset-ref",
+            label: "missing-asset-ref",
+            scopeKind: "assets",
+            sourceRef: "missing-asset-ref",
+            classification: "blocked",
+            detail: "Preview only: missing-asset-ref is blocked because canonical data, provenance, or required source detail is incomplete.",
+            repairTarget: "assets",
+          },
+        ],
+      }}
+      onNewWorkflow={vi.fn()}
+      onReconfigurePreview={vi.fn()}
+    />
+  );
+}
+
 describe("BackupMigrationFoundation", () => {
   it("renders idle workflow selector including migration preview", () => {
     const html = renderBackupMigrationFoundation(null);
@@ -303,5 +334,13 @@ describe("BackupMigrationFoundation panels", () => {
     expect(html).toContain("Return to scope configuration");
     expect(html).toContain("No runtime restore or apply.");
     expect(html).not.toContain("Imported or backed-up sessions are product-readable only");
+  });
+
+  it("renders migration preview blocker status explicitly", () => {
+    const html = renderMigrationPreviewBlockerResultPanel();
+
+    expect(html).toContain("preview-with-blockers");
+    expect(html).toContain("blocked");
+    expect(html).toContain("missing-asset-ref");
   });
 });

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -79,8 +79,47 @@ function renderOperationResultPanel() {
   );
 }
 
+function renderMigrationPreviewResultPanel() {
+  return renderToStaticMarkup(
+    <OperationResultPanel
+      result={{
+        id: "op-preview-1",
+        workflowType: "migration-preview",
+        status: "preview-with-concerns",
+        timestamp: "2026-04-15T13:00:00Z",
+        summary: "Preview only: 2 reusable context assets checked — 1 portable, 1 degraded, 0 unsupported, 0 blocked.",
+        previewSourceContext: { product: "codex", kind: "context-asset" },
+        previewTargetContext: { profile: "reusable-context-assets" },
+        previewScope: { kind: "assets", itemRefs: ["asset-rule-project-codex", "asset-memory-user-windsurf"] },
+        previewCounts: { portable: 1, degraded: 1, unsupported: 0, blocked: 0 },
+        previewItems: [
+          {
+            id: "assets:asset-rule-project-codex",
+            label: "asset-rule-project-codex",
+            scopeKind: "assets",
+            sourceRef: "asset-rule-project-codex",
+            classification: "portable",
+            detail: "Preview only: asset-rule-project-codex maps cleanly into Reusable context assets with recognized metadata.",
+          },
+          {
+            id: "assets:asset-memory-user-windsurf",
+            label: "asset-memory-user-windsurf",
+            scopeKind: "assets",
+            sourceRef: "asset-memory-user-windsurf",
+            classification: "degraded",
+            detail: "Preview only: asset-memory-user-windsurf can be represented in Reusable context assets, but fidelity or contextual detail will be reduced.",
+            repairTarget: "assets",
+          },
+        ],
+      }}
+      onNewWorkflow={vi.fn()}
+      onReconfigurePreview={vi.fn()}
+    />
+  );
+}
+
 describe("BackupMigrationFoundation", () => {
-  it("renders idle workflow selector without unimplemented workflows", () => {
+  it("renders idle workflow selector including migration preview", () => {
     const html = renderBackupMigrationFoundation(null);
 
     expect(html).toContain("Backup / Migration");
@@ -89,7 +128,8 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("Start Bulk Session Backup");
     expect(html).toContain("Start Import Backup");
     expect(html).toContain("Start Validate Package");
-    expect(html).toContain("does not support migration preview, project bundle packaging, vendor-runtime restore, or cloud sync");
+    expect(html).toContain("Start Migration Preview");
+    expect(html).toContain("does not support migration apply, project bundle packaging, vendor-runtime restore, or cloud sync");
   });
 
   it("renders routed session-backup workflow with prefilling context", () => {
@@ -112,20 +152,49 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("Pre-filled from routed handoff.");
   });
 
-  it("degrades vague asset handoff to idle selector instead of opening a broken workflow", () => {
+  it("opens migration preview from asset-routed handoff with explicit scope but editable missing fields", () => {
     const html = renderBackupMigrationFoundation({
       origin: "assets",
-      subtitle: "Prepare bounded backup or migration work for skill assets.",
+      subtitle: "Preview bounded migration scope for skill assets starting from asset-skill-global-generated.",
+      workflowType: "migration-preview",
       assetId: "asset-skill-global-generated",
       assetSubtype: "skill",
-      continueLabel: "Workflow execution belongs to Backup / Migration.",
+      continueLabel: "Only explicit asset source and scope context are prefilled here. Source and target remain editable if they were not supplied by the route.",
       returnLabel: "Return to Assets for object-level review.",
+      migrationPreviewSourceContext: {
+        kind: "context-asset",
+        label: "asset-skill-global-generated",
+      },
+      migrationPreviewScope: {
+        kind: "assets",
+        itemRefs: ["asset-skill-global-generated"],
+      },
     });
 
     expect(html).toContain("routed workflow");
     expect(html).toContain("from assets");
-    expect(html).toContain("Choose a bounded workflow below.");
-    expect(html).not.toContain("Select Session");
+    expect(html).toContain("Migration Preview");
+    expect(html).toContain("Select Source Context");
+    expect(html).toContain("asset-skill-global-generated");
+    expect(html).toContain("Source still required");
+  });
+
+  it("renders overview-routed migration-preview workflow as a direct routed entry", () => {
+    const html = renderBackupMigrationFoundation({
+      origin: "overview",
+      subtitle: "Start a bounded migration preview workflow from Project Overview.",
+      workflowType: "migration-preview",
+      continueLabel: "Workflow execution belongs to Backup / Migration.",
+      returnLabel: "Return to Project Overview.",
+      migrationPreviewSourceContext: {
+        kind: "project-overview",
+      },
+    });
+
+    expect(html).toContain("from overview");
+    expect(html).toContain("Migration Preview");
+    expect(html).toContain("Select Source Context");
+    expect(html).not.toContain("Choose a bounded workflow below.");
   });
 
   it("renders overview-routed validate-package workflow as a direct routed entry", () => {
@@ -221,5 +290,18 @@ describe("BackupMigrationFoundation panels", () => {
     expect(html).toContain("Per-session results");
     expect(html).toContain("backup-1");
     expect(html).toContain("Canonical record could not be read.");
+  });
+
+  it("renders migration preview result details and preview-only messaging", () => {
+    const html = renderMigrationPreviewResultPanel();
+
+    expect(html).toContain("Preview only.");
+    expect(html).toContain("Preview context");
+    expect(html).toContain("Reusable context assets");
+    expect(html).toContain("Preview item detail");
+    expect(html).toContain("asset-memory-user-windsurf");
+    expect(html).toContain("Return to scope configuration");
+    expect(html).toContain("No runtime restore or apply.");
+    expect(html).not.toContain("Imported or backed-up sessions are product-readable only");
   });
 });

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -7,6 +7,7 @@ import {
   buildBulkConfirmationDetails,
   resolveInitialBulkSelections,
   OperationResultPanel,
+  resolveMigrationPreviewInvalidWorkflowState,
   ValidationPanel,
 } from "@/components/BackupMigrationFoundation";
 import type { BackupMigrationHandoff } from "@/lib/backupMigration";
@@ -150,6 +151,12 @@ function renderMigrationPreviewBlockerResultPanel() {
 }
 
 describe("BackupMigrationFoundation", () => {
+  it("keeps invalid migration preview validation on the owning input step", () => {
+    expect(resolveMigrationPreviewInvalidWorkflowState({ sourceContext: {} })).toBe("selection");
+    expect(resolveMigrationPreviewInvalidWorkflowState({ sourceContext: { product: "codex" } })).toBe("selection");
+    expect(resolveMigrationPreviewInvalidWorkflowState({ sourceContext: { product: "codex", kind: "session-evidence" } })).toBe("configuration");
+  });
+
   it("renders idle workflow selector including migration preview", () => {
     const html = renderBackupMigrationFoundation(null);
 

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -126,7 +126,7 @@ function renderMigrationPreviewBlockerResultPanel() {
         workflowType: "migration-preview",
         status: "preview-with-blockers",
         timestamp: "2026-04-15T13:00:00Z",
-        summary: "Preview only: 1 reusable context assets checked — 0 portable, 0 degraded, 0 unsupported, 1 blocked.",
+        summary: "Preview only: 1 reusable context asset checked — 0 portable, 0 degraded, 0 unsupported, 1 blocked.",
         previewSourceContext: { product: "codex", kind: "context-asset" },
         previewTargetContext: { profile: "reusable-context-assets" },
         previewScope: { kind: "assets", itemRefs: ["missing-asset-ref"] },

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -350,11 +350,20 @@ describe("backup handoff builders", () => {
       origin: "assets",
       assetId: "asset-skill-global-generated",
       assetSubtype: "skill",
+      workflowType: "migration-preview",
+      migrationPreviewSourceContext: {
+        kind: "context-asset",
+        label: "asset-skill-global-generated",
+      },
+      migrationPreviewScope: {
+        kind: "assets",
+        itemRefs: ["asset-skill-global-generated"],
+      },
     });
-    expect(handoff).not.toHaveProperty("workflowType");
+    expect(handoff).not.toHaveProperty("migrationPreviewTargetContext");
   });
 
-  it("builds an analysis handoff with preservation warning and finding context", () => {
+  it("keeps preservation-oriented analysis backup handoff on session backup", () => {
     const handoff = buildBackupHandoffFromAnalysis({
       findingId: "finding-preserve-before-migration",
       title: "Preserve session evidence before migration cleanup",
@@ -369,6 +378,28 @@ describe("backup handoff builders", () => {
       preservationWarning: "Preserve before risky migration or cleanup work.",
     });
     expect(handoff.subtitle).toContain("Preserve in Backup / Migration");
+  });
+
+  it("builds an analysis migration-preview handoff when the route asks for preview", () => {
+    const handoff = buildBackupHandoffFromAnalysis({
+      findingId: "finding-preserve-before-migration",
+      title: "Preserve session evidence before migration cleanup",
+      preservationWarning: "Preview before risky migration or cleanup work.",
+      routeLabel: "Preview migration compatibility",
+      backupWorkflowType: "migration-preview",
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "analysis",
+      workflowType: "migration-preview",
+      findingId: "finding-preserve-before-migration",
+      preservationWarning: "Preview before risky migration or cleanup work.",
+      migrationPreviewSourceContext: {
+        kind: "analysis-context",
+        label: "Preserve session evidence before migration cleanup",
+      },
+    });
+    expect(handoff.subtitle).toContain("Preview migration compatibility");
   });
 
   it("builds an overview handoff with an explicit workflow type", () => {
@@ -392,5 +423,20 @@ describe("backup handoff builders", () => {
     expect(handoff).not.toHaveProperty("sessionId");
     expect(handoff).not.toHaveProperty("sessions");
     expect(handoff.subtitle).toContain("bulk session backup workflow");
+  });
+
+  it("builds an overview handoff for migration preview without inventing target or scope", () => {
+    const handoff = buildBackupHandoffFromOverview("migration-preview");
+
+    expect(handoff).toMatchObject({
+      origin: "overview",
+      workflowType: "migration-preview",
+      migrationPreviewSourceContext: {
+        kind: "project-overview",
+      },
+    });
+    expect(handoff).not.toHaveProperty("migrationPreviewTargetContext");
+    expect(handoff).not.toHaveProperty("migrationPreviewScope");
+    expect(handoff.subtitle).toContain("migration preview workflow");
   });
 });


### PR DESCRIPTION
## Summary

- Implement bounded `migration-preview` workflow in `Backup / Migration` with explicit source context, target context, and bounded scope.
- Add preview-only validation/result flow with `portable`, `degraded`, `unsupported`, and `blocked` item classifications plus preview-specific aggregate statuses.
- Add routed entry from Project Overview, Assets, and Analysis while preserving existing preservation-oriented Analysis routes to session backup.
- Record migration previews as compact recent operations and allow returning to preview detail/scope configuration.
- Update README, CHANGELOG, OpenSpec tasks, and external QA prompt.

## Boundaries

- No migration apply.
- No migrated object writing.
- No project bundle packaging.
- No vendor-runtime restore, cloud sync, or cross-machine transfer.

## Validation

- `pnpm test`
- `pnpm build`
- `OPENSPEC_TELEMETRY=0 openspec validate migration-preview --strict`
- `git diff --check`

Tracks #54.
