### PR TITLE
feat: add project bundle workflow foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-04-16` — Project bundle foundation
+  - Added a bounded `project bundle` workflow to `Backup / Migration` with explicit `selection -> configuration -> validation -> confirmation -> execution -> result` flow
+  - Added local `project-bundle/v1` generation with bundle manifest, package/project metadata, member inventory, member references, validation summary, and lightweight member snapshots
+  - Reused existing session backup packages for session members, preserved missing-package sessions as unresolved references with warnings, and added routed handoff into project bundle from `Project Overview`, `Assets`, and `Analysis`
+
 - `2026-04-15` — Migration preview workflow
   - Added a bounded `migration preview` workflow to `Backup / Migration` with explicit source context, target context, and bounded scope state flow (`selection -> configuration -> validation -> result`)
   - Added preview-only classification and aggregate reporting for `portable`, `degraded`, `unsupported`, and `blocked` items, plus recent-operation entries that route back to preview detail without implying migration apply

--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - verify/import flows are available through `/api/session-backups`, `/api/session-backups/import`, and `/api/session-backups/[backupId]`
   - v1 `Source Backup` is opt-in and currently supports copy-only source preservation for Codex sessions only
 - Backup / Migration workflows:
-  - `Backup / Migration` now provides bounded `session backup`, `bulk session backup`, `import backup`, `validate package`, and `migration preview` workflows
+  - `Backup / Migration` now provides bounded `session backup`, `bulk session backup`, `import backup`, `validate package`, `migration preview`, and `project bundle` workflows
   - bulk session backup requires explicit session selection, validates each selected session independently, and fans out through the existing single-session backup execution path
   - bulk results show aggregate status plus per-session detail, while recent operations record one compact batch entry instead of one entry per session
   - migration preview requires explicit source context, target context, and bounded scope, and ends at preview-only validation/result states without migration apply or bundle generation
-  - the foundation still does not implement migration apply, project bundle packaging, vendor-runtime restore, or cloud sync
+  - project bundle requires explicit composition and validation before generation, writes a real local `project-bundle/v1` file, and reuses existing session backup packages instead of inventing a second session archive format
+  - the foundation still does not implement migration apply, restore/apply for project bundles, vendor-runtime reopen, or cloud sync
 
 For detailed view semantics and cross-source alignment notes, see `docs/viewer/trajectory-view.md`.
 

--- a/docs/superpowers/specs/2026-04-16-project-bundle-foundation-design.md
+++ b/docs/superpowers/specs/2026-04-16-project-bundle-foundation-design.md
@@ -20,14 +20,14 @@ This design should serve as the upstream input for:
 
 ## References
 
-- [research-project-bundle.md](/Users/tr/Workspace/agent-storage-manager/docs/research-project-bundle.md)
-- [session-backup-migration-ux.md](/Users/tr/Workspace/agent-storage-manager/docs/session-backup-migration-ux.md)
-- [page-state-ia.md](/Users/tr/Workspace/agent-storage-manager/docs/page-state-ia.md)
-- [task-flow-ia.md](/Users/tr/Workspace/agent-storage-manager/docs/task-flow-ia.md)
-- [routed-context-handoff.md](/Users/tr/Workspace/agent-storage-manager/docs/routed-context-handoff.md)
-- [feature-follow-up-priority.md](/Users/tr/Workspace/agent-storage-manager/docs/dev/feature-follow-up-priority.md)
-- [session-backup/spec.md](/Users/tr/Workspace/agent-storage-manager/openspec/specs/session-backup/spec.md)
-- [backup-migration/spec.md](/Users/tr/Workspace/agent-storage-manager/openspec/specs/backup-migration/spec.md)
+- [research-project-bundle.md](/docs/research-project-bundle.md)
+- [session-backup-migration-ux.md](/docs/session-backup-migration-ux.md)
+- [page-state-ia.md](/docs/page-state-ia.md)
+- [task-flow-ia.md](/docs/task-flow-ia.md)
+- [routed-context-handoff.md](/docs/routed-context-handoff.md)
+- [feature-follow-up-priority.md](/docs/dev/feature-follow-up-priority.md)
+- [session-backup/spec.md](/openspec/specs/session-backup/spec.md)
+- [backup-migration/spec.md](/openspec/specs/backup-migration/spec.md)
 
 ## Product Intent
 

--- a/docs/superpowers/specs/2026-04-16-project-bundle-foundation-design.md
+++ b/docs/superpowers/specs/2026-04-16-project-bundle-foundation-design.md
@@ -1,0 +1,269 @@
+# Project Bundle Foundation Design
+
+Date: 2026-04-16
+
+Status: draft for user review
+
+## Purpose
+
+This document captures the converged design baseline for
+`project-bundle-foundation`.
+
+It is intentionally narrower than an OpenSpec proposal. Its job is to fix the
+product boundary before proposal and implementation work begin.
+
+This design should serve as the upstream input for:
+
+- a future OpenSpec change for `project-bundle-foundation`
+- external-agent proposal drafting
+- workflow and QA prompt design for the `Backup / Migration` surface
+
+## References
+
+- [research-project-bundle.md](/Users/tr/Workspace/agent-storage-manager/docs/research-project-bundle.md)
+- [session-backup-migration-ux.md](/Users/tr/Workspace/agent-storage-manager/docs/session-backup-migration-ux.md)
+- [page-state-ia.md](/Users/tr/Workspace/agent-storage-manager/docs/page-state-ia.md)
+- [task-flow-ia.md](/Users/tr/Workspace/agent-storage-manager/docs/task-flow-ia.md)
+- [routed-context-handoff.md](/Users/tr/Workspace/agent-storage-manager/docs/routed-context-handoff.md)
+- [feature-follow-up-priority.md](/Users/tr/Workspace/agent-storage-manager/docs/dev/feature-follow-up-priority.md)
+- [session-backup/spec.md](/Users/tr/Workspace/agent-storage-manager/openspec/specs/session-backup/spec.md)
+- [backup-migration/spec.md](/Users/tr/Workspace/agent-storage-manager/openspec/specs/backup-migration/spec.md)
+
+## Product Intent
+
+`Project Bundle` is a project-scoped portable package under `Backup / Migration`.
+
+Its first responsibility is not cloud sync, app snapshotting, or third-party
+runtime restoration. Its first responsibility is to generate a bounded local
+bundle package that makes the current project context set explicit, inspectable,
+and portable.
+
+The bundle should preserve:
+
+- what was selected for packaging
+- why it was eligible
+- what was excluded
+- what warnings were present at generation time
+- how project-scoped context members relate to one another
+
+## Foundation Commitment
+
+Foundation v1 should:
+
+- provide a real `Project Bundle` workflow inside `Backup / Migration`
+- generate a real local bundle package file
+- require composition and validation before generation
+- expose a result state with package identity and generation outcome
+
+Foundation v1 should not:
+
+- promise restore or apply
+- promise vendor-runtime reopen
+- become cloud sync
+- become a full app snapshot
+- silently infer full project composition from a routed entry
+
+## Product Positioning
+
+The user-facing promise should be:
+
+- a validated, project-scoped portable package
+
+The bundle also has preservation value, but preservation is a secondary value,
+not the primary headline promise.
+
+This avoids overstating completeness while still acknowledging that a generated
+bundle is useful for later safekeeping and handoff.
+
+## Relationship to Existing Workflows
+
+`Project Bundle` is not a replacement for existing workflows.
+
+### Session Backup
+
+`Session Backup` remains the canonical preserved copy for session evidence.
+
+`Project Bundle` should reuse `Session Backup` packaging rather than redefine
+session packaging inside the bundle workflow.
+
+### Migration Preview
+
+`Migration Preview` remains the preview-only compatibility workflow.
+
+`Project Bundle` is not the apply-version of migration preview. It is a package
+generation workflow with explicit composition and validation.
+
+### Import / Restore
+
+Foundation v1 may generate a package that is importable later, but it does not
+promise restore semantics in this change.
+
+## Default Bundle Members
+
+Foundation v1 should treat the following as the default project-scoped bundle
+member set:
+
+- sessions
+- rules
+- memory
+- skills
+- commands
+- package-level metadata
+- project-level metadata
+
+This keeps the bundle aligned with the product's project-scoped context model
+rather than collapsing into an asset-only package.
+
+## Session Packaging Rule
+
+Sessions included in `Project Bundle` should default to reuse existing
+`session backup package` objects.
+
+Foundation v1 should therefore:
+
+- reference existing session backup packages
+- not redefine canonical session payload structure
+- not create a second session archive format inside the bundle workflow
+
+This keeps `Session Backup` and `Project Bundle` cleanly layered:
+
+- `Session Backup` = canonical session preserved copy
+- `Project Bundle` = project-level composition container
+
+## Workflow Shape
+
+The workflow should be:
+
+1. selection
+2. configuration
+3. validation
+4. confirmation
+5. generation
+6. result
+
+The workflow must not jump directly to generation.
+
+Before any package file is written, the user must be able to inspect:
+
+- intended bundle scope
+- included members
+- excluded members
+- warning state
+- blocker state
+- validation summary
+
+In practice, this means composition and validation are first-class workflow
+steps, not secondary details.
+
+## Validation Severity Strategy
+
+Foundation v1 should be permissive by default.
+
+The following member-quality problems should default to warnings rather than
+blockers:
+
+- missing provenance summary
+- incomplete or uncertain subtype classification
+- stale member state
+- missing member reference that still leaves the bundle structurally valid
+
+Blockers should be reserved for structural impossibility, for example:
+
+- the bundle manifest cannot be formed legally
+- required package identity or required metadata is missing
+- no valid bundle output can be written
+- workflow input is invalid to the point that no legal bundle can be created
+
+This keeps v1 usable and allows severity tuning later based on real usage.
+
+## Bundle File Minimum Structure
+
+The generated bundle file should include, at minimum:
+
+- bundle manifest
+- package metadata
+- project metadata
+- member inventory
+- member references
+- validation summary
+- lightweight metadata snapshots for each member
+
+The metadata snapshot requirement matters because a pure reference list is too
+fragile once the bundle leaves the original machine or workspace.
+
+At the same time, v1 should stop short of embedding full payloads for every
+member. The snapshot exists to preserve interpretability, not to create a full
+second archive of all object contents.
+
+## Routed Entry Rules
+
+`Project Bundle` may be entered from:
+
+- `Project Overview`
+- `Assets`
+- `Analysis`
+- `Backup / Migration`
+
+Routed handoff may prefill only:
+
+- workflow identity
+- origin cue or issue cue
+- compact scope hint
+- compact filter hint
+- explicitly provided object references
+
+Routed handoff must not:
+
+- invent a bundle member set implicitly
+- auto-decide final composition from a single asset, finding, or issue
+- skip explicit selection or configuration
+- proceed directly to generation
+
+All routed entries may accelerate composition, but none may replace explicit
+composition decisions.
+
+## User-Facing Interpretation
+
+The user should understand the workflow as:
+
+- "Package this project's context set into a portable local bundle."
+
+The workflow should not imply:
+
+- "Clone the whole app state."
+- "Rebuild this project automatically elsewhere."
+- "Reopen my work inside another vendor runtime."
+
+## Non-Goals
+
+Foundation v1 does not include:
+
+- cloud sync
+- team collaboration bundle semantics
+- full repository copy
+- raw source copies by default
+- machine-local tokens, ports, or secrets
+- global app preferences
+- restore or apply
+- vendor-runtime continuation
+
+## OpenSpec Implications
+
+The future `project-bundle-foundation` OpenSpec change should reflect these
+decisions directly:
+
+- `Project Bundle` is a real workflow, not a placeholder entry
+- the workflow generates a real local file
+- generation is gated by explicit composition and validation
+- sessions reuse the session-backup sub-format
+- warnings are broad; blockers are structural
+- the bundle file includes lightweight metadata snapshots
+- routed handoff is assistive, not compositional authority
+
+## Ready State
+
+This design is ready to be used as the basis for:
+
+- an external-agent prompt to draft OpenSpec artifacts
+- a proposal/design/spec/tasks convergence pass
+- later implementation planning after the proposal is reviewed

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -6,7 +6,7 @@ Use this prompt with an external QA agent that can operate the local app through
 You are QA-ing the `project-bundle`, `migration-preview`, and `bulk-session-backup` implementation for the local-first Agent Storage Manager project.
 
 Repository: <repo-path>
-Branch under test: feat/migration-preview
+Branch under test: <branch-under-test>
 
 Goal:
 Verify that the new `Backup / Migration` page behaves as a bounded workflow-first foundation surface. It should support:

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -3,7 +3,7 @@
 Use this prompt with an external QA agent that can operate the local app through a browser.
 
 ```text
-You are QA-ing the `migration-preview` and `bulk-session-backup` implementation for the local-first Agent Storage Manager project.
+You are QA-ing the `project-bundle`, `migration-preview`, and `bulk-session-backup` implementation for the local-first Agent Storage Manager project.
 
 Repository: <repo-path>
 Branch under test: feat/migration-preview
@@ -15,13 +15,13 @@ Verify that the new `Backup / Migration` page behaves as a bounded workflow-firs
 - import backup
 - validate package
 - migration preview
+- project bundle
 - routed handoff from `Project Overview`, `Sessions`, `Assets`, and `Analysis`
 - compact recent operations
 
 It must not behave like:
 - a generic tools drawer
 - a migration apply surface
-- a project bundle implementation
 - a vendor runtime restore UI
 
 Setup:
@@ -43,7 +43,6 @@ Primary smoke checks:
    - result / recent operations region
 6. Confirm copy clearly states bounded foundation behavior and does not imply:
    - migration apply
-   - project bundle execution
    - vendor-runtime restore
 
 Workflow selector / idle checks:
@@ -54,7 +53,7 @@ Workflow selector / idle checks:
    - import backup
    - validate package
    - migration preview
-3. Confirm `project bundle` is not presented as an active workflow.
+   - project bundle
 
 Session backup workflow checks:
 1. Enter the `session backup` workflow from `Backup / Migration`.
@@ -136,19 +135,63 @@ Migration preview workflow checks:
 9. Confirm aggregate counts are shown for all four preview classifications.
 10. Confirm degraded / unsupported / blocked rows offer inspection or repair-oriented follow-up wording without executing work inline.
 
+Project bundle workflow checks:
+1. Enter the `project bundle` workflow from `Backup / Migration`.
+2. Confirm the workflow follows this full path only:
+   - selection
+   - configuration
+   - validation
+   - confirmation
+   - execution
+   - result
+3. Confirm selection presents default bundle member categories:
+   - sessions
+   - rules
+   - memory
+   - skills
+   - commands
+   - package-level metadata
+   - project-level metadata
+4. Confirm generation is not available before validation and confirmation.
+5. Add at least one explicit session reference if the UI allows it, then validate.
+6. If the selected session has no existing backup package, confirm validation shows a warning rather than a blocker.
+7. Confirm warnings remain visible through confirmation and do not silently remove the selected session.
+8. Execute generation and confirm the result shows:
+   - package identity
+   - local file path
+   - member count
+   - validation summary
+   - member inventory / references
+9. Confirm result copy does not promise:
+   - restore/apply
+   - vendor-runtime reopen
+   - cloud sync
+   - app snapshot
+   - team collaboration semantics
+10. If bundle file inspection is available, confirm it includes:
+   - bundle manifest
+   - package metadata
+   - project metadata
+   - member inventory
+   - member references
+   - validation summary
+   - lightweight metadata snapshots
+
 Routed handoff checks:
 1. From `Sessions`, if available, route into `Backup / Migration` for a selected session.
 2. Confirm `Backup / Migration` opens the `session backup` workflow with the session prefilled and a compact origin cue.
 3. If `Sessions` exposes explicit multi-selection under this branch, route that selection into `Backup / Migration`.
 4. Confirm the destination opens `bulk session backup` with the selected sessions prefilled and no silently dropped entries.
-5. From `Assets`, trigger a route into `Backup / Migration` if available.
-6. Confirm the destination page may open migration preview with explicit asset scope context only, while missing source product or target context remains editable.
-7. From `Analysis`, trigger a preservation-oriented route into `Backup / Migration` if available.
-8. Confirm preservation-oriented analysis routes still open `session backup` and preserve the issue/preservation warning context.
-9. From `Analysis`, trigger a migration-preview route into `Backup / Migration` if available.
-10. Confirm migration-preview analysis routes open `migration preview`, preserve issue context, and do not invent missing source or target.
-11. From `Project Overview`, trigger a route into single backup, bulk backup, import, validation, and migration preview if available.
-12. Confirm routed context opens the correct workflow and degrades safely to selection/configuration if preview context is incomplete.
+5. From `Assets`, trigger both migration-preview and project-bundle routes into `Backup / Migration` if available.
+6. Confirm assets-routed project bundle preserves only explicit object refs / scope hints and still opens at bundle selection instead of skipping composition.
+7. Confirm the assets migration-preview route may open migration preview with explicit asset scope context only, while missing source product or target context remains editable.
+8. From `Analysis`, trigger a preservation-oriented route into `Backup / Migration` if available.
+9. Confirm preservation-oriented analysis routes still open `session backup` and preserve the issue/preservation warning context.
+10. From `Analysis`, trigger both migration-preview and project-bundle routes into `Backup / Migration` if available.
+11. Confirm analysis-routed project bundle preserves issue context as a cue only and does not auto-decide final composition.
+12. Confirm migration-preview analysis routes open `migration preview`, preserve issue context, and do not invent missing source or target.
+13. From `Project Overview`, trigger a route into single backup, bulk backup, import, validation, migration preview, and project bundle if available.
+14. Confirm routed context opens the correct workflow and degrades safely to selection/configuration when context is incomplete.
 
 Recent operations checks:
 1. After completing or simulating at least one workflow, confirm a compact recent-operations region appears.
@@ -159,22 +202,24 @@ Recent operations checks:
    - status
    - session count for bulk runs
    - selected preview scope for migration preview runs
+   - package identity for project bundle runs
 3. Confirm it reads as a secondary result/history strip, not a persistent audit console.
 4. Confirm a bulk run produces one recent-operation entry for the batch, not one entry per selected session.
 5. Confirm a migration preview entry routes back to preview detail and does not claim migration was applied.
+6. Confirm a project bundle entry routes back to bundle result detail and does not claim restore, apply, or sync.
 
 Regression checks:
 1. `Sessions` still works as before, including existing viewer behavior and direct session backup.
 2. `Assets` and `Analysis` routing into `Backup / Migration` does not break their own page roles.
 3. Top-level navigation away from `Backup / Migration` clears stale routed workflow context when appropriate.
-4. `Backup / Migration` does not expose migration apply or project bundle execution accidentally through copy or buttons.
+4. Existing single backup, bulk backup, import, validate package, and migration preview behavior does not regress.
 
 Boundary checks:
 1. No button or copy should imply:
    - unscoped or implicit batch backup
    - migration apply
-   - project bundle packaging
-   - runtime continuation in third-party tools
+    - runtime continuation in third-party tools
+    - automatic project bundle composition from routed context
 2. If any such implication exists, record it as a blocker or strong concern.
 
 Report format:

--- a/docs/viewer/project-bundle-foundation-qa.md
+++ b/docs/viewer/project-bundle-foundation-qa.md
@@ -1,0 +1,58 @@
+# QA Report — `project-bundle-foundation`
+
+Date: 2026-04-16
+
+Verdict: Pass with minor concerns
+
+## Summary
+
+External QA verified that `Project Bundle` behaves as a bounded workflow inside
+`Backup / Migration` and does not over-promise restore, apply, sync, or vendor
+runtime continuation semantics.
+
+Primary QA conclusion:
+
+- core workflow behavior passed
+- no blocking issues were reported
+- only minor UI/documentation refinements were suggested
+
+## Key Verified Areas
+
+- top-level shell and workflow-first `Backup / Migration` identity
+- `Project Bundle` workflow presence in idle selector
+- full workflow spine:
+  - selection
+  - configuration
+  - validation
+  - confirmation
+  - execution
+  - result
+- permissive warning vs structural blocker behavior
+- reuse of existing `session backup package` semantics
+- unresolved session references when an existing backup package is missing
+- bounded routed handoff from `Project Overview`, `Assets`, `Analysis`, and
+  direct `Backup / Migration` entry
+- recent operations result summary for project bundle runs
+- regression coverage for existing backup/import/validate/migration workflows
+
+## Non-blocking Concerns
+
+1. Bundle category labels currently render raw keys such as `sessions` instead
+   of more polished display labels.
+2. Missing-package reference detail could say more explicitly that this is
+   expected until the session has been backed up.
+
+## Suggested Follow-up Tests
+
+1. Add direct API/service tests that verify file creation under the managed
+   bundle root.
+2. Add a stale-routed-context regression case for project bundle entry.
+3. Add an end-to-end check for analysis-routed bundle context preservation.
+
+## Source
+
+This document preserves the external QA result provided during PR #61 review.
+The original report concluded:
+
+- no blocking issues
+- pass with minor concerns

--- a/docs/viewer/project-bundle-foundation-qa.md
+++ b/docs/viewer/project-bundle-foundation-qa.md
@@ -37,10 +37,11 @@ Primary QA conclusion:
 
 ## Non-blocking Concerns
 
-1. Bundle category labels currently render raw keys such as `sessions` instead
-   of more polished display labels.
-2. Missing-package reference detail could say more explicitly that this is
-   expected until the session has been backed up.
+1. The 2026-04-16 external QA run noted that bundle category labels rendered
+   raw keys such as `sessions` instead of more polished display labels.
+2. The 2026-04-16 external QA run also noted that the missing-package
+   reference detail could more explicitly say that this is expected until the
+   session has been backed up.
 
 ## Suggested Follow-up Tests
 

--- a/openspec/changes/project-bundle-foundation/.openspec.yaml
+++ b/openspec/changes/project-bundle-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/project-bundle-foundation/design.md
+++ b/openspec/changes/project-bundle-foundation/design.md
@@ -111,6 +111,11 @@ The default member categories are: sessions, rules, memory, skills, commands,
 package-level metadata, and project-level metadata. These align with the
 product's project-scoped context model.
 
+Sessions, rules, memory, skills, and commands are the selectable composition
+categories. Package-level metadata and project-level metadata remain mandatory
+foundation metadata in v1: they are always included in the generated bundle and
+should be shown as fixed sections rather than removable toggles.
+
 Items explicitly excluded from v1 membership: raw source copies, derived view
 caches, search indexes, internal cache / temp state, UI state, machine-local
 tokens / ports / secrets, repository full copy, and app preferences / global

--- a/openspec/changes/project-bundle-foundation/design.md
+++ b/openspec/changes/project-bundle-foundation/design.md
@@ -1,0 +1,241 @@
+## Context
+
+`Backup / Migration` is a bounded workflow page for preservation, portability,
+and recovery-oriented operations. It already hosts single session backup, bulk
+session backup, import backup, validate package, and migration preview. These
+workflows operate at the session or package level.
+
+`Project Bundle` is the first project-scoped packaging workflow. It compiles a
+validated, portable, local bundle file from the current project's agent context
+set — sessions, rules, memory, skills, commands, and metadata — without
+requiring the user to export each member individually.
+
+The user-facing promise is: **a validated, project-scoped portable package**.
+Preservation is a secondary value, not the headline promise. The bundle is not
+a full app snapshot, not a migration-preview apply version, not a session-backup
+wrapper, and not a repository copy.
+
+## Relationship to Existing Workflows
+
+### Relationship to Session Backup
+
+`Session Backup` remains the canonical preserved copy for session evidence.
+
+`Project Bundle` reuses existing `session backup package` semantics for session
+members. It does not redefine canonical session payload, invent a second
+session archive format, or generate ad hoc session backup payloads as part of
+bundle execution.
+
+The layering is:
+
+- `Session Backup` = canonical session preserved copy
+- `Project Bundle` = project-scoped composition container
+
+### Relationship to Migration Preview
+
+`Migration Preview` remains a preview-only compatibility workflow.
+
+`Project Bundle` is not a migration-preview apply step and should not inherit
+apply semantics from preview terminology. Its responsibility is bounded package
+generation after explicit composition and validation, not portability preview
+classification or migration execution.
+
+### Relationship to Import / Restore
+
+Foundation v1 may produce a package that a future workflow can import or
+inspect, but this change does not promise restore semantics, import-ready
+guarantees across every environment, or vendor-runtime continuation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `project-bundle` to the existing `Backup / Migration` workflow model.
+- Define default bundle member categories: sessions, rules, memory, skills,
+  commands, package-level metadata, and project-level metadata.
+- Require explicit composition (selection and configuration) and validation
+  before bundle generation.
+- Generate a real local bundle package file on the filesystem.
+- Include in the bundle file: bundle manifest, package metadata, project
+  metadata, member inventory, member references, validation summary, and
+  lightweight metadata snapshots for each member.
+- Reuse `session backup package` semantics for session members instead of
+  redefining canonical session payload.
+- Apply permissive validation severity: structural impossibilities are blockers;
+  provenance gaps, uncertain classification, stale state, and non-critical
+  reference gaps are warnings.
+- Support routed entry from `Project Overview`, `Assets`, `Analysis`, and
+  `Backup / Migration` with bounded prefill authority.
+- Record completed bundle workflows as compact recent-operation entries.
+
+**Non-Goals:**
+
+- No restore or apply.
+- No vendor-runtime reopen or continuation.
+- No cloud sync.
+- No team collaboration handoff semantics.
+- No full app state snapshot.
+- No full repository copy.
+- No privacy-redaction in this change.
+- No raw source copies in v1.
+- No machine-local tokens, ports, or secrets in the bundle.
+- No global app preferences in the bundle.
+
+## Decisions
+
+### Decision 1: Add project bundle as a workflow type, not a separate page
+
+`project-bundle` should use the same workflow selector, workflow spine,
+validation panel, result panel, and recent operations model as other
+`Backup / Migration` workflows.
+
+Alternative considered: add a standalone bundle page. Rejected because the
+product defines `Backup / Migration` as the workflow home for preservation and
+portability work, and project bundle is a portability workflow.
+
+### Decision 2: Use a full workflow spine including generation
+
+The project bundle state path should be:
+Idle → Selection → Configuration → Validation → Confirmation → Execution → Result.
+
+Unlike migration preview which stops at result, project bundle generates a real
+file. Therefore confirmation and execution are required workflow steps.
+
+Alternative considered: skip confirmation and go directly from validation to
+generation. Rejected because the design requires explicit user inspection of
+composition, warnings, and blockers before any package file is written.
+
+### Decision 3: Default bundle members are project-scoped context objects
+
+The default member categories are: sessions, rules, memory, skills, commands,
+package-level metadata, and project-level metadata. These align with the
+product's project-scoped context model.
+
+Items explicitly excluded from v1 membership: raw source copies, derived view
+caches, search indexes, internal cache / temp state, UI state, machine-local
+tokens / ports / secrets, repository full copy, and app preferences / global
+runtime state. Foundation v1 should not expose inclusion toggles for these
+objects.
+
+Alternative considered: start with sessions only. Rejected because project
+bundle is explicitly a project-level composition container, not a session-only
+backup.
+
+### Decision 4: Sessions reuse session backup package semantics
+
+Sessions included in a project bundle reference existing session backup package
+objects. The bundle does not redefine canonical session payload, create a second
+session archive format, or embed raw session sources by default.
+
+Alternative considered: define an independent session representation for
+bundles. Rejected to avoid schema duplication and divergent migration pathways.
+
+When a selected session lacks an existing backup package, bundle validation
+should surface a warning and preserve the user's composition intent by writing
+an unresolved session member reference plus metadata snapshot. It must not
+silently omit the session and must not generate an ad hoc session backup
+payload during bundle execution.
+
+### Decision 5: Validation severity is permissive by default
+
+Warning-level issues (proceed allowed):
+- Missing or incomplete provenance summary.
+- Uncertain subtype classification for a member.
+- Stale member state.
+- Missing member reference that does not break bundle structural validity.
+
+Blocker-level issues (proceed denied):
+- Bundle manifest cannot be formed legally.
+- Required package identity or required metadata is missing to the point that
+  no valid bundle can be generated.
+- No valid bundle output can be written.
+- Workflow input is invalid to the point that no legal bundle can be created.
+
+Alternative considered: strict validation that blocks on provenance gaps.
+Rejected because v1 should be usable across imperfect real projects, with
+severity tuning informed by real usage later.
+
+### Decision 6: Bundle file includes lightweight metadata snapshots
+
+Each member in the bundle file should carry a lightweight metadata snapshot —
+enough to preserve interpretability when the bundle leaves the original machine
+or workspace.
+
+This is not a full payload embed for every member. The snapshot preserves
+identity, provenance summary, scope, subtype, timestamps, and status — not the
+full object content.
+
+Alternative considered: pure reference list only. Rejected because references
+without metadata are too fragile for offline or cross-machine interpretability.
+
+Alternative considered: full payload embed for all members. Rejected because
+v1 should remain lightweight and avoid the archive-weight and privacy risks of
+embedding full member content.
+
+### Decision 7: Routed handoff is assistive, not compositional authority
+
+Routed handoff from `Project Overview`, `Assets`, `Analysis`, or
+`Backup / Migration` may prefill:
+- Workflow identity (`project-bundle`).
+- Origin cue or issue cue.
+- Compact scope hint.
+- Compact filter hint.
+- Explicitly provided object references.
+
+Routed handoff must not:
+- Invent a bundle member set implicitly.
+- Auto-decide final composition from a single asset, finding, or issue.
+- Skip explicit selection or configuration.
+- Proceed directly to generation.
+
+All routed entries may accelerate composition, but none may replace explicit
+composition decisions.
+
+Alternative considered: allow routed entry to skip selection when coming from
+overview with a "full project" cue. Rejected because implicit full-scope
+composition without user inspection violates the design's composition-before-
+generation requirement.
+
+### Decision 8: Recent operations records bundle results
+
+Completed project bundle workflows should appear as compact recent-operation
+entries with workflow type, timestamp, aggregate status, bundle identity, and
+route to bundle result detail.
+
+Alternative considered: do not record bundle runs. Rejected because users need
+to return to inspect bundle results within the same page session.
+
+## Risks / Trade-offs
+
+- Composition complexity → Keep default member set well-defined; allow
+  deselection but do not force deep configuration in the first step.
+- Session reference fragility → Sessions lacking an existing backup package
+  should produce a validation warning, not silently skip the session or fail the
+  entire bundle.
+- Snapshot depth ambiguity → Define a clear enumeration of snapshot fields in
+  implementation to prevent scope creep from "metadata snapshot" to "full
+  content embed".
+- Bundle file format evolution → Use a schema version field in the manifest from
+  day one so import / validate can gate on version later.
+- Routed entry confusion → Clearly separate prefill (assistive) from
+  composition (authoritative) in UX copy and workflow behavior.
+- User expectation mismatch → Users may expect the bundle to mean "full project
+  clone" or "everything". UX copy must frame the bundle as a portable context
+  package, not a complete archive.
+
+## Migration Plan
+
+- Add the new workflow type and bundle helper types without changing existing
+  backup / import / validate / bulk / migration-preview behavior.
+- Add bundle composition, validation, and generation UI states behind
+  `Backup / Migration`.
+- Add route builders for explicit bundle entry from `Project Overview`, `Assets`,
+  and `Analysis`.
+- If rollback is needed, remove `project-bundle` from the workflow descriptor
+  list while leaving existing workflows untouched.
+
+## Open Questions
+
+None for foundation. Future changes may define restore/apply semantics for
+bundle packages, richer member categories, privacy-redaction integration, or
+team collaboration bundle semantics, but those are out of scope here.

--- a/openspec/changes/project-bundle-foundation/proposal.md
+++ b/openspec/changes/project-bundle-foundation/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+`Backup / Migration` now supports single session backup, bulk session backup,
+import, validate, and migration preview workflows. The missing piece is
+project-level packaging: users still cannot compile their project-scoped agent
+context — sessions, rules, memory, skills, commands, and metadata — into a
+validated portable bundle file.
+
+`Project Bundle` fills this gap as the first real project-level packaging
+workflow. It should produce a bounded local bundle file that makes the project
+context set explicit, inspectable, and portable, without overpromising restore,
+vendor-runtime continuation, or cloud sync.
+
+## What Changes
+
+- Add a `project-bundle` workflow to `Backup / Migration`.
+- Define default bundle members: sessions, rules, memory, skills, commands,
+  package-level metadata, and project-level metadata.
+- Require explicit composition (selection + configuration) and validation before
+  any bundle file is generated.
+- Generate a real local bundle package file with manifest, metadata, member
+  inventory, member references, validation summary, and lightweight metadata
+  snapshots for each member.
+- Reuse existing `session backup package` semantics for sessions included in the
+  bundle — do not redefine canonical session payload or create a second session
+  archive format.
+- Apply a permissive validation severity strategy: structural impossibilities
+  are blockers; provenance gaps, stale state, and uncertain classification are
+  warnings.
+- Support routed entry from `Project Overview`, `Assets`, `Analysis`, and
+  `Backup / Migration` with bounded prefill rules: handoff may provide workflow
+  identity, origin/issue cue, compact scope/filter hints, and explicit object
+  references, but must not invent member sets, auto-decide composition, skip
+  explicit selection, or proceed directly to generation.
+- Record completed project bundle workflows as compact recent-operation entries.
+- Do not add restore, apply, vendor-runtime reopen, cloud sync, team
+  collaboration handoff, app snapshot, or privacy-redaction behavior in this
+  change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `backup-migration`: Adds a project-bundle generation workflow with
+  composition, validation, generation steps, member inventory types, bundle
+  manifest structure, routed bundle entry, and recent-operation summary.
+
+## Impact
+
+- Affected UI: `src/components/BackupMigrationFoundation.tsx` workflow selector,
+  workflow body, composition panel, validation panel, result panel, and recent
+  operations.
+- Affected model code: `src/lib/backupMigration.ts` workflow descriptors, bundle
+  member types, composition context types, validation helpers, generation result
+  types, and handoff mapping.
+- Affected shell code: `ProjectShellClient` route builders for overview, assets,
+  and analysis project-bundle entry.
+- Affected tests: model tests, component tests for bundle workflow states, and
+  shell routing tests for bundle handoff.
+- Affected docs: `README.md`, `CHANGELOG.md`, and external QA prompt when the
+  implementation ships.

--- a/openspec/changes/project-bundle-foundation/specs/backup-migration/spec.md
+++ b/openspec/changes/project-bundle-foundation/specs/backup-migration/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Project bundle workflow SHALL be available from the workflow surface
+The system SHALL provide a bounded `project-bundle` workflow inside `Backup / Migration` for composing and generating a validated, project-scoped portable bundle package file.
+
+#### Scenario: Workflow selector includes project bundle
+- **WHEN** the user opens `Backup / Migration` without active workflow context
+- **THEN** the workflow selector includes `Project Bundle` as an available workflow
+- **AND** the workflow description frames it as packaging the current project's context set into a portable local bundle
+- **AND** the description does not claim restore, apply, vendor-runtime reopen, cloud sync, app snapshot, or team collaboration handoff
+
+#### Scenario: Project bundle workflow follows full workflow spine
+- **WHEN** the user starts the project bundle workflow
+- **THEN** the workflow proceeds through selection, configuration, validation, confirmation, execution, and result states
+- **AND** no step is skipped or auto-advanced without explicit user action
+
+### Requirement: Project bundle SHALL define default member categories
+The system SHALL treat the following as default bundle member categories: sessions, rules, memory, skills, commands, package-level metadata, and project-level metadata.
+
+#### Scenario: Default member categories are presented at selection
+- **WHEN** the user enters the project bundle selection step
+- **THEN** the workflow presents sessions, rules, memory, skills, commands, package-level metadata, and project-level metadata as the default member categories
+- **AND** the user can deselect or adjust member inclusion before proceeding
+
+#### Scenario: Non-core objects are out of scope for v1
+- **WHEN** the user enters the project bundle selection step
+- **THEN** the workflow does not include raw source copies, derived view caches, search indexes, internal cache, UI state, machine-local tokens, ports, secrets, repository full copy, or app preferences
+- **AND** foundation v1 does not expose inclusion toggles for those objects
+
+### Requirement: Project bundle SHALL require explicit composition before generation
+The system SHALL require explicit composition — selection and configuration — and validation before generating any bundle package file.
+
+#### Scenario: Missing selection blocks generation
+- **WHEN** the user starts the project bundle workflow without selecting any members
+- **THEN** the workflow remains in selection state
+- **AND** it explains that member selection is required before validation
+
+#### Scenario: Validation must occur before confirmation
+- **WHEN** the user completes selection and configuration
+- **THEN** the workflow runs validation before offering confirmation
+- **AND** the user can inspect intended bundle scope, included members, excluded members, warning state, blocker state, and validation summary before proceeding
+
+#### Scenario: Direct generation is not allowed
+- **WHEN** any page or routed entry attempts to bypass composition and validation
+- **THEN** the workflow does not proceed to execution
+- **AND** it returns to the appropriate composition or validation step
+
+### Requirement: Project bundle sessions SHALL reuse session backup package semantics
+The system SHALL reference existing `session backup package` objects for sessions included in a project bundle instead of redefining canonical session payload or creating a second session archive format.
+
+#### Scenario: Session members reference session backup packages
+- **WHEN** selected sessions are included in a project bundle
+- **THEN** the bundle references existing session backup package artifacts for those sessions
+- **AND** the bundle does not redefine or duplicate the canonical session payload format
+
+#### Scenario: Sessions without existing backup produce validation warning
+- **WHEN** a selected session does not have an existing session backup package
+- **THEN** the validation step produces a warning identifying the session
+- **AND** the warning does not block the bundle workflow unless the session reference makes the bundle structurally invalid
+
+#### Scenario: Sessions without existing backup remain unresolved references
+- **WHEN** bundle generation proceeds after validation warned that a selected session lacks an existing session backup package
+- **THEN** the generated bundle preserves that session as an unresolved or missing-package member reference with a lightweight metadata snapshot
+- **AND** the bundle does not silently omit the session
+- **AND** the workflow does not generate an ad hoc session backup payload during project bundle execution
+
+### Requirement: Project bundle validation SHALL use permissive severity
+The system SHALL classify validation issues as warnings or blockers using a permissive severity strategy.
+
+#### Scenario: Warning-level issues do not block generation
+- **WHEN** validation finds missing or incomplete provenance summary, uncertain subtype classification, stale member state, or missing member references that leave the bundle structurally valid
+- **THEN** these issues are classified as warnings
+- **AND** warnings remain visible through confirmation but do not prevent proceeding
+
+#### Scenario: Blocker-level issues prevent generation
+- **WHEN** validation finds that the bundle manifest cannot be formed legally, required package identity or metadata is missing to the point that no valid bundle can be generated, no valid bundle output can be written, or workflow input is invalid to the point that no legal bundle can be created
+- **THEN** these issues are classified as blockers
+- **AND** the workflow does not offer execution until all blockers are resolved
+
+### Requirement: Project bundle generation SHALL produce a real local bundle file
+The system SHALL generate a real bundle package file on the local filesystem when execution completes successfully.
+
+#### Scenario: Bundle file includes minimum structure
+- **WHEN** project bundle generation completes successfully
+- **THEN** the generated bundle file includes bundle manifest, package metadata, project metadata, member inventory, member references, validation summary, and lightweight metadata snapshots for each member
+
+#### Scenario: Metadata snapshots preserve interpretability
+- **WHEN** the bundle file includes member metadata snapshots
+- **THEN** each snapshot includes enough information for the bundle to remain interpretable outside the original machine or workspace
+- **AND** the snapshot does not embed full member content or full member payloads
+
+#### Scenario: Bundle file includes schema version
+- **WHEN** the system writes a bundle file
+- **THEN** the bundle manifest includes a schema version field that future import or validate workflows can use for compatibility checks
+
+### Requirement: Routed handoff SHALL be assistive, not compositional authority
+The system SHALL consume routed handoff context from `Project Overview`, `Assets`, `Analysis`, and `Backup / Migration` to open the project bundle workflow and prefill selections, but routed context must not replace explicit composition decisions.
+
+#### Scenario: Routed entry prefills only allowed context
+- **WHEN** `Project Overview`, `Assets`, `Analysis`, or `Backup / Migration` routes to the project bundle workflow
+- **THEN** the workflow opens with prefilled workflow identity, origin cue, compact scope or filter hints, and explicit object references as provided by the handoff
+
+#### Scenario: Routed entry does not invent member sets
+- **WHEN** any routed entry provides partial context such as a single asset reference, a finding, or a scope hint
+- **THEN** the workflow does not invent a complete bundle member set from that partial context
+- **AND** the workflow does not auto-decide final composition without user selection
+
+#### Scenario: Routed entry does not skip composition
+- **WHEN** any routed entry provides prefill context
+- **THEN** the workflow does not skip selection, configuration, or validation steps
+- **AND** the workflow does not proceed directly to generation
+
+#### Scenario: Stale routed context degrades to selection
+- **WHEN** routed handoff context is stale, invalid, or partially missing
+- **THEN** the workflow preserves the workflow type and any valid context
+- **AND** it degrades to the selection step instead of showing a broken workflow state
+
+### Requirement: Project bundle result SHALL expose package identity and outcome
+The system SHALL present a result state after bundle generation with package identity, generation outcome, and inspection routes.
+
+#### Scenario: Successful generation shows result
+- **WHEN** project bundle generation completes successfully
+- **THEN** the result state shows bundle package identity, file location, generation timestamp, member count, warning count, and validation summary
+- **AND** the user can inspect bundle contents
+
+#### Scenario: Failed generation shows actionable diagnostics
+- **WHEN** project bundle generation fails
+- **THEN** the result state shows the failure reason with actionable diagnostics
+- **AND** it offers routes to inspect or repair the blocking issue
+
+### Requirement: Recent operations SHALL summarize project bundle runs
+The system SHALL record completed project bundle workflows as compact recent-operation entries with route to bundle result detail.
+
+#### Scenario: Project bundle appears as recent operation
+- **WHEN** a project bundle workflow completes
+- **THEN** recent operations shows one entry for the bundle run
+- **AND** the entry includes workflow type, timestamp, aggregate status, and bundle identity
+- **AND** it does not claim that the bundle was restored, applied, or synced
+
+#### Scenario: Recent operation opens bundle result detail
+- **WHEN** the user selects a project bundle recent-operation entry
+- **THEN** the page shows the bundle result detail with package identity, member inventory, validation summary, and generation outcome

--- a/openspec/changes/project-bundle-foundation/specs/backup-migration/spec.md
+++ b/openspec/changes/project-bundle-foundation/specs/backup-migration/spec.md
@@ -17,10 +17,15 @@ The system SHALL provide a bounded `project-bundle` workflow inside `Backup / Mi
 ### Requirement: Project bundle SHALL define default member categories
 The system SHALL treat the following as default bundle member categories: sessions, rules, memory, skills, commands, package-level metadata, and project-level metadata.
 
-#### Scenario: Default member categories are presented at selection
+#### Scenario: Selectable member categories are presented at selection
 - **WHEN** the user enters the project bundle selection step
-- **THEN** the workflow presents sessions, rules, memory, skills, commands, package-level metadata, and project-level metadata as the default member categories
-- **AND** the user can deselect or adjust member inclusion before proceeding
+- **THEN** the workflow presents sessions, rules, memory, skills, and commands as the selectable member categories
+- **AND** the user can deselect or adjust those member categories before proceeding
+
+#### Scenario: Foundation metadata is always included
+- **WHEN** the user enters the project bundle selection step
+- **THEN** the workflow shows package-level metadata and project-level metadata as always included foundation metadata
+- **AND** foundation v1 does not expose deselection toggles for those metadata sections
 
 #### Scenario: Non-core objects are out of scope for v1
 - **WHEN** the user enters the project bundle selection step

--- a/openspec/changes/project-bundle-foundation/tasks.md
+++ b/openspec/changes/project-bundle-foundation/tasks.md
@@ -1,127 +1,127 @@
 ## 1. Workflow Model
 
-- [ ] 1.1 Add `project-bundle` to backup workflow types, labels, descriptors,
+- [x] 1.1 Add `project-bundle` to backup workflow types, labels, descriptors,
   and step definitions.
-- [ ] 1.2 Define bundle member category types: sessions, rules, memory, skills,
+- [x] 1.2 Define bundle member category types: sessions, rules, memory, skills,
   commands, package-level metadata, project-level metadata.
-- [ ] 1.3 Define bundle composition context: member selection state,
+- [x] 1.3 Define bundle composition context: member selection state,
   configuration options, scope summary.
-- [ ] 1.4 Define bundle validation result types: warning-level items,
+- [x] 1.4 Define bundle validation result types: warning-level items,
   blocker-level items, validation summary.
-- [ ] 1.5 Define bundle generation result types: package identity, file
+- [x] 1.5 Define bundle generation result types: package identity, file
   location, member inventory, generation timestamp, aggregate status.
-- [ ] 1.6 Define lightweight member metadata snapshot shape: identity,
+- [x] 1.6 Define lightweight member metadata snapshot shape: identity,
   provenance summary, scope, subtype, timestamps, status.
-- [ ] 1.7 Define bundle manifest structure: schema version, package metadata,
+- [x] 1.7 Define bundle manifest structure: schema version, package metadata,
   project metadata, member inventory, member references, validation summary.
-- [ ] 1.8 Add helper functions for composition validation, severity
+- [x] 1.8 Add helper functions for composition validation, severity
   classification, generation result creation, and recent-operation creation.
-- [ ] 1.9 Ensure existing backup/import/validate/bulk/migration-preview workflow
+- [x] 1.9 Ensure existing backup/import/validate/bulk/migration-preview workflow
   helpers remain backward compatible.
 
 ## 2. Selection and Composition
 
-- [ ] 2.1 Add project bundle selection state to `BackupMigrationFoundation`.
-- [ ] 2.2 Present default member categories (sessions, rules, memory, skills,
+- [x] 2.1 Add project bundle selection state to `BackupMigrationFoundation`.
+- [x] 2.2 Present default member categories (sessions, rules, memory, skills,
   commands, package-level metadata, project-level metadata) at selection.
-- [ ] 2.3 Allow member deselection and inclusion adjustment.
-- [ ] 2.4 Keep non-core objects (raw sources, caches, indexes, tokens, UI
+- [x] 2.3 Allow member deselection and inclusion adjustment.
+- [x] 2.4 Keep non-core objects (raw sources, caches, indexes, tokens, UI
   state, repo copies, app preferences) explicitly out of scope for v1, and do
   not build inclusion toggles for them.
-- [ ] 2.5 Add configuration step for bundle-level options (bundle name, optional
+- [x] 2.5 Add configuration step for bundle-level options (bundle name, optional
   notes).
-- [ ] 2.6 Ensure selection cannot be bypassed by routed entry or direct
+- [x] 2.6 Ensure selection cannot be bypassed by routed entry or direct
   generation.
 
 ## 3. Validation
 
-- [ ] 3.1 Validate composition completeness: at least one member selected,
+- [x] 3.1 Validate composition completeness: at least one member selected,
   bundle identity derivable, manifest formable.
-- [ ] 3.2 Classify warning-level issues: missing provenance, uncertain subtype,
+- [x] 3.2 Classify warning-level issues: missing provenance, uncertain subtype,
   stale member state, non-critical missing references.
-- [ ] 3.3 Classify blocker-level issues: unformable manifest, missing required
+- [x] 3.3 Classify blocker-level issues: unformable manifest, missing required
   metadata/identity, unwritable output, invalid workflow input.
-- [ ] 3.4 Produce per-member validation status with issue classification.
-- [ ] 3.5 Produce aggregate validation summary with warning count, blocker
+- [x] 3.4 Produce per-member validation status with issue classification.
+- [x] 3.5 Produce aggregate validation summary with warning count, blocker
   count, and member eligibility.
-- [ ] 3.6 Surface sessions without existing backup packages as validation
+- [x] 3.6 Surface sessions without existing backup packages as validation
   warnings.
-- [ ] 3.7 Ensure warnings remain visible through confirmation state.
-- [ ] 3.8 Define unresolved session-reference status for selected sessions that
+- [x] 3.7 Ensure warnings remain visible through confirmation state.
+- [x] 3.8 Define unresolved session-reference status for selected sessions that
   lack existing backup packages, without auto-generating session payloads.
 
 ## 4. Confirmation and Execution
 
-- [ ] 4.1 Add confirmation state showing bundle scope, included members,
+- [x] 4.1 Add confirmation state showing bundle scope, included members,
   excluded members, warning count, and blocker state.
-- [ ] 4.2 Block confirmation when blockers exist.
-- [ ] 4.3 Add execution state that generates the bundle file on the local
+- [x] 4.2 Block confirmation when blockers exist.
+- [x] 4.3 Add execution state that generates the bundle file on the local
   filesystem.
-- [ ] 4.4 Write bundle file with minimum structure: manifest, package metadata,
+- [x] 4.4 Write bundle file with minimum structure: manifest, package metadata,
   project metadata, member inventory, member references, validation summary,
   and lightweight metadata snapshots.
-- [ ] 4.5 Include schema version in bundle manifest.
-- [ ] 4.6 When generation proceeds with a session-without-backup warning, write
+- [x] 4.5 Include schema version in bundle manifest.
+- [x] 4.6 When generation proceeds with a session-without-backup warning, write
   an unresolved session member reference plus metadata snapshot instead of
   silently omitting the session or generating an ad hoc session backup payload.
 
 ## 5. Result
 
-- [ ] 5.1 Add result state showing package identity, file location, generation
+- [x] 5.1 Add result state showing package identity, file location, generation
   timestamp, member count, warning count, and validation summary.
-- [ ] 5.2 Add bundle content inspection from result state.
-- [ ] 5.3 Add failure result with actionable diagnostics and repair routes.
-- [ ] 5.4 Update idle-state description copy in `BackupMigrationFoundation` to
+- [x] 5.2 Add bundle content inspection from result state.
+- [x] 5.3 Add failure result with actionable diagnostics and repair routes.
+- [x] 5.4 Update idle-state description copy in `BackupMigrationFoundation` to
   include project bundle.
 
 ## 6. Routed Handoff
 
-- [ ] 6.1 Extend backup-migration handoff types to carry project bundle
+- [x] 6.1 Extend backup-migration handoff types to carry project bundle
   workflow identity, origin cue, scope hints, filter hints, and explicit object
   references.
-- [ ] 6.2 Add `Project Overview → Project Bundle` route that opens bundle
+- [x] 6.2 Add `Project Overview → Project Bundle` route that opens bundle
   selection without invented member sets.
-- [ ] 6.3 Add `Assets → Project Bundle` route that may prefill explicit asset
+- [x] 6.3 Add `Assets → Project Bundle` route that may prefill explicit asset
   references only.
-- [ ] 6.4 Add `Analysis → Project Bundle` route that preserves issue context
+- [x] 6.4 Add `Analysis → Project Bundle` route that preserves issue context
   but does not infer composition.
-- [ ] 6.5 Ensure stale or incomplete bundle handoff degrades to selection
+- [x] 6.5 Ensure stale or incomplete bundle handoff degrades to selection
   instead of broken workflow state.
 
 ## 7. Recent Operations
 
-- [ ] 7.1 Record completed project bundle workflows as compact recent-operation
+- [x] 7.1 Record completed project bundle workflows as compact recent-operation
   entries.
-- [ ] 7.2 Include workflow type, timestamp, aggregate status, and bundle
+- [x] 7.2 Include workflow type, timestamp, aggregate status, and bundle
   identity in recent operations.
-- [ ] 7.3 Route from a project bundle recent operation back to bundle result
+- [x] 7.3 Route from a project bundle recent operation back to bundle result
   detail.
-- [ ] 7.4 Ensure recent-operation copy does not claim restore, apply, or sync.
+- [x] 7.4 Ensure recent-operation copy does not claim restore, apply, or sync.
 
 ## 8. Tests and QA
 
-- [ ] 8.1 Add model tests for project bundle workflow descriptors, member
+- [x] 8.1 Add model tests for project bundle workflow descriptors, member
   types, composition validation, severity classification, generation result,
   and recent-operation summary.
-- [ ] 8.2 Add component tests for selection, configuration, validation
+- [x] 8.2 Add component tests for selection, configuration, validation
   (warnings and blockers), confirmation, execution, result (success and
   failure), and session-without-backup warning states.
-- [ ] 8.3 Add shell routing tests for overview, assets, and analysis handoff
+- [x] 8.3 Add shell routing tests for overview, assets, and analysis handoff
   into project bundle.
-- [ ] 8.4 Add regression tests proving existing backup/import/validate/bulk/
+- [x] 8.4 Add regression tests proving existing backup/import/validate/bulk/
   migration-preview workflows still work.
-- [ ] 8.5 Prepare an external QA prompt covering composition-before-generation
+- [x] 8.5 Prepare an external QA prompt covering composition-before-generation
   boundary, validation severity, session reuse, routed handoff prefill limits,
   bundle file structure, and recent operations.
 
 ## 9. Documentation and Validation
 
-- [ ] 9.1 Update `README.md` if user-facing Backup / Migration behavior
+- [x] 9.1 Update `README.md` if user-facing Backup / Migration behavior
   changes.
-- [ ] 9.2 Update `CHANGELOG.md` under `## Unreleased` when implementation
+- [x] 9.2 Update `CHANGELOG.md` under `## Unreleased` when implementation
   ships.
-- [ ] 9.3 Run targeted tests for backup-migration model helpers,
+- [x] 9.3 Run targeted tests for backup-migration model helpers,
   `BackupMigrationFoundation`, and shell routing.
-- [ ] 9.4 Run `pnpm test`, `pnpm build`, and
+- [x] 9.4 Run `pnpm test`, `pnpm build`, and
   `OPENSPEC_TELEMETRY=0 openspec validate project-bundle-foundation --strict`.
-- [ ] 9.5 Update external QA prompt to include project bundle smoke checks.
+- [x] 9.5 Update external QA prompt to include project bundle smoke checks.

--- a/openspec/changes/project-bundle-foundation/tasks.md
+++ b/openspec/changes/project-bundle-foundation/tasks.md
@@ -1,0 +1,127 @@
+## 1. Workflow Model
+
+- [ ] 1.1 Add `project-bundle` to backup workflow types, labels, descriptors,
+  and step definitions.
+- [ ] 1.2 Define bundle member category types: sessions, rules, memory, skills,
+  commands, package-level metadata, project-level metadata.
+- [ ] 1.3 Define bundle composition context: member selection state,
+  configuration options, scope summary.
+- [ ] 1.4 Define bundle validation result types: warning-level items,
+  blocker-level items, validation summary.
+- [ ] 1.5 Define bundle generation result types: package identity, file
+  location, member inventory, generation timestamp, aggregate status.
+- [ ] 1.6 Define lightweight member metadata snapshot shape: identity,
+  provenance summary, scope, subtype, timestamps, status.
+- [ ] 1.7 Define bundle manifest structure: schema version, package metadata,
+  project metadata, member inventory, member references, validation summary.
+- [ ] 1.8 Add helper functions for composition validation, severity
+  classification, generation result creation, and recent-operation creation.
+- [ ] 1.9 Ensure existing backup/import/validate/bulk/migration-preview workflow
+  helpers remain backward compatible.
+
+## 2. Selection and Composition
+
+- [ ] 2.1 Add project bundle selection state to `BackupMigrationFoundation`.
+- [ ] 2.2 Present default member categories (sessions, rules, memory, skills,
+  commands, package-level metadata, project-level metadata) at selection.
+- [ ] 2.3 Allow member deselection and inclusion adjustment.
+- [ ] 2.4 Keep non-core objects (raw sources, caches, indexes, tokens, UI
+  state, repo copies, app preferences) explicitly out of scope for v1, and do
+  not build inclusion toggles for them.
+- [ ] 2.5 Add configuration step for bundle-level options (bundle name, optional
+  notes).
+- [ ] 2.6 Ensure selection cannot be bypassed by routed entry or direct
+  generation.
+
+## 3. Validation
+
+- [ ] 3.1 Validate composition completeness: at least one member selected,
+  bundle identity derivable, manifest formable.
+- [ ] 3.2 Classify warning-level issues: missing provenance, uncertain subtype,
+  stale member state, non-critical missing references.
+- [ ] 3.3 Classify blocker-level issues: unformable manifest, missing required
+  metadata/identity, unwritable output, invalid workflow input.
+- [ ] 3.4 Produce per-member validation status with issue classification.
+- [ ] 3.5 Produce aggregate validation summary with warning count, blocker
+  count, and member eligibility.
+- [ ] 3.6 Surface sessions without existing backup packages as validation
+  warnings.
+- [ ] 3.7 Ensure warnings remain visible through confirmation state.
+- [ ] 3.8 Define unresolved session-reference status for selected sessions that
+  lack existing backup packages, without auto-generating session payloads.
+
+## 4. Confirmation and Execution
+
+- [ ] 4.1 Add confirmation state showing bundle scope, included members,
+  excluded members, warning count, and blocker state.
+- [ ] 4.2 Block confirmation when blockers exist.
+- [ ] 4.3 Add execution state that generates the bundle file on the local
+  filesystem.
+- [ ] 4.4 Write bundle file with minimum structure: manifest, package metadata,
+  project metadata, member inventory, member references, validation summary,
+  and lightweight metadata snapshots.
+- [ ] 4.5 Include schema version in bundle manifest.
+- [ ] 4.6 When generation proceeds with a session-without-backup warning, write
+  an unresolved session member reference plus metadata snapshot instead of
+  silently omitting the session or generating an ad hoc session backup payload.
+
+## 5. Result
+
+- [ ] 5.1 Add result state showing package identity, file location, generation
+  timestamp, member count, warning count, and validation summary.
+- [ ] 5.2 Add bundle content inspection from result state.
+- [ ] 5.3 Add failure result with actionable diagnostics and repair routes.
+- [ ] 5.4 Update idle-state description copy in `BackupMigrationFoundation` to
+  include project bundle.
+
+## 6. Routed Handoff
+
+- [ ] 6.1 Extend backup-migration handoff types to carry project bundle
+  workflow identity, origin cue, scope hints, filter hints, and explicit object
+  references.
+- [ ] 6.2 Add `Project Overview → Project Bundle` route that opens bundle
+  selection without invented member sets.
+- [ ] 6.3 Add `Assets → Project Bundle` route that may prefill explicit asset
+  references only.
+- [ ] 6.4 Add `Analysis → Project Bundle` route that preserves issue context
+  but does not infer composition.
+- [ ] 6.5 Ensure stale or incomplete bundle handoff degrades to selection
+  instead of broken workflow state.
+
+## 7. Recent Operations
+
+- [ ] 7.1 Record completed project bundle workflows as compact recent-operation
+  entries.
+- [ ] 7.2 Include workflow type, timestamp, aggregate status, and bundle
+  identity in recent operations.
+- [ ] 7.3 Route from a project bundle recent operation back to bundle result
+  detail.
+- [ ] 7.4 Ensure recent-operation copy does not claim restore, apply, or sync.
+
+## 8. Tests and QA
+
+- [ ] 8.1 Add model tests for project bundle workflow descriptors, member
+  types, composition validation, severity classification, generation result,
+  and recent-operation summary.
+- [ ] 8.2 Add component tests for selection, configuration, validation
+  (warnings and blockers), confirmation, execution, result (success and
+  failure), and session-without-backup warning states.
+- [ ] 8.3 Add shell routing tests for overview, assets, and analysis handoff
+  into project bundle.
+- [ ] 8.4 Add regression tests proving existing backup/import/validate/bulk/
+  migration-preview workflows still work.
+- [ ] 8.5 Prepare an external QA prompt covering composition-before-generation
+  boundary, validation severity, session reuse, routed handoff prefill limits,
+  bundle file structure, and recent operations.
+
+## 9. Documentation and Validation
+
+- [ ] 9.1 Update `README.md` if user-facing Backup / Migration behavior
+  changes.
+- [ ] 9.2 Update `CHANGELOG.md` under `## Unreleased` when implementation
+  ships.
+- [ ] 9.3 Run targeted tests for backup-migration model helpers,
+  `BackupMigrationFoundation`, and shell routing.
+- [ ] 9.4 Run `pnpm test`, `pnpm build`, and
+  `OPENSPEC_TELEMETRY=0 openspec validate project-bundle-foundation --strict`.
+- [ ] 9.5 Update external QA prompt to include project bundle smoke checks.

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+
 import { NextResponse } from "next/server";
 
 import {
@@ -30,6 +32,12 @@ function normalizeConfiguration(input?: ProjectBundleConfiguration | null): Proj
     bundleName: input?.bundleName?.trim() ?? "",
     notes: input?.notes?.trim() || undefined,
   };
+}
+
+function redactDisplayPath(filePath: string): string {
+  return filePath
+    .replace(os.homedir(), "~")
+    .replace(/\\/g, "/");
 }
 
 export async function POST(req: Request) {
@@ -87,7 +95,10 @@ export async function POST(req: Request) {
   try {
     if (body.mode === "generate") {
       const generated = await generateProjectBundle(selection, configuration);
-      return NextResponse.json(generated);
+      return NextResponse.json({
+        ...generated,
+        filePath: redactDisplayPath(generated.filePath),
+      });
     }
 
     const validation = await validateProjectBundle(selection, configuration);

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -103,8 +103,7 @@ export async function POST(req: Request) {
 
     const validation = await validateProjectBundle(selection, configuration);
     return NextResponse.json(validation);
-  } catch (error) {
-    console.error("Project bundle route failed.", error);
+  } catch {
     return NextResponse.json(
       {
         error: body.mode === "generate"

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -104,11 +104,17 @@ export async function POST(req: Request) {
     const validation = await validateProjectBundle(selection, configuration);
     return NextResponse.json(validation);
   } catch (error) {
+    console.error("Project bundle route failed.", error);
     return NextResponse.json(
       {
-        error: error instanceof Error ? error.message : String(error),
+        error: body.mode === "generate"
+          ? "Project bundle generation failed."
+          : "Project bundle validation failed.",
         code: "PROJECT_BUNDLE_FAILED",
         title: body.mode === "generate" ? "Bundle generation failed" : "Bundle validation failed",
+        hint: body.mode === "generate"
+          ? "Review validation output and bundle configuration, then try generation again."
+          : "Review bundle selection and configuration, then retry validation.",
       },
       { status: 400 }
     );

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+
+import {
+  createDefaultProjectBundleSelection,
+  type BackupMigrationHandoff,
+  type BackupSessionSelection,
+  type ProjectBundleConfiguration,
+} from "@/lib/backupMigration";
+import { generateProjectBundle, validateProjectBundle } from "@/lib/server/projectBundleService";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type ProjectBundleRequestBody = {
+  mode?: "validate" | "generate";
+  selection?: {
+    includedCategories?: Partial<ReturnType<typeof createDefaultProjectBundleSelection>["includedCategories"]>;
+    sessionSelections?: BackupSessionSelection[];
+    objectRefs?: string[];
+    originCue?: string;
+    scopeHint?: string;
+    filterHint?: string;
+  };
+  configuration?: ProjectBundleConfiguration;
+  handoff?: BackupMigrationHandoff | null;
+};
+
+function normalizeConfiguration(input?: ProjectBundleConfiguration | null): ProjectBundleConfiguration {
+  return {
+    bundleName: input?.bundleName?.trim() ?? "",
+    notes: input?.notes?.trim() || undefined,
+  };
+}
+
+export async function POST(req: Request) {
+  let body: ProjectBundleRequestBody;
+  try {
+    body = (await req.json()) as ProjectBundleRequestBody;
+  } catch {
+    return NextResponse.json(
+      {
+        error: "Invalid JSON body",
+        code: "INVALID_REQUEST",
+        title: "Invalid request",
+        hint: "Send a JSON body with mode, selection, and configuration.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const configuration = normalizeConfiguration(body.configuration);
+  const selection = createDefaultProjectBundleSelection(body.handoff ?? null, body.selection?.sessionSelections ?? []);
+
+  selection.includedCategories = {
+    ...selection.includedCategories,
+    ...(body.selection?.includedCategories ?? {}),
+  };
+  selection.objectRefs = Array.from(new Set((body.selection?.objectRefs ?? selection.objectRefs).map((item) => item.trim()).filter(Boolean)));
+  selection.originCue = body.selection?.originCue?.trim() || selection.originCue;
+  selection.scopeHint = body.selection?.scopeHint?.trim() || selection.scopeHint;
+  selection.filterHint = body.selection?.filterHint?.trim() || selection.filterHint;
+
+  try {
+    if (body.mode === "generate") {
+      const generated = await generateProjectBundle(selection, configuration);
+      return NextResponse.json(generated);
+    }
+
+    const validation = await validateProjectBundle(selection, configuration);
+    return NextResponse.json(validation);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        code: "PROJECT_BUNDLE_FAILED",
+        title: body.mode === "generate" ? "Bundle generation failed" : "Bundle validation failed",
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -48,6 +48,18 @@ export async function POST(req: Request) {
     );
   }
 
+  if (body.mode !== undefined && body.mode !== "validate" && body.mode !== "generate") {
+    return NextResponse.json(
+      {
+        error: `Unsupported mode: ${String(body.mode)}`,
+        code: "INVALID_MODE",
+        title: "Invalid request",
+        hint: "Use mode validate or generate.",
+      },
+      { status: 400 }
+    );
+  }
+
   const configuration = normalizeConfiguration(body.configuration);
   const selection = createDefaultProjectBundleSelection(body.handoff ?? null, body.selection?.sessionSelections ?? []);
 

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -60,6 +60,18 @@ export async function POST(req: Request) {
     );
   }
 
+  if (body.mode === "generate" && (!body.selection || !body.configuration)) {
+    return NextResponse.json(
+      {
+        error: "Generate mode requires explicit selection and configuration.",
+        code: "MISSING_GENERATE_INPUT",
+        title: "Invalid request",
+        hint: "Run explicit composition first, then submit selection and configuration for generation.",
+      },
+      { status: 400 }
+    );
+  }
+
   const configuration = normalizeConfiguration(body.configuration);
   const selection = createDefaultProjectBundleSelection(body.handoff ?? null, body.selection?.sessionSelections ?? []);
 

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -37,7 +37,7 @@ export type AssetsFoundationProps = {
   handoff: AssetsHandoff | null;
   onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
   onOpenAnalysis(context: { issueLabel: string; assetId?: string; subtype?: ContextAssetSubtype; status?: ContextAssetStatus }): void;
-  onOpenBackup(context: { assetId?: string; subtype?: ContextAssetSubtype }): void;
+  onOpenBackup(context: { assetId?: string; subtype?: ContextAssetSubtype; workflowType?: "migration-preview" | "project-bundle" }): void;
   loadingDelayMs?: number;
 };
 
@@ -316,8 +316,8 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                   <Button size="sm" variant="outline" onClick={() => updateFilter("scope", "all")}>
                     Clear scope filter
                   </Button>
-                  <Button size="sm" variant="outline" onClick={() => onOpenBackup({ subtype: filters.subtype === "all" ? undefined : filters.subtype })}>
-                    Prepare import in Backup / Migration
+                  <Button size="sm" variant="outline" onClick={() => onOpenBackup({ subtype: filters.subtype === "all" ? undefined : filters.subtype, workflowType: "project-bundle" })}>
+                    Open Project Bundle
                   </Button>
                 </div>
               </div>
@@ -437,8 +437,11 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                 </div>
 
                 <div className="flex flex-wrap gap-2">
-                  <Button size="sm" variant="outline" onClick={() => onOpenBackup({ assetId: selectedAsset.id, subtype: selectedAsset.subtype })}>
-                    Prepare backup / migration
+                  <Button size="sm" variant="outline" onClick={() => onOpenBackup({ assetId: selectedAsset.id, subtype: selectedAsset.subtype, workflowType: "migration-preview" })}>
+                    Preview in Backup / Migration
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => onOpenBackup({ assetId: selectedAsset.id, subtype: selectedAsset.subtype, workflowType: "project-bundle" })}>
+                    Open Project Bundle
                   </Button>
                 </div>
               </div>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -39,6 +39,7 @@ import {
   summarizeSourceCopyConfiguration,
   validateBackupPackageRemote,
   PROJECT_BUNDLE_MEMBER_CATEGORIES,
+  PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES,
   WORKFLOW_DESCRIPTORS,
   type BackupSessionSelection,
   type BackupMigrationHandoff,
@@ -59,6 +60,7 @@ import {
   type ProjectBundleMemberCategory,
   type ProjectBundleMemberInventoryItem,
   type ProjectBundleMemberReference,
+  type ProjectBundleSelectableMemberCategory,
   type ProjectBundleSelectionState,
   type ProjectBundleValidationSummary,
   type RecentOperation,
@@ -834,7 +836,7 @@ export function BackupMigrationFoundation({
     setBulkDraftRootId("");
   }, [bulkDraftRootId, bulkDraftSessionId, bulkDraftSource]);
 
-  const toggleProjectBundleCategory = useCallback((category: ProjectBundleMemberCategory, selected: boolean) => {
+  const toggleProjectBundleCategory = useCallback((category: ProjectBundleSelectableMemberCategory, selected: boolean) => {
     setProjectBundleSelection((prev) => ({
       ...prev,
       includedCategories: {
@@ -1531,7 +1533,7 @@ export function BackupMigrationFoundation({
                   Project Bundle is a real Backup / Migration workflow. Routed context can prefill cues and explicit refs, but final composition still happens here before validation and generation.
                 </div>
                 <div className="grid gap-2 sm:grid-cols-2">
-                  {PROJECT_BUNDLE_MEMBER_CATEGORIES.map((category) => (
+                  {PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.map((category) => (
                     <label key={category} className="flex items-center gap-2 rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
                       <input
                         type="checkbox"
@@ -1541,6 +1543,12 @@ export function BackupMigrationFoundation({
                       <span>{formatBundleCategoryLabel(category)}</span>
                     </label>
                   ))}
+                </div>
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Foundation metadata is always included:
+                  <span className="ml-1 font-medium text-foreground">Package Metadata</span>
+                  <span className="mx-1">and</span>
+                  <span className="font-medium text-foreground">Project Metadata</span>.
                 </div>
                 <div className="space-y-3 rounded-xl border border-border/60 bg-background/10 px-3 py-3">
                   <div className="text-xs uppercase tracking-[0.18em] text-muted">Explicit session refs</div>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -9,9 +9,11 @@ import {
   addRecentOperation,
   buildBulkSessionValidationResult,
   buildMigrationPreviewItems,
+  createDefaultProjectBundleSelection,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
   createMigrationPreviewOperationResult,
+  createProjectBundleOperationResult,
   createBulkOperationSummary,
   createOperationResult,
   dedupeSessionSelections,
@@ -33,8 +35,10 @@ import {
   isTerminalState,
   normalizeBackupId,
   resolveWorkflowFromHandoff,
+  summarizeProjectBundleSelection,
   summarizeSourceCopyConfiguration,
   validateBackupPackageRemote,
+  PROJECT_BUNDLE_MEMBER_CATEGORIES,
   WORKFLOW_DESCRIPTORS,
   type BackupSessionSelection,
   type BackupMigrationHandoff,
@@ -51,6 +55,12 @@ import {
   type MigrationPreviewSourceProduct,
   type MigrationPreviewTargetContext,
   type MigrationPreviewTargetProfile,
+  type ProjectBundleConfiguration,
+  type ProjectBundleMemberCategory,
+  type ProjectBundleMemberInventoryItem,
+  type ProjectBundleMemberReference,
+  type ProjectBundleSelectionState,
+  type ProjectBundleValidationSummary,
   type RecentOperation,
 } from "@/lib/backupMigration";
 import type { Source } from "@/lib/types";
@@ -137,6 +147,21 @@ export function resolveInitialBulkSelections(handoff: BackupMigrationHandoff | n
   if (!handoff) return [];
   if (handoff.sessions?.length) return dedupeSessionSelections(handoff.sessions);
   if (handoff.workflowType === "bulk-session-backup" && handoff.sessionId) {
+    return dedupeSessionSelections([
+      {
+        sessionId: handoff.sessionId,
+        source: handoff.source,
+        rootId: handoff.rootId,
+      },
+    ]);
+  }
+  return [];
+}
+
+export function resolveInitialProjectBundleSessionSelections(handoff: BackupMigrationHandoff | null): BackupSessionSelection[] {
+  if (!handoff) return [];
+  if (handoff.sessions?.length) return dedupeSessionSelections(handoff.sessions);
+  if (handoff.workflowType === "project-bundle" && handoff.sessionId) {
     return dedupeSessionSelections([
       {
         sessionId: handoff.sessionId,
@@ -275,8 +300,17 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
           {props.result.backupId ? (
             <div className="mt-2 text-xs text-muted">Backup ID: {props.result.backupId}</div>
           ) : null}
+          {props.result.packageId ? (
+            <div className="mt-2 text-xs text-muted">Package ID: {props.result.packageId}</div>
+          ) : null}
+          {props.result.filePath ? (
+            <div className="mt-1 text-xs text-muted">File: {props.result.filePath}</div>
+          ) : null}
           {props.result.sessionCount != null ? (
             <div className="text-xs text-muted">Sessions: {props.result.sessionCount}</div>
+          ) : null}
+          {props.result.memberCount != null ? (
+            <div className="text-xs text-muted">Members: {props.result.memberCount}</div>
           ) : null}
           <div className="text-xs text-muted">Completed: {props.result.timestamp}</div>
         </div>
@@ -292,6 +326,60 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
           <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
             <div className="font-medium text-foreground">Source-copy configuration</div>
             <div className="mt-1 text-xs leading-5">{props.result.sourceCopySummary}</div>
+          </div>
+        ) : null}
+        {props.result.workflowType === "project-bundle" && props.result.projectBundleValidationSummary ? (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+              <div className="text-xs text-muted">Warnings</div>
+              <div className="mt-1 font-medium">{props.result.projectBundleValidationSummary.warningCount}</div>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+              <div className="text-xs text-muted">Blockers at validation</div>
+              <div className="mt-1 font-medium">{props.result.projectBundleValidationSummary.blockerCount}</div>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+              <div className="text-xs text-muted">Selected categories</div>
+              <div className="mt-1 font-medium">{props.result.projectBundleValidationSummary.selectedCategoryCount}</div>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+              <div className="text-xs text-muted">Unresolved refs</div>
+              <div className="mt-1 font-medium">{props.result.projectBundleValidationSummary.unresolvedReferenceCount}</div>
+            </div>
+          </div>
+        ) : null}
+        {props.result.workflowType === "project-bundle" && (props.result.projectBundleMemberInventory?.length ?? 0) > 0 ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Bundle member inventory</div>
+            <div className="mt-3 space-y-2">
+              {props.result.projectBundleMemberInventory!.map((item) => (
+                <div key={item.category} className="rounded-lg border border-border/60 bg-background/40 px-3 py-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{item.category}</span>
+                    <Badge variant={item.status === "ready" ? "ok" : item.status === "warning" ? "warn" : "default"}>
+                      {item.status}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 text-xs leading-5">{item.detail}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {props.result.workflowType === "project-bundle" && (props.result.projectBundleMemberReferences?.length ?? 0) > 0 ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <div className="font-medium text-foreground">Member references</div>
+            <div className="mt-3 space-y-2">
+              {props.result.projectBundleMemberReferences!.map((item) => (
+                <div key={item.id} className="rounded-lg border border-border/60 bg-background/40 px-3 py-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{item.label}</span>
+                    <Badge variant={item.status === "resolved" ? "ok" : "warn"}>{item.status}</Badge>
+                  </div>
+                  <div className="mt-1 text-xs leading-5">{item.detail}</div>
+                </div>
+              ))}
+            </div>
           </div>
         ) : null}
         {props.result.workflowType === "migration-preview" ? (
@@ -395,6 +483,11 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
             <span className="font-medium text-foreground">No runtime restore or apply.</span>{" "}
             Preview results are advisory compatibility findings only. They do not write objects, reopen third-party runtimes, or create backup packages.
           </div>
+        ) : props.result.workflowType === "project-bundle" ? (
+          <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+            <span className="font-medium text-foreground">No restore or apply in foundation v1.</span>{" "}
+            The generated project bundle is a portable local package only. It does not promise vendor-runtime reopen, cloud sync, app snapshot, or team collaboration semantics.
+          </div>
         ) : (
           <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
             <span className="font-medium text-foreground">No vendor-runtime restore.</span>{" "}
@@ -441,6 +534,8 @@ function RecentOperationsPanel(props: { operations: RecentOperation[]; onSelectO
             </div>
             <div className="mt-1 text-xs text-muted">{op.summary}</div>
             {op.sessionCount != null ? <div className="mt-1 text-[11px] text-muted">Sessions: {op.sessionCount}</div> : null}
+            {op.packageId ? <div className="mt-1 text-[11px] text-muted">Package: {op.packageId}</div> : null}
+            {op.memberCount != null ? <div className="mt-1 text-[11px] text-muted">Members: {op.memberCount}</div> : null}
             {op.workflowType === "migration-preview" && op.previewScope?.kind ? (
               <div className="mt-1 text-[11px] text-muted">
                 Scope: {formatMigrationPreviewScopeLabel(op.previewScope.kind)} ({op.previewScope.itemRefs.length})
@@ -487,6 +582,21 @@ export function BackupMigrationFoundation({
   const [previewScope, setPreviewScope] = useState<MigrationPreviewScope>(() => deriveInitialPreviewScope(handoff));
   const [previewScopeDraft, setPreviewScopeDraft] = useState(deriveInitialPreviewScope(handoff).itemRefs.join("\n"));
 
+  // Project bundle state
+  const [projectBundleSelection, setProjectBundleSelection] = useState<ProjectBundleSelectionState>(() =>
+    createDefaultProjectBundleSelection(handoff, resolveInitialProjectBundleSessionSelections(handoff))
+  );
+  const [bundleDraftSessionId, setBundleDraftSessionId] = useState("");
+  const [bundleDraftSource, setBundleDraftSource] = useState<Source | "">("");
+  const [bundleDraftRootId, setBundleDraftRootId] = useState("");
+  const [bundleConfig, setBundleConfig] = useState<ProjectBundleConfiguration>({
+    bundleName: "Current project context bundle",
+    notes: "",
+  });
+  const [projectBundleValidationSummary, setProjectBundleValidationSummary] = useState<ProjectBundleValidationSummary | null>(null);
+  const [projectBundleMemberInventory, setProjectBundleMemberInventory] = useState<ProjectBundleMemberInventoryItem[]>([]);
+  const [projectBundleMemberReferences, setProjectBundleMemberReferences] = useState<ProjectBundleMemberReference[]>([]);
+
   // Validation
   const [validationResult, setValidationResult] = useState<BackupValidationResult | null>(null);
 
@@ -525,6 +635,17 @@ export function BackupMigrationFoundation({
     setPreviewTargetContext({});
     setPreviewScope({ itemRefs: [] });
     setPreviewScopeDraft("");
+    setProjectBundleSelection(createDefaultProjectBundleSelection(null, []));
+    setBundleDraftSessionId("");
+    setBundleDraftSource("");
+    setBundleDraftRootId("");
+    setBundleConfig({
+      bundleName: "Current project context bundle",
+      notes: "",
+    });
+    setProjectBundleValidationSummary(null);
+    setProjectBundleMemberInventory([]);
+    setProjectBundleMemberReferences([]);
     setValidationResult(null);
     setIsExecuting(false);
     setExecutionError(null);
@@ -549,6 +670,16 @@ export function BackupMigrationFoundation({
       setPreviewTargetContext(initialTarget);
       setPreviewScope(initialScope);
       setPreviewScopeDraft(initialScope.itemRefs.join("\n"));
+    }
+    if (type === "project-bundle") {
+      setProjectBundleSelection(createDefaultProjectBundleSelection(activeHandoff, resolveInitialProjectBundleSessionSelections(activeHandoff)));
+      setBundleConfig({
+        bundleName: "Current project context bundle",
+        notes: activeHandoff?.subtitle ?? "",
+      });
+      setProjectBundleValidationSummary(null);
+      setProjectBundleMemberInventory([]);
+      setProjectBundleMemberReferences([]);
     }
   }, [activeHandoff]);
 
@@ -604,6 +735,42 @@ export function BackupMigrationFoundation({
       return;
     }
 
+    if (activeWorkflow === "project-bundle") {
+      const response = await fetch("/api/project-bundles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "validate",
+          handoff: activeHandoff,
+          selection: projectBundleSelection,
+          configuration: bundleConfig,
+        }),
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok || !payload) {
+        const result = deriveValidationResult([
+          {
+            id: "bundle-validation-request-failed",
+            label: "Bundle validation",
+            severity: "block",
+            detail: payload?.error ?? `Bundle validation failed with HTTP ${response.status}.`,
+          },
+        ]);
+        setValidationResult(result);
+        setProjectBundleValidationSummary(null);
+        setProjectBundleMemberInventory([]);
+        setProjectBundleMemberReferences([]);
+        setWorkflowState("validation");
+        return;
+      }
+      setValidationResult(payload.validation);
+      setProjectBundleValidationSummary(payload.summary);
+      setProjectBundleMemberInventory(payload.memberInventory ?? []);
+      setProjectBundleMemberReferences(payload.memberReferences ?? []);
+      setWorkflowState("validation");
+      return;
+    }
+
     let items: BackupValidationItem[];
     if (!normalizedBackupId) {
       items = activeWorkflow === "import-backup"
@@ -615,7 +782,19 @@ export function BackupMigrationFoundation({
     const result = deriveValidationResult(items);
     setValidationResult(result);
     setWorkflowState("validation");
-  }, [activeWorkflow, dedupedBulkSelections, normalizedBackupId, previewScope, previewScopeDraft, previewSourceContext, previewTargetContext, selectedSessionId]);
+  }, [
+    activeHandoff,
+    activeWorkflow,
+    bundleConfig,
+    dedupedBulkSelections,
+    normalizedBackupId,
+    previewScope,
+    previewScopeDraft,
+    previewSourceContext,
+    previewTargetContext,
+    projectBundleSelection,
+    selectedSessionId,
+  ]);
 
   const addBulkSelection = useCallback(() => {
     if (!bulkDraftSessionId.trim() || !bulkDraftSource) return;
@@ -633,6 +812,44 @@ export function BackupMigrationFoundation({
     setBulkDraftSource("");
     setBulkDraftRootId("");
   }, [bulkDraftRootId, bulkDraftSessionId, bulkDraftSource]);
+
+  const toggleProjectBundleCategory = useCallback((category: ProjectBundleMemberCategory, selected: boolean) => {
+    setProjectBundleSelection((prev) => ({
+      ...prev,
+      includedCategories: {
+        ...prev.includedCategories,
+        [category]: selected,
+      },
+    }));
+  }, []);
+
+  const addProjectBundleSession = useCallback(() => {
+    if (!bundleDraftSessionId.trim() || !bundleDraftSource) return;
+    setProjectBundleSelection((prev) => ({
+      ...prev,
+      sessionSelections: dedupeSessionSelections([
+        ...prev.sessionSelections,
+        {
+          sessionId: bundleDraftSessionId,
+          source: bundleDraftSource,
+          rootId: bundleDraftRootId || undefined,
+        },
+      ]),
+    }));
+    setBundleDraftSessionId("");
+    setBundleDraftSource("");
+    setBundleDraftRootId("");
+  }, [bundleDraftRootId, bundleDraftSessionId, bundleDraftSource]);
+
+  const removeProjectBundleSession = useCallback((selection: BackupSessionSelection) => {
+    const target = `${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`;
+    setProjectBundleSelection((prev) => ({
+      ...prev,
+      sessionSelections: prev.sessionSelections.filter(
+        (item) => `${item.sessionId}:${item.source ?? ""}:${item.rootId ?? ""}` !== target
+      ),
+    }));
+  }, []);
 
   const removeBulkSelection = useCallback((selection: BackupSessionSelection) => {
     const target = `${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`;
@@ -877,6 +1094,66 @@ export function BackupMigrationFoundation({
     }
   }, [normalizedBackupId]);
 
+  const executeProjectBundle = useCallback(async () => {
+    setIsExecuting(true);
+    setExecutionError(null);
+    setWorkflowState("execution");
+
+    try {
+      const response = await fetch("/api/project-bundles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "generate",
+          handoff: activeHandoff,
+          selection: projectBundleSelection,
+          configuration: bundleConfig,
+        }),
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok || !payload) {
+        throw new Error(payload?.error ?? `HTTP ${response.status}`);
+      }
+
+      setProjectBundleValidationSummary(payload.summary);
+      setProjectBundleMemberInventory(payload.memberInventory ?? []);
+      setProjectBundleMemberReferences(payload.memberReferences ?? []);
+      const warnings = (payload.validation?.items ?? [])
+        .filter((item: BackupValidationItem) => item.severity === "warning")
+        .map((item: BackupValidationItem) => item.detail);
+
+      const result = createProjectBundleOperationResult({
+        status: warnings.length ? "success-with-warnings" : "success",
+        packageId: payload.packageId,
+        filePath: payload.filePath,
+        summary: `Project bundle ${payload.packageId} generated with ${payload.memberReferences?.length ?? 0} member references.`,
+        validationSummary: payload.summary,
+        memberInventory: payload.memberInventory ?? [],
+        memberReferences: payload.memberReferences ?? [],
+        bundle: payload.bundle,
+        warnings,
+      });
+
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("result");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setExecutionError(message);
+      const result = createOperationResult({
+        workflowType: "project-bundle",
+        status: "failed",
+        summary: `Project bundle generation failed: ${message}`,
+      });
+      setOperationResult(result);
+      setRecentOperations((prev) => addRecentOperation(prev, result));
+      setWorkflowState("failed");
+    } finally {
+      setIsExecuting(false);
+    }
+  }, [activeHandoff, bundleConfig, projectBundleSelection]);
+
   const finishValidateOnly = useCallback(() => {
     if (!validationResult) return;
     const result = createOperationResult({
@@ -927,6 +1204,11 @@ export function BackupMigrationFoundation({
       setPreviewScope(op.previewScope ?? { itemRefs: [] });
       setPreviewScopeDraft((op.previewScope?.itemRefs ?? []).join("\n"));
     }
+    if (op.workflowType === "project-bundle") {
+      setProjectBundleValidationSummary(op.projectBundleValidationSummary ?? null);
+      setProjectBundleMemberInventory(op.projectBundleMemberInventory ?? []);
+      setProjectBundleMemberReferences(op.projectBundleMemberReferences ?? []);
+    }
     setWorkflowState("result");
   }, []);
 
@@ -961,7 +1243,7 @@ export function BackupMigrationFoundation({
             <h2 className="text-xl font-semibold">Backup / Migration</h2>
             <p className="max-w-3xl text-sm leading-6 text-muted">
               Choose a bounded workflow below. Each workflow follows explicit selection, validation, and result steps.
-              This foundation does not support migration apply, project bundle packaging, vendor-runtime restore, or cloud sync.
+              This foundation does not support migration apply, vendor-runtime restore, or cloud sync.
             </p>
           </div>
         </Card>
@@ -1221,6 +1503,100 @@ export function BackupMigrationFoundation({
             </Card>
           ) : null}
 
+          {workflowState === "selection" && activeWorkflow === "project-bundle" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Bundle Scope</div>
+              <div className="space-y-4">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Project Bundle is a real Backup / Migration workflow. Routed context can prefill cues and explicit refs, but final composition still happens here before validation and generation.
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {PROJECT_BUNDLE_MEMBER_CATEGORIES.map((category) => (
+                    <label key={category} className="flex items-center gap-2 rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={projectBundleSelection.includedCategories[category]}
+                        onChange={(e) => toggleProjectBundleCategory(category, e.target.checked)}
+                      />
+                      <span>{category}</span>
+                    </label>
+                  ))}
+                </div>
+                <div className="space-y-3 rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                  <div className="text-xs uppercase tracking-[0.18em] text-muted">Explicit session refs</div>
+                  <div className="grid gap-3 md:grid-cols-[minmax(0,1.3fr)_180px_minmax(0,1fr)_auto]">
+                    <label className="grid gap-1 text-sm">
+                      <span className="text-xs uppercase tracking-[0.18em] text-muted">Session ID</span>
+                      <input
+                        type="text"
+                        value={bundleDraftSessionId}
+                        onChange={(e) => setBundleDraftSessionId(e.target.value)}
+                        placeholder="Enter session ID"
+                        className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                      />
+                    </label>
+                    <label className="grid gap-1 text-sm">
+                      <span className="text-xs uppercase tracking-[0.18em] text-muted">Source</span>
+                      <select
+                        value={bundleDraftSource}
+                        onChange={(e) => setBundleDraftSource((e.target.value as Source | "") ?? "")}
+                        className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                      >
+                        <option value="">Choose source</option>
+                        <option value="antigravity">Antigravity</option>
+                        <option value="windsurf">Windsurf</option>
+                        <option value="codex">Codex</option>
+                      </select>
+                    </label>
+                    <label className="grid gap-1 text-sm">
+                      <span className="text-xs uppercase tracking-[0.18em] text-muted">Root ID (optional)</span>
+                      <input
+                        type="text"
+                        value={bundleDraftRootId}
+                        onChange={(e) => setBundleDraftRootId(e.target.value)}
+                        placeholder="Optional root ID"
+                        className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                      />
+                    </label>
+                    <div className="flex items-end">
+                      <Button size="sm" onClick={addProjectBundleSession} disabled={!bundleDraftSessionId.trim() || !bundleDraftSource}>
+                        Add session ref
+                      </Button>
+                    </div>
+                  </div>
+                  {(projectBundleSelection.sessionSelections.length ?? 0) > 0 ? (
+                    <div className="space-y-2">
+                      {projectBundleSelection.sessionSelections.map((selection) => (
+                        <div key={`${selection.sessionId}:${selection.source ?? ""}:${selection.rootId ?? ""}`} className="rounded-lg border border-border/60 bg-background/40 px-3 py-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <div>
+                              <div className="font-medium">{selection.sessionId}</div>
+                              <div className="text-xs text-muted">
+                                {selection.source ?? "unknown-source"}
+                                {selection.rootId ? ` / ${selection.rootId}` : ""}
+                              </div>
+                            </div>
+                            <Button size="sm" variant="outline" onClick={() => removeProjectBundleSession(selection)}>
+                              Remove
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-xs text-muted">No explicit sessions listed yet. If you keep sessions selected, validation may warn but will not invent session members for you.</div>
+                  )}
+                </div>
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  {summarizeProjectBundleSelection(projectBundleSelection)}
+                </div>
+                <Button size="sm" onClick={advanceState}>
+                  Continue to Configuration
+                </Button>
+              </div>
+            </Card>
+          ) : null}
+
           {workflowState === "selection" && (activeWorkflow === "import-backup" || activeWorkflow === "validate-package") ? (
             <Card className="p-4">
               <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Select Package</div>
@@ -1398,6 +1774,45 @@ export function BackupMigrationFoundation({
             </Card>
           ) : null}
 
+          {workflowState === "configuration" && activeWorkflow === "project-bundle" ? (
+            <Card className="p-4">
+              <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Configure Bundle</div>
+              <div className="space-y-3">
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                  Bundle generation is gated by composition and validation. This configuration step only sets bundle identity and notes; it does not decide final composition for you.
+                </div>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Bundle name</span>
+                  <input
+                    type="text"
+                    value={bundleConfig.bundleName}
+                    onChange={(e) => setBundleConfig((prev) => ({ ...prev, bundleName: e.target.value }))}
+                    placeholder="Enter bundle name"
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="text-xs uppercase tracking-[0.18em] text-muted">Notes (optional)</span>
+                  <textarea
+                    value={bundleConfig.notes ?? ""}
+                    onChange={(e) => setBundleConfig((prev) => ({ ...prev, notes: e.target.value }))}
+                    rows={4}
+                    placeholder="Optional notes captured in package metadata"
+                    className="rounded-lg border border-border/60 bg-background/30 px-3 py-2 text-sm"
+                  />
+                </label>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={retreatState}>
+                    Back
+                  </Button>
+                  <Button size="sm" onClick={runValidation}>
+                    Validate Bundle
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
           {activeWorkflow === "migration-preview" && workflowState !== "validation" && validationResult?.status === "invalid" ? (
             <ValidationPanel result={validationResult} />
           ) : null}
@@ -1424,6 +1839,40 @@ export function BackupMigrationFoundation({
                             {entry.result.status}
                           </Badge>
                         </div>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              ) : null}
+              {activeWorkflow === "project-bundle" && projectBundleMemberInventory.length > 0 ? (
+                <Card className="p-4">
+                  <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Bundle inventory</div>
+                  <div className="space-y-2">
+                    {projectBundleMemberInventory.map((item) => (
+                      <div key={item.category} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="font-medium">{item.category}</div>
+                          <Badge variant={item.status === "ready" ? "ok" : item.status === "warning" ? "warn" : "default"}>
+                            {item.status}
+                          </Badge>
+                        </div>
+                        <div className="mt-1 text-xs leading-5 text-muted">{item.detail}</div>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              ) : null}
+              {activeWorkflow === "project-bundle" && projectBundleMemberReferences.length > 0 ? (
+                <Card className="p-4">
+                  <div className="mb-3 text-xs uppercase tracking-[0.18em] text-muted">Member references</div>
+                  <div className="space-y-2">
+                    {projectBundleMemberReferences.map((item) => (
+                      <div key={item.id} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="font-medium">{item.label}</div>
+                          <Badge variant={item.status === "resolved" ? "ok" : "warn"}>{item.status}</Badge>
+                        </div>
+                        <div className="mt-1 text-xs leading-5 text-muted">{item.detail}</div>
                       </div>
                     ))}
                   </div>
@@ -1509,9 +1958,39 @@ export function BackupMigrationFoundation({
                     </div>
                   </div>
                 ) : null}
+                {activeWorkflow === "project-bundle" ? (
+                  <div className="space-y-3">
+                    <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                      <div className="font-medium">{bundleConfig.bundleName}</div>
+                      <div className="mt-1 text-xs text-muted">{summarizeProjectBundleSelection(projectBundleSelection)}</div>
+                      {bundleConfig.notes ? <div className="mt-2 text-xs text-muted">{bundleConfig.notes}</div> : null}
+                    </div>
+                    {projectBundleValidationSummary ? (
+                      <div className="grid gap-3 sm:grid-cols-3">
+                        <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                          <div className="text-xs text-muted">Warnings</div>
+                          <div className="mt-1 font-medium">{projectBundleValidationSummary.warningCount}</div>
+                        </div>
+                        <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                          <div className="text-xs text-muted">Resolved refs</div>
+                          <div className="mt-1 font-medium">{projectBundleValidationSummary.resolvedReferenceCount}</div>
+                        </div>
+                        <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                          <div className="text-xs text-muted">Unresolved refs</div>
+                          <div className="mt-1 font-medium">{projectBundleValidationSummary.unresolvedReferenceCount}</div>
+                        </div>
+                      </div>
+                    ) : null}
+                    <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
+                      Generation writes a real local bundle file containing manifest, package metadata, project metadata, member inventory, member references, validation summary, and lightweight member snapshots.
+                    </div>
+                  </div>
+                ) : null}
                 <div className="rounded-xl border border-amber-400/35 bg-amber-400/10 px-3 py-3 text-sm text-muted">
                   <span className="font-medium text-foreground">Preservation notice:</span>{" "}
-                  {activeWorkflow === "import-backup"
+                  {activeWorkflow === "project-bundle"
+                    ? "Project Bundle preserves portable project context composition only. It does not promise restore, apply, vendor-runtime reopen, cloud sync, or full app snapshot semantics."
+                    : activeWorkflow === "import-backup"
                     ? "Import restores product-readable state only. Sessions will not reopen inside a third-party agent runtime or private source store."
                     : "This backup preserves a canonical session record. It does not modify, move, or delete the upstream session source."}
                 </div>
@@ -1527,7 +2006,15 @@ export function BackupMigrationFoundation({
                   <Button
                     size="sm"
                     disabled={isExecuting}
-                    onClick={activeWorkflow === "session-backup" ? executeSessionBackup : activeWorkflow === "bulk-session-backup" ? executeBulkSessionBackup : executeImport}
+                    onClick={
+                      activeWorkflow === "session-backup"
+                        ? executeSessionBackup
+                        : activeWorkflow === "bulk-session-backup"
+                          ? executeBulkSessionBackup
+                          : activeWorkflow === "project-bundle"
+                            ? executeProjectBundle
+                            : executeImport
+                    }
                   >
                     {isExecuting ? "Executing…" : "Execute"}
                   </Button>
@@ -1593,6 +2080,15 @@ export function BackupMigrationFoundation({
                       ? `${formatMigrationPreviewScopeLabel(previewScope.kind)} (${previewScope.itemRefs.length || previewScopeDraft.split("\n").map((item) => item.trim()).filter(Boolean).length})`
                       : "Scope still required"}
                   </div>
+                </div>
+              ) : null}
+              {activeWorkflow === "project-bundle" ? (
+                <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-2">
+                  <div className="text-xs text-muted">Bundle context</div>
+                  <div className="font-medium">{bundleConfig.bundleName || "Bundle name still required"}</div>
+                  <div className="mt-1 text-xs text-muted">{summarizeProjectBundleSelection(projectBundleSelection)}</div>
+                  {projectBundleSelection.scopeHint ? <div className="mt-1 text-xs text-muted">Scope hint: {projectBundleSelection.scopeHint}</div> : null}
+                  {projectBundleSelection.filterHint ? <div className="mt-1 text-xs text-muted">Filter hint: {projectBundleSelection.filterHint}</div> : null}
                 </div>
               ) : null}
               {normalizedBackupId && activeWorkflow !== "session-backup" ? (

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -173,6 +173,20 @@ export function resolveInitialProjectBundleSessionSelections(handoff: BackupMigr
   return [];
 }
 
+function formatBundleCategoryLabel(category: ProjectBundleMemberCategory): string {
+  const labels: Record<ProjectBundleMemberCategory, string> = {
+    sessions: "Sessions",
+    rules: "Rules",
+    memory: "Memory",
+    skills: "Skills",
+    commands: "Commands",
+    "package-metadata": "Package Metadata",
+    "project-metadata": "Project Metadata",
+  };
+
+  return labels[category];
+}
+
 export function buildBulkConfirmationDetails(input: {
   selections: BackupSessionSelection[];
   validationResult: BackupValidationResult | null;
@@ -355,7 +369,7 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
               {props.result.projectBundleMemberInventory!.map((item) => (
                 <div key={item.category} className="rounded-lg border border-border/60 bg-background/40 px-3 py-2">
                   <div className="flex items-center justify-between gap-2">
-                    <span className="font-medium">{item.category}</span>
+                    <span className="font-medium">{formatBundleCategoryLabel(item.category)}</span>
                     <Badge variant={item.status === "ready" ? "ok" : item.status === "warning" ? "warn" : "default"}>
                       {item.status}
                     </Badge>
@@ -1518,7 +1532,7 @@ export function BackupMigrationFoundation({
                         checked={projectBundleSelection.includedCategories[category]}
                         onChange={(e) => toggleProjectBundleCategory(category, e.target.checked)}
                       />
-                      <span>{category}</span>
+                      <span>{formatBundleCategoryLabel(category)}</span>
                     </label>
                   ))}
                 </div>
@@ -1851,7 +1865,7 @@ export function BackupMigrationFoundation({
                     {projectBundleMemberInventory.map((item) => (
                       <div key={item.category} className="rounded-xl border border-border/60 bg-background/10 px-3 py-3">
                         <div className="flex items-center justify-between gap-2">
-                          <div className="font-medium">{item.category}</div>
+                          <div className="font-medium">{formatBundleCategoryLabel(item.category)}</div>
                           <Badge variant={item.status === "ready" ? "ok" : item.status === "warning" ? "warn" : "default"}>
                             {item.status}
                           </Badge>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -635,6 +635,13 @@ export function BackupMigrationFoundation({
   const descriptor = activeWorkflow ? getWorkflowDescriptor(activeWorkflow) : null;
   const normalizedBackupId = normalizeBackupId(backupIdInput);
   const dedupedBulkSelections = useMemo(() => dedupeSessionSelections(bulkSelections), [bulkSelections]);
+  const hasSelectedProjectBundleCategories = useMemo(
+    () =>
+      PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.some(
+        (category) => projectBundleSelection.includedCategories[category]
+      ),
+    [projectBundleSelection]
+  );
   const bulkConfirmationDetails = useMemo(
     () => buildBulkConfirmationDetails({ selections: dedupedBulkSelections, validationResult }),
     [dedupedBulkSelections, validationResult]
@@ -1618,7 +1625,20 @@ export function BackupMigrationFoundation({
                 <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm text-muted">
                   {summarizeProjectBundleSelection(projectBundleSelection)}
                 </div>
-                <Button size="sm" onClick={advanceState}>
+                {!hasSelectedProjectBundleCategories ? (
+                  <div id="project-bundle-selection-hint" className="text-xs text-muted">
+                    Select at least one bundle category before continuing to configuration and validation.
+                  </div>
+                ) : null}
+                <Button
+                  size="sm"
+                  aria-describedby={!hasSelectedProjectBundleCategories ? "project-bundle-selection-hint" : undefined}
+                  disabled={!hasSelectedProjectBundleCategories}
+                  onClick={() => {
+                    if (!hasSelectedProjectBundleCategories) return;
+                    advanceState();
+                  }}
+                >
                   Continue to Configuration
                 </Button>
               </div>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -187,6 +187,13 @@ function formatBundleCategoryLabel(category: ProjectBundleMemberCategory): strin
   return labels[category];
 }
 
+function redactDisplayPath(filePath: string): string {
+  return filePath
+    .replace(/^\/Users\/[^/]+/, "~")
+    .replace(/^\/home\/[^/]+/, "~")
+    .replace(/^[A-Za-z]:\\Users\\[^\\]+/, "~");
+}
+
 export function buildBulkConfirmationDetails(input: {
   selections: BackupSessionSelection[];
   validationResult: BackupValidationResult | null;
@@ -318,7 +325,7 @@ export function OperationResultPanel(props: { result: BackupOperationResult; onN
             <div className="mt-2 text-xs text-muted">Package ID: {props.result.packageId}</div>
           ) : null}
           {props.result.filePath ? (
-            <div className="mt-1 text-xs text-muted">File: {props.result.filePath}</div>
+            <div className="mt-1 text-xs text-muted">File: {redactDisplayPath(props.result.filePath)}</div>
           ) : null}
           {props.result.sessionCount != null ? (
             <div className="text-xs text-muted">Sessions: {props.result.sessionCount}</div>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -1152,7 +1152,6 @@ export function BackupMigrationFoundation({
         validationSummary: payload.summary,
         memberInventory: payload.memberInventory ?? [],
         memberReferences: payload.memberReferences ?? [],
-        bundle: payload.bundle,
         warnings,
       });
 

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -224,7 +224,23 @@ export function buildAssetsFoundationInstanceKey(handoff: AssetsHandoff | null):
 export function buildBackupHandoffFromAssets(context: {
   assetId?: string;
   subtype?: ContextAssetSubtype;
+  workflowType?: "migration-preview" | "project-bundle";
 }): BackupMigrationHandoff {
+  if (context.workflowType === "project-bundle") {
+    return {
+      origin: "assets",
+      subtitle: `Open Project Bundle${context.subtype ? ` with ${context.subtype} asset context` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}.`,
+      continueLabel: "Assets may prefill explicit object references and compact hints only. Final bundle composition still happens in Backup / Migration.",
+      returnLabel: "Return to Assets for object-level review.",
+      assetId: context.assetId,
+      assetSubtype: context.subtype,
+      workflowType: "project-bundle",
+      projectBundleScopeHint: context.subtype ? `${context.subtype} asset scope` : undefined,
+      projectBundleObjectRefs: context.assetId ? [context.assetId] : [],
+      projectBundleFilterHint: context.subtype ? `asset subtype = ${context.subtype}` : undefined,
+    };
+  }
+
   return {
     origin: "assets",
     subtitle: `Preview bounded migration scope${context.subtype ? ` for ${context.subtype} assets` : ""}${context.assetId ? ` starting from ${context.assetId}` : ""}.`,
@@ -250,8 +266,23 @@ export function buildBackupHandoffFromAnalysis(context: {
   title: string;
   preservationWarning?: string;
   routeLabel?: string;
-  backupWorkflowType?: "session-backup" | "migration-preview";
+  backupWorkflowType?: "session-backup" | "migration-preview" | "project-bundle";
 }): BackupMigrationHandoff {
+  if (context.backupWorkflowType === "project-bundle") {
+    return {
+      origin: "analysis",
+      subtitle: `${context.routeLabel ?? "Project bundle"} for ${context.title}.`,
+      continueLabel: context.preservationWarning ?? "Analysis may preserve issue framing, but Backup / Migration still owns explicit bundle composition and validation.",
+      returnLabel: "Return to Analysis for grouped interpretation.",
+      findingId: context.findingId,
+      preservationWarning: context.preservationWarning,
+      issueLabel: context.title,
+      workflowType: "project-bundle",
+      projectBundleScopeHint: "analysis-routed bundle context",
+      projectBundleObjectRefs: [context.findingId],
+    };
+  }
+
   if (context.backupWorkflowType !== "migration-preview") {
     return {
       origin: "analysis",
@@ -317,6 +348,7 @@ export function buildBackupHandoffFromOverview(workflowType: BackupWorkflowType)
     "import-backup": "Start a bounded import workflow from Project Overview.",
     "validate-package": "Start a bounded package validation workflow from Project Overview.",
     "migration-preview": "Start a bounded migration preview workflow from Project Overview.",
+    "project-bundle": "Start a bounded project bundle workflow from Project Overview.",
   } satisfies Record<BackupWorkflowType, string>;
 
   return {
@@ -325,6 +357,7 @@ export function buildBackupHandoffFromOverview(workflowType: BackupWorkflowType)
     continueLabel: "Workflow execution belongs to Backup / Migration.",
     returnLabel: "Return to Project Overview.",
     workflowType,
+    projectBundleScopeHint: workflowType === "project-bundle" ? "overview-routed project context" : undefined,
     migrationPreviewSourceContext: workflowType === "migration-preview" ? { kind: "project-overview" } : undefined,
   };
 }
@@ -532,6 +565,14 @@ function ProjectOverviewSurface(props: {
           >
             Open migration preview
           </Button>
+          <Button
+            className="w-full justify-start"
+            variant="outline"
+            size="sm"
+            onClick={() => props.onOpenBackup(buildBackupHandoffFromOverview("project-bundle"))}
+          >
+            Open project bundle
+          </Button>
           <Button className="w-full justify-start" variant="outline" size="sm" onClick={() => props.onNavigate("backup")}>
             Browse backup workflows
           </Button>
@@ -677,7 +718,7 @@ export default function ProjectShellClient() {
     setActivePage("analysis");
   }, [leaveSessionsSurface]);
 
-  const handleOpenBackupFromAssets = useCallback((context: { assetId?: string; subtype?: ContextAssetSubtype }) => {
+  const handleOpenBackupFromAssets = useCallback((context: { assetId?: string; subtype?: ContextAssetSubtype; workflowType?: "migration-preview" | "project-bundle" }) => {
     leaveSessionsSurface();
     setAssetsHandoff(null);
     setAnalysisHandoff(null);
@@ -698,7 +739,7 @@ export default function ProjectShellClient() {
     title: string;
     preservationWarning?: string;
     routeLabel?: string;
-    backupWorkflowType?: "session-backup" | "migration-preview";
+    backupWorkflowType?: "session-backup" | "migration-preview" | "project-bundle";
   }) => {
     leaveSessionsSurface();
     setAssetsHandoff(null);

--- a/src/lib/analysisFindings.ts
+++ b/src/lib/analysisFindings.ts
@@ -28,7 +28,7 @@ export type AnalysisRoute = {
   target: AnalysisRouteTarget;
   label: string;
   reason: string;
-  backupWorkflowType?: "session-backup" | "migration-preview";
+  backupWorkflowType?: "session-backup" | "migration-preview" | "project-bundle";
   sessionId?: string;
   source?: Source;
   rootId?: string;
@@ -212,6 +212,12 @@ export function createAnalysisFindingSeeds(): AnalysisFinding[] {
           assetId: "asset-skill-global-generated",
           assetSubtype: "skill",
           assetStatus: "conflicted",
+        },
+        {
+          target: "backup",
+          label: "Bundle project context",
+          reason: "Open Project Bundle with this finding as an explicit context cue without auto-deciding final composition.",
+          backupWorkflowType: "project-bundle",
         },
       ],
     }),

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -2,7 +2,14 @@ import type { Source } from "@/lib/types";
 
 // ── Workflow types ──────────────────────────────────────────────────────────
 
-export const BACKUP_WORKFLOW_TYPES = ["session-backup", "bulk-session-backup", "import-backup", "validate-package", "migration-preview"] as const;
+export const BACKUP_WORKFLOW_TYPES = [
+  "session-backup",
+  "bulk-session-backup",
+  "import-backup",
+  "validate-package",
+  "migration-preview",
+  "project-bundle",
+] as const;
 export type BackupWorkflowType = (typeof BACKUP_WORKFLOW_TYPES)[number];
 
 export const BACKUP_WORKFLOW_STATES = [
@@ -66,6 +73,134 @@ export type MigrationPreviewItem = {
 };
 
 export type MigrationPreviewAggregateCounts = Record<MigrationPreviewClassification, number>;
+
+// ── Project bundle ──────────────────────────────────────────────────────────
+
+export const PROJECT_BUNDLE_MEMBER_CATEGORIES = [
+  "sessions",
+  "rules",
+  "memory",
+  "skills",
+  "commands",
+  "package-metadata",
+  "project-metadata",
+] as const;
+export type ProjectBundleMemberCategory = (typeof PROJECT_BUNDLE_MEMBER_CATEGORIES)[number];
+
+export const PROJECT_BUNDLE_REFERENCE_STATUSES = ["resolved", "unresolved", "missing-package"] as const;
+export type ProjectBundleReferenceStatus = (typeof PROJECT_BUNDLE_REFERENCE_STATUSES)[number];
+
+export const PROJECT_BUNDLE_MEMBER_STATUSES = ["ready", "warning", "blocked"] as const;
+export type ProjectBundleMemberStatus = (typeof PROJECT_BUNDLE_MEMBER_STATUSES)[number];
+
+export type ProjectBundleValidationSummary = {
+  warningCount: number;
+  blockerCount: number;
+  selectedCategoryCount: number;
+  selectedSessionCount: number;
+  resolvedReferenceCount: number;
+  unresolvedReferenceCount: number;
+};
+
+export type ProjectBundleMetadataSnapshot = {
+  id: string;
+  label: string;
+  category: ProjectBundleMemberCategory;
+  scope?: string;
+  subtype?: string;
+  provenanceSummary?: string;
+  status?: string;
+  timestamps?: {
+    createdAt?: string;
+    updatedAt?: string;
+    capturedAt?: string;
+  };
+};
+
+export type ProjectBundleMemberReference = {
+  id: string;
+  category: ProjectBundleMemberCategory;
+  label: string;
+  referenceType: "session-backup-package" | "context-asset" | "package-metadata" | "project-metadata";
+  referenceId: string;
+  status: ProjectBundleReferenceStatus;
+  detail: string;
+  backupId?: string;
+  manifestPath?: string;
+  snapshot: ProjectBundleMetadataSnapshot;
+};
+
+export type ProjectBundleMemberInventoryItem = {
+  category: ProjectBundleMemberCategory;
+  selected: boolean;
+  includedCount: number;
+  status: ProjectBundleMemberStatus;
+  detail: string;
+};
+
+export type ProjectBundleSelectionState = {
+  includedCategories: Record<ProjectBundleMemberCategory, boolean>;
+  sessionSelections: BackupSessionSelection[];
+  objectRefs: string[];
+  originCue?: string;
+  scopeHint?: string;
+  filterHint?: string;
+};
+
+export type ProjectBundleConfiguration = {
+  bundleName: string;
+  notes?: string;
+};
+
+export type ProjectBundlePackageMetadata = {
+  packageId: string;
+  schemaVersion: "project-bundle/v1";
+  createdAt: string;
+  createdBy: "agent-storage-manager";
+  bundleName: string;
+  notes?: string;
+};
+
+export type ProjectBundleProjectMetadata = {
+  projectName: string;
+  workspacePath: string;
+  repository?: string;
+  packageName: string;
+  packageVersion: string;
+  originCue?: string;
+  scopeHint?: string;
+  filterHint?: string;
+  objectRefs: string[];
+};
+
+export type ProjectBundleDocument = {
+  manifest: {
+    schemaVersion: "project-bundle/v1";
+    packageId: string;
+    createdAt: string;
+    memberInventory: ProjectBundleMemberInventoryItem[];
+    memberReferences: ProjectBundleMemberReference[];
+    validationSummary: ProjectBundleValidationSummary;
+  };
+  packageMetadata: ProjectBundlePackageMetadata;
+  projectMetadata: ProjectBundleProjectMetadata;
+  memberInventory: ProjectBundleMemberInventoryItem[];
+  memberReferences: ProjectBundleMemberReference[];
+  validationSummary: ProjectBundleValidationSummary;
+};
+
+export type ProjectBundleValidationResponse = {
+  validation: BackupValidationResult;
+  summary: ProjectBundleValidationSummary;
+  memberInventory: ProjectBundleMemberInventoryItem[];
+  memberReferences: ProjectBundleMemberReference[];
+};
+
+export type ProjectBundleGenerateResponse = ProjectBundleValidationResponse & {
+  packageId: string;
+  filePath: string;
+  bundle: ProjectBundleDocument;
+};
 
 // ── Validation ──────────────────────────────────────────────────────────────
 
@@ -131,7 +266,10 @@ export type BackupOperationResult = {
   timestamp: string;
   summary: string;
   backupId?: string;
+  packageId?: string;
+  filePath?: string;
   sessionCount?: number;
+  memberCount?: number;
   warnings?: string[];
   sourceCopySummary?: string;
   sessionResults?: BulkSessionExecutionResult[];
@@ -140,6 +278,10 @@ export type BackupOperationResult = {
   previewScope?: MigrationPreviewScope;
   previewCounts?: MigrationPreviewAggregateCounts;
   previewItems?: MigrationPreviewItem[];
+  projectBundleValidationSummary?: ProjectBundleValidationSummary;
+  projectBundleMemberInventory?: ProjectBundleMemberInventoryItem[];
+  projectBundleMemberReferences?: ProjectBundleMemberReference[];
+  projectBundleDocument?: ProjectBundleDocument;
   issueLabel?: string;
 };
 
@@ -184,6 +326,9 @@ export type BackupMigrationHandoff = {
   findingId?: string;
   preservationWarning?: string;
   issueLabel?: string;
+  projectBundleScopeHint?: string;
+  projectBundleFilterHint?: string;
+  projectBundleObjectRefs?: string[];
   migrationPreviewSourceContext?: MigrationPreviewSourceContext;
   migrationPreviewTargetContext?: MigrationPreviewTargetContext;
   migrationPreviewScope?: MigrationPreviewScope;
@@ -229,6 +374,12 @@ export const WORKFLOW_DESCRIPTORS: BackupWorkflowDescriptor[] = [
     description: "Preview only: compare explicit source, target, and bounded scope before any migration action.",
     stepsLabel: ["Select source", "Configure preview", "Validate", "Result"],
   },
+  {
+    type: "project-bundle",
+    label: "Project Bundle",
+    description: "Package the current project's context set into a validated portable local bundle. Compose and validate before generation.",
+    stepsLabel: ["Select bundle scope", "Configure bundle", "Validate", "Confirm", "Execute", "Result"],
+  },
 ];
 
 // ── Helper functions ────────────────────────────────────────────────────────
@@ -244,6 +395,7 @@ export function formatWorkflowTypeLabel(type: BackupWorkflowType): string {
     "import-backup": "Import Backup",
     "validate-package": "Validate Package",
     "migration-preview": "Migration Preview",
+    "project-bundle": "Project Bundle",
   };
   return labels[type];
 }
@@ -273,7 +425,54 @@ export function getStepsForWorkflow(type: BackupWorkflowType): BackupWorkflowSta
       return ["selection", "validation", "result"];
     case "migration-preview":
       return ["selection", "configuration", "validation", "result"];
+    case "project-bundle":
+      return ["selection", "configuration", "validation", "confirmation", "execution", "result"];
   }
+}
+
+export function createDefaultProjectBundleSelection(
+  handoff: BackupMigrationHandoff | null,
+  sessionSelections: BackupSessionSelection[] = []
+): ProjectBundleSelectionState {
+  return {
+    includedCategories: {
+      sessions: true,
+      rules: true,
+      memory: true,
+      skills: true,
+      commands: true,
+      "package-metadata": true,
+      "project-metadata": true,
+    },
+    sessionSelections: dedupeSessionSelections(sessionSelections),
+    objectRefs: Array.from(new Set((handoff?.projectBundleObjectRefs ?? []).map((item) => item.trim()).filter(Boolean))),
+    originCue: handoff ? `from ${handoff.origin}` : undefined,
+    scopeHint: handoff?.projectBundleScopeHint?.trim() || undefined,
+    filterHint: handoff?.projectBundleFilterHint?.trim() || undefined,
+  };
+}
+
+export function summarizeProjectBundleSelection(selection: ProjectBundleSelectionState): string {
+  const selectedCategories = PROJECT_BUNDLE_MEMBER_CATEGORIES.filter((category) => selection.includedCategories[category]);
+  const sessionCount = dedupeSessionSelections(selection.sessionSelections).length;
+  return `${selectedCategories.length} categories selected, ${sessionCount} explicit session reference${sessionCount === 1 ? "" : "s"}.`;
+}
+
+export function buildProjectBundleValidationSummary(input: {
+  validationItems: BackupValidationItem[];
+  memberReferences: ProjectBundleMemberReference[];
+  memberInventory: ProjectBundleMemberInventoryItem[];
+  selectedCategoryCount: number;
+  selectedSessionCount: number;
+}): ProjectBundleValidationSummary {
+  return {
+    warningCount: input.validationItems.filter((item) => item.severity === "warning").length,
+    blockerCount: input.validationItems.filter((item) => item.severity === "block").length,
+    selectedCategoryCount: input.selectedCategoryCount,
+    selectedSessionCount: input.selectedSessionCount,
+    resolvedReferenceCount: input.memberReferences.filter((item) => item.status === "resolved").length,
+    unresolvedReferenceCount: input.memberReferences.filter((item) => item.status !== "resolved").length,
+  };
 }
 
 export function getNextState(
@@ -817,7 +1016,10 @@ export function createOperationResult(input: {
   status: OperationResultStatus;
   summary: string;
   backupId?: string;
+  packageId?: string;
+  filePath?: string;
   sessionCount?: number;
+  memberCount?: number;
   warnings?: string[];
   sourceCopySummary?: string;
   sessionResults?: BulkSessionExecutionResult[];
@@ -826,6 +1028,10 @@ export function createOperationResult(input: {
   previewScope?: MigrationPreviewScope;
   previewCounts?: MigrationPreviewAggregateCounts;
   previewItems?: MigrationPreviewItem[];
+  projectBundleValidationSummary?: ProjectBundleValidationSummary;
+  projectBundleMemberInventory?: ProjectBundleMemberInventoryItem[];
+  projectBundleMemberReferences?: ProjectBundleMemberReference[];
+  projectBundleDocument?: ProjectBundleDocument;
   issueLabel?: string;
 }): BackupOperationResult {
   operationCounter += 1;
@@ -836,7 +1042,10 @@ export function createOperationResult(input: {
     timestamp: new Date().toISOString(),
     summary: input.summary,
     backupId: input.backupId,
+    packageId: input.packageId,
+    filePath: input.filePath,
     sessionCount: input.sessionCount,
+    memberCount: input.memberCount,
     warnings: input.warnings,
     sourceCopySummary: input.sourceCopySummary,
     sessionResults: input.sessionResults,
@@ -845,6 +1054,10 @@ export function createOperationResult(input: {
     previewScope: input.previewScope,
     previewCounts: input.previewCounts,
     previewItems: input.previewItems,
+    projectBundleValidationSummary: input.projectBundleValidationSummary,
+    projectBundleMemberInventory: input.projectBundleMemberInventory,
+    projectBundleMemberReferences: input.projectBundleMemberReferences,
+    projectBundleDocument: input.projectBundleDocument,
     issueLabel: input.issueLabel,
   };
 }
@@ -867,6 +1080,32 @@ export function createMigrationPreviewOperationResult(input: {
     previewCounts: counts,
     previewItems: input.items,
     issueLabel: input.issueLabel,
+  });
+}
+
+export function createProjectBundleOperationResult(input: {
+  status: BackupOperationStatus;
+  packageId: string;
+  filePath: string;
+  summary: string;
+  validationSummary: ProjectBundleValidationSummary;
+  memberInventory: ProjectBundleMemberInventoryItem[];
+  memberReferences: ProjectBundleMemberReference[];
+  bundle: ProjectBundleDocument;
+  warnings?: string[];
+}): BackupOperationResult {
+  return createOperationResult({
+    workflowType: "project-bundle",
+    status: input.status,
+    summary: input.summary,
+    packageId: input.packageId,
+    filePath: input.filePath,
+    memberCount: input.memberReferences.length,
+    warnings: input.warnings,
+    projectBundleValidationSummary: input.validationSummary,
+    projectBundleMemberInventory: input.memberInventory,
+    projectBundleMemberReferences: input.memberReferences,
+    projectBundleDocument: input.bundle,
   });
 }
 
@@ -956,6 +1195,9 @@ export function resolveWorkflowFromHandoff(
   if (handoff.migrationPreviewSourceContext || handoff.migrationPreviewTargetContext || handoff.migrationPreviewScope) {
     return "migration-preview";
   }
+  if (handoff.projectBundleObjectRefs || handoff.projectBundleScopeHint || handoff.projectBundleFilterHint) {
+    return "project-bundle";
+  }
   if ((handoff.sessions?.length ?? 0) > 1) return "bulk-session-backup";
   if (handoff.sessionId) return "session-backup";
   if (handoff.origin === "overview") return null;
@@ -980,6 +1222,9 @@ export function buildBackupHandoffInstanceKey(handoff: BackupMigrationHandoff | 
     handoff.findingId ?? "no-finding",
     handoff.issueLabel ?? "no-issue",
     handoff.preservationWarning ?? "no-preservation-warning",
+    handoff.projectBundleScopeHint ?? "no-bundle-scope-hint",
+    handoff.projectBundleFilterHint ?? "no-bundle-filter-hint",
+    handoff.projectBundleObjectRefs?.join("|") ?? "no-bundle-object-refs",
     handoff.migrationPreviewSourceContext?.product ?? "no-preview-source-product",
     handoff.migrationPreviewSourceContext?.kind ?? "no-preview-source-kind",
     handoff.migrationPreviewTargetContext?.profile ?? "no-preview-target-profile",

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -198,7 +198,6 @@ export type ProjectBundleValidationResponse = {
 export type ProjectBundleGenerateResponse = ProjectBundleValidationResponse & {
   packageId: string;
   filePath: string;
-  bundle: ProjectBundleDocument;
 };
 
 // ── Validation ──────────────────────────────────────────────────────────────
@@ -280,7 +279,6 @@ export type BackupOperationResult = {
   projectBundleValidationSummary?: ProjectBundleValidationSummary;
   projectBundleMemberInventory?: ProjectBundleMemberInventoryItem[];
   projectBundleMemberReferences?: ProjectBundleMemberReference[];
-  projectBundleDocument?: ProjectBundleDocument;
   issueLabel?: string;
 };
 
@@ -1030,7 +1028,6 @@ export function createOperationResult(input: {
   projectBundleValidationSummary?: ProjectBundleValidationSummary;
   projectBundleMemberInventory?: ProjectBundleMemberInventoryItem[];
   projectBundleMemberReferences?: ProjectBundleMemberReference[];
-  projectBundleDocument?: ProjectBundleDocument;
   issueLabel?: string;
 }): BackupOperationResult {
   operationCounter += 1;
@@ -1056,7 +1053,6 @@ export function createOperationResult(input: {
     projectBundleValidationSummary: input.projectBundleValidationSummary,
     projectBundleMemberInventory: input.projectBundleMemberInventory,
     projectBundleMemberReferences: input.projectBundleMemberReferences,
-    projectBundleDocument: input.projectBundleDocument,
     issueLabel: input.issueLabel,
   };
 }
@@ -1090,7 +1086,6 @@ export function createProjectBundleOperationResult(input: {
   validationSummary: ProjectBundleValidationSummary;
   memberInventory: ProjectBundleMemberInventoryItem[];
   memberReferences: ProjectBundleMemberReference[];
-  bundle: ProjectBundleDocument;
   warnings?: string[];
 }): BackupOperationResult {
   return createOperationResult({
@@ -1104,7 +1099,6 @@ export function createProjectBundleOperationResult(input: {
     projectBundleValidationSummary: input.validationSummary,
     projectBundleMemberInventory: input.memberInventory,
     projectBundleMemberReferences: input.memberReferences,
-    projectBundleDocument: input.bundle,
   });
 }
 

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -126,7 +126,6 @@ export type ProjectBundleMemberReference = {
   status: ProjectBundleReferenceStatus;
   detail: string;
   backupId?: string;
-  manifestPath?: string;
   snapshot: ProjectBundleMetadataSnapshot;
 };
 

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -76,14 +76,24 @@ export type MigrationPreviewAggregateCounts = Record<MigrationPreviewClassificat
 
 // ── Project bundle ──────────────────────────────────────────────────────────
 
-export const PROJECT_BUNDLE_MEMBER_CATEGORIES = [
+export const PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES = [
   "sessions",
   "rules",
   "memory",
   "skills",
   "commands",
+] as const;
+export type ProjectBundleSelectableMemberCategory = (typeof PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES)[number];
+
+export const PROJECT_BUNDLE_FOUNDATION_METADATA_CATEGORIES = [
   "package-metadata",
   "project-metadata",
+] as const;
+export type ProjectBundleFoundationMetadataCategory = (typeof PROJECT_BUNDLE_FOUNDATION_METADATA_CATEGORIES)[number];
+
+export const PROJECT_BUNDLE_MEMBER_CATEGORIES = [
+  ...PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES,
+  ...PROJECT_BUNDLE_FOUNDATION_METADATA_CATEGORIES,
 ] as const;
 export type ProjectBundleMemberCategory = (typeof PROJECT_BUNDLE_MEMBER_CATEGORIES)[number];
 
@@ -138,7 +148,7 @@ export type ProjectBundleMemberInventoryItem = {
 };
 
 export type ProjectBundleSelectionState = {
-  includedCategories: Record<ProjectBundleMemberCategory, boolean>;
+  includedCategories: Record<ProjectBundleSelectableMemberCategory, boolean>;
   sessionSelections: BackupSessionSelection[];
   objectRefs: string[];
   originCue?: string;
@@ -438,8 +448,6 @@ export function createDefaultProjectBundleSelection(
       memory: true,
       skills: true,
       commands: true,
-      "package-metadata": true,
-      "project-metadata": true,
     },
     sessionSelections: dedupeSessionSelections(sessionSelections),
     objectRefs: Array.from(new Set((handoff?.projectBundleObjectRefs ?? []).map((item) => item.trim()).filter(Boolean))),
@@ -450,9 +458,9 @@ export function createDefaultProjectBundleSelection(
 }
 
 export function summarizeProjectBundleSelection(selection: ProjectBundleSelectionState): string {
-  const selectedCategories = PROJECT_BUNDLE_MEMBER_CATEGORIES.filter((category) => selection.includedCategories[category]);
+  const selectedCategories = PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.filter((category) => selection.includedCategories[category]);
   const sessionCount = dedupeSessionSelections(selection.sessionSelections).length;
-  return `${selectedCategories.length} categories selected, ${sessionCount} explicit session reference${sessionCount === 1 ? "" : "s"}.`;
+  return `${selectedCategories.length} selectable categories selected, 2 foundation metadata sections included, ${sessionCount} explicit session reference${sessionCount === 1 ? "" : "s"}.`;
 }
 
 export function buildProjectBundleValidationSummary(input: {

--- a/src/lib/server/paths.ts
+++ b/src/lib/server/paths.ts
@@ -18,3 +18,9 @@ export function getSessionBackupsRoot(): string {
   if (override && override.trim().length) return expandHome(override.trim());
   return path.join(getAgentStorageManagerDir(), "backups");
 }
+
+export function getProjectBundlesRoot(): string {
+  const override = process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT;
+  if (override && override.trim().length) return expandHome(override.trim());
+  return path.join(getAgentStorageManagerDir(), "project-bundles");
+}

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -420,6 +420,7 @@ async function composeProjectBundle(
       promoteCategoryStatus("sessions", item.severity === "block" ? "blocked" : "warning");
     } else if (item.id.startsWith("bundle-package-metadata-")) {
       promoteCategoryStatus("package-metadata", item.severity === "block" ? "blocked" : "warning");
+      promoteCategoryStatus("project-metadata", item.severity === "block" ? "blocked" : "warning");
     } else {
       const categoryPrefix = PROJECT_BUNDLE_MEMBER_CATEGORIES.find((category) => item.id.startsWith(`bundle-${category}-`));
       if (categoryPrefix) {

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -1,0 +1,477 @@
+import "server-only";
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  PROJECT_BUNDLE_MEMBER_CATEGORIES,
+  buildProjectBundleValidationSummary,
+  dedupeSessionSelections,
+  deriveValidationResult,
+  formatSessionSelectionLabel,
+  type BackupValidationItem,
+  type ProjectBundleConfiguration,
+  type ProjectBundleDocument,
+  type ProjectBundleGenerateResponse,
+  type ProjectBundleMemberCategory,
+  type ProjectBundleMemberInventoryItem,
+  type ProjectBundleMemberReference,
+  type ProjectBundleMetadataSnapshot,
+  type ProjectBundlePackageMetadata,
+  type ProjectBundleProjectMetadata,
+  type ProjectBundleSelectionState,
+  type ProjectBundleValidationResponse,
+} from "@/lib/backupMigration";
+import { createContextAssetSeeds } from "@/lib/contextAssets";
+import { readSessionBackupPackage } from "@/lib/server/sessionBackupService";
+import { getProjectBundlesRoot, getSessionBackupsRoot } from "@/lib/server/paths";
+
+type SessionBackupReferenceMatch = {
+  backupId: string;
+  manifestPath: string;
+  createdAt: string;
+  source: string;
+  sessionId: string;
+  rootId?: string;
+};
+
+type ComposeProjectBundleResult = ProjectBundleValidationResponse & {
+  packageMetadata: ProjectBundlePackageMetadata;
+  projectMetadata: ProjectBundleProjectMetadata;
+};
+
+function createPackageId(): string {
+  return `project-bundle-${new Date().toISOString().replace(/[:.]/g, "-")}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function createSnapshot(input: {
+  id: string;
+  label: string;
+  category: ProjectBundleMemberCategory;
+  scope?: string;
+  subtype?: string;
+  provenanceSummary?: string;
+  status?: string;
+  capturedAt?: string;
+}): ProjectBundleMetadataSnapshot {
+  return {
+    id: input.id,
+    label: input.label,
+    category: input.category,
+    scope: input.scope,
+    subtype: input.subtype,
+    provenanceSummary: input.provenanceSummary,
+    status: input.status,
+    timestamps: input.capturedAt ? { capturedAt: input.capturedAt } : undefined,
+  };
+}
+
+async function listSessionBackupMatches(): Promise<Map<string, SessionBackupReferenceMatch>> {
+  const index = new Map<string, SessionBackupReferenceMatch>();
+  const root = getSessionBackupsRoot();
+
+  try {
+    const entries = await fs.readdir(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      try {
+        const pkg = await readSessionBackupPackage(entry.name);
+        for (const record of pkg.records) {
+          const key = formatSessionSelectionLabel({
+            sessionId: record.session.id,
+            source: record.session.source,
+            rootId: record.session.rootId,
+          });
+          if (index.has(key)) continue;
+          index.set(key, {
+            backupId: pkg.manifest.backupId,
+            manifestPath: path.join(root, entry.name, "manifest.json"),
+            createdAt: pkg.manifest.createdAt,
+            source: record.session.source,
+            sessionId: record.session.id,
+            rootId: record.session.rootId,
+          });
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return index;
+  }
+
+  return index;
+}
+
+async function readPackageMetadata(): Promise<{
+  projectName: string;
+  packageName: string;
+  packageVersion: string;
+  repository?: string;
+  workspacePath: string;
+}> {
+  const workspacePath = process.cwd();
+  const raw = await fs.readFile(path.join(workspacePath, "package.json"), "utf8");
+  const pkg = JSON.parse(raw) as {
+    name?: string;
+    version?: string;
+    repository?: { url?: string } | string;
+  };
+
+  const repository = typeof pkg.repository === "string"
+    ? pkg.repository
+    : pkg.repository?.url;
+
+  return {
+    projectName: path.basename(workspacePath),
+    packageName: pkg.name ?? "",
+    packageVersion: pkg.version ?? "",
+    repository: repository || undefined,
+    workspacePath,
+  };
+}
+
+function buildContextAssetReferences(
+  selection: ProjectBundleSelectionState
+): {
+  memberReferences: ProjectBundleMemberReference[];
+  validationItems: BackupValidationItem[];
+} {
+  const assets = createContextAssetSeeds();
+  const selectedSubtypes = new Map<ProjectBundleMemberCategory, string>([
+    ["rules", "rule"],
+    ["memory", "memory"],
+    ["skills", "skill"],
+    ["commands", "command"],
+  ]);
+
+  const memberReferences: ProjectBundleMemberReference[] = [];
+  const validationItems: BackupValidationItem[] = [];
+
+  for (const [category, subtype] of selectedSubtypes.entries()) {
+    if (!selection.includedCategories[category]) continue;
+
+    for (const asset of assets.filter((item) => item.subtype === subtype)) {
+      memberReferences.push({
+        id: `${category}:${asset.id}`,
+        category,
+        label: asset.title,
+        referenceType: "context-asset",
+        referenceId: asset.id,
+        status: "resolved",
+        detail: `Include ${asset.title} as a ${category} member reference.`,
+        snapshot: createSnapshot({
+          id: asset.id,
+          label: asset.title,
+          category,
+          scope: asset.scope,
+          subtype: asset.subtype,
+          provenanceSummary: asset.provenance,
+          status: asset.status,
+        }),
+      });
+
+      if (!asset.provenance || asset.provenance === "Provenance unavailable.") {
+        validationItems.push({
+          id: `bundle-${asset.id}-provenance-missing`,
+          label: `${asset.title} provenance`,
+          severity: "warning",
+          detail: "Provenance is incomplete. The bundle remains structurally valid and will preserve a lightweight metadata snapshot.",
+        });
+      }
+      if (asset.subtype === "unknown") {
+        validationItems.push({
+          id: `bundle-${asset.id}-subtype-unknown`,
+          label: `${asset.title} subtype classification`,
+          severity: "warning",
+          detail: "Subtype classification is uncertain. The bundle remains structurally valid and keeps the member snapshot.",
+        });
+      }
+      if (asset.status === "stale" || asset.status === "conflicted" || asset.status === "orphaned" || asset.status === "unknown") {
+        validationItems.push({
+          id: `bundle-${asset.id}-state-warning`,
+          label: `${asset.title} member state`,
+          severity: "warning",
+          detail: `Member state is ${asset.status}. The bundle can proceed, but the warning remains visible through confirmation.`,
+        });
+      }
+    }
+  }
+
+  return { memberReferences, validationItems };
+}
+
+async function composeProjectBundle(
+  selection: ProjectBundleSelectionState,
+  configuration: ProjectBundleConfiguration
+): Promise<ComposeProjectBundleResult> {
+  const selectedCategories = PROJECT_BUNDLE_MEMBER_CATEGORIES.filter((category) => selection.includedCategories[category]);
+  const validationItems: BackupValidationItem[] = [];
+  const memberReferences: ProjectBundleMemberReference[] = [];
+  const now = new Date().toISOString();
+
+  if (selectedCategories.length === 0) {
+    validationItems.push({
+      id: "bundle-no-categories",
+      label: "Bundle composition",
+      severity: "block",
+      detail: "Select at least one bundle member category before validation.",
+    });
+  }
+
+  if (!configuration.bundleName.trim()) {
+    validationItems.push({
+      id: "bundle-name-required",
+      label: "Bundle name",
+      severity: "block",
+      detail: "Bundle name is required before a legal bundle manifest can be formed.",
+    });
+  }
+
+  let packageInfo: Awaited<ReturnType<typeof readPackageMetadata>> | null = null;
+  try {
+    packageInfo = await readPackageMetadata();
+  } catch (error) {
+    validationItems.push({
+      id: "bundle-package-metadata-missing",
+      label: "Package metadata",
+      severity: "block",
+      detail: `Required package metadata could not be read. ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  if (packageInfo && (!packageInfo.packageName || !packageInfo.packageVersion || !packageInfo.projectName)) {
+    validationItems.push({
+      id: "bundle-package-metadata-incomplete",
+      label: "Package identity",
+      severity: "block",
+      detail: "Required package identity is incomplete, so a legal bundle package cannot be generated.",
+    });
+  }
+
+  try {
+    await fs.mkdir(getProjectBundlesRoot(), { recursive: true });
+  } catch (error) {
+    validationItems.push({
+      id: "bundle-output-root-unwritable",
+      label: "Bundle output",
+      severity: "block",
+      detail: `Bundle output root is not writable. ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+
+  const sessionSelections = dedupeSessionSelections(selection.sessionSelections);
+  const sessionBackupIndex = await listSessionBackupMatches();
+  if (selection.includedCategories.sessions && sessionSelections.length === 0) {
+    validationItems.push({
+      id: "bundle-sessions-empty",
+      label: "Session members",
+      severity: "warning",
+      detail: "Sessions are selected as a default bundle category, but no explicit session references are currently listed.",
+    });
+  }
+
+  if (selection.includedCategories.sessions) {
+    for (const sessionSelection of sessionSelections) {
+      const key = formatSessionSelectionLabel(sessionSelection);
+      const match = sessionBackupIndex.get(key);
+      if (!match) {
+        validationItems.push({
+          id: `bundle-session-missing-package-${key}`,
+          label: `${sessionSelection.sessionId} existing backup package`,
+          severity: "warning",
+          detail: "No existing session backup package is available. Bundle generation will preserve an unresolved member reference plus metadata snapshot instead of silently omitting the session.",
+        });
+      }
+
+      memberReferences.push({
+        id: `sessions:${key}`,
+        category: "sessions",
+        label: sessionSelection.sessionId || "unresolved-session",
+        referenceType: "session-backup-package",
+        referenceId: key,
+        status: match ? "resolved" : "missing-package",
+        detail: match
+          ? `Reuse existing session backup package ${match.backupId}.`
+          : "No existing session backup package is available for this selected session.",
+        backupId: match?.backupId,
+        manifestPath: match?.manifestPath,
+        snapshot: createSnapshot({
+          id: key,
+          label: sessionSelection.sessionId || "unresolved-session",
+          category: "sessions",
+          scope: "project",
+          subtype: "session-backup-package",
+          provenanceSummary: sessionSelection.source
+            ? `Selected from ${sessionSelection.source}${sessionSelection.rootId ? ` / ${sessionSelection.rootId}` : ""}.`
+            : "Selected session provenance is incomplete.",
+          status: match ? "resolved" : "missing-package",
+          capturedAt: match?.createdAt,
+        }),
+      });
+    }
+  }
+
+  const contextAssets = buildContextAssetReferences(selection);
+  memberReferences.push(...contextAssets.memberReferences);
+  validationItems.push(...contextAssets.validationItems);
+
+  if (selection.includedCategories["package-metadata"] && packageInfo) {
+    memberReferences.push({
+      id: "package-metadata:self",
+      category: "package-metadata",
+      label: packageInfo.packageName,
+      referenceType: "package-metadata",
+      referenceId: packageInfo.packageName,
+      status: "resolved",
+      detail: "Include package-level metadata snapshot for the current app package.",
+      snapshot: createSnapshot({
+        id: packageInfo.packageName,
+        label: packageInfo.packageName,
+        category: "package-metadata",
+        scope: "package",
+        provenanceSummary: packageInfo.repository,
+        status: "active",
+      }),
+    });
+  }
+
+  if (selection.includedCategories["project-metadata"] && packageInfo) {
+    memberReferences.push({
+      id: "project-metadata:self",
+      category: "project-metadata",
+      label: packageInfo.projectName,
+      referenceType: "project-metadata",
+      referenceId: packageInfo.workspacePath,
+      status: "resolved",
+      detail: "Include project-level metadata snapshot for the current workspace.",
+      snapshot: createSnapshot({
+        id: packageInfo.workspacePath,
+        label: packageInfo.projectName,
+        category: "project-metadata",
+        scope: "project",
+        provenanceSummary: packageInfo.workspacePath,
+        status: "active",
+      }),
+    });
+  }
+
+  const memberInventory: ProjectBundleMemberInventoryItem[] = PROJECT_BUNDLE_MEMBER_CATEGORIES.map((category) => {
+    const selected = selection.includedCategories[category];
+    const includedCount =
+      category === "sessions"
+        ? sessionSelections.length
+        : memberReferences.filter((item) => item.category === category).length;
+    const hasBlocker = validationItems.some((item) => item.severity === "block" && item.id.includes(category));
+    const hasWarning = validationItems.some((item) => item.severity === "warning" && item.id.includes(category));
+
+    return {
+      category,
+      selected,
+      includedCount,
+      status: hasBlocker ? "blocked" : hasWarning ? "warning" : "ready",
+      detail: !selected
+        ? "Excluded from bundle composition."
+        : includedCount === 0
+          ? "Selected with no resolved members yet."
+          : `${includedCount} member reference${includedCount === 1 ? "" : "s"} included.`,
+    };
+  });
+
+  const validation = deriveValidationResult(validationItems);
+  const summary = buildProjectBundleValidationSummary({
+    validationItems,
+    memberReferences,
+    memberInventory,
+    selectedCategoryCount: selectedCategories.length,
+    selectedSessionCount: sessionSelections.length,
+  });
+
+  const packageId = createPackageId();
+  const packageMetadata: ProjectBundlePackageMetadata = {
+    packageId,
+    schemaVersion: "project-bundle/v1",
+    createdAt: now,
+    createdBy: "agent-storage-manager",
+    bundleName: configuration.bundleName.trim(),
+    notes: configuration.notes?.trim() || undefined,
+  };
+
+  const projectMetadata: ProjectBundleProjectMetadata = {
+    projectName: packageInfo?.projectName ?? "unknown-project",
+    workspacePath: packageInfo?.workspacePath ?? process.cwd(),
+    repository: packageInfo?.repository,
+    packageName: packageInfo?.packageName ?? "unknown-package",
+    packageVersion: packageInfo?.packageVersion ?? "0.0.0",
+    originCue: selection.originCue,
+    scopeHint: selection.scopeHint,
+    filterHint: selection.filterHint,
+    objectRefs: selection.objectRefs,
+  };
+
+  return {
+    validation,
+    summary,
+    memberInventory,
+    memberReferences,
+    packageMetadata,
+    projectMetadata,
+  };
+}
+
+function createBundleDocument(input: ComposeProjectBundleResult): ProjectBundleDocument {
+  return {
+    manifest: {
+      schemaVersion: "project-bundle/v1",
+      packageId: input.packageMetadata.packageId,
+      createdAt: input.packageMetadata.createdAt,
+      memberInventory: input.memberInventory,
+      memberReferences: input.memberReferences,
+      validationSummary: input.summary,
+    },
+    packageMetadata: input.packageMetadata,
+    projectMetadata: input.projectMetadata,
+    memberInventory: input.memberInventory,
+    memberReferences: input.memberReferences,
+    validationSummary: input.summary,
+  };
+}
+
+export async function validateProjectBundle(
+  selection: ProjectBundleSelectionState,
+  configuration: ProjectBundleConfiguration
+): Promise<ProjectBundleValidationResponse> {
+  const composed = await composeProjectBundle(selection, configuration);
+  return {
+    validation: composed.validation,
+    summary: composed.summary,
+    memberInventory: composed.memberInventory,
+    memberReferences: composed.memberReferences,
+  };
+}
+
+export async function generateProjectBundle(
+  selection: ProjectBundleSelectionState,
+  configuration: ProjectBundleConfiguration
+): Promise<ProjectBundleGenerateResponse> {
+  const composed = await composeProjectBundle(selection, configuration);
+  if (composed.validation.status === "invalid") {
+    throw new Error("Project bundle generation requires a structurally valid composition.");
+  }
+
+  const bundle = createBundleDocument(composed);
+  const filePath = path.join(getProjectBundlesRoot(), `${composed.packageMetadata.packageId}.bundle.json`);
+  await fs.writeFile(filePath, JSON.stringify(bundle, null, 2), "utf8");
+
+  return {
+    validation: composed.validation,
+    summary: composed.summary,
+    memberInventory: composed.memberInventory,
+    memberReferences: composed.memberReferences,
+    packageId: composed.packageMetadata.packageId,
+    filePath,
+    bundle,
+  };
+}

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -17,6 +17,7 @@ import {
   type ProjectBundleMemberCategory,
   type ProjectBundleMemberInventoryItem,
   type ProjectBundleMemberReference,
+  type ProjectBundleMemberStatus,
   type ProjectBundleMetadataSnapshot,
   type ProjectBundlePackageMetadata,
   type ProjectBundleProjectMetadata,
@@ -29,7 +30,6 @@ import { getProjectBundlesRoot, getSessionBackupsRoot } from "@/lib/server/paths
 
 type SessionBackupReferenceMatch = {
   backupId: string;
-  manifestPath: string;
   createdAt: string;
   source: string;
   sessionId: string;
@@ -87,7 +87,6 @@ async function listSessionBackupMatches(): Promise<Map<string, SessionBackupRefe
           if (index.has(key)) continue;
           index.set(key, {
             backupId: pkg.manifest.backupId,
-            manifestPath: path.join(root, entry.name, "manifest.json"),
             createdAt: pkg.manifest.createdAt,
             source: record.session.source,
             sessionId: record.session.id,
@@ -295,9 +294,8 @@ async function composeProjectBundle(
         status: match ? "resolved" : "missing-package",
         detail: match
           ? `Reuse existing session backup package ${match.backupId}.`
-          : "No existing session backup package is available for this selected session.",
+          : "No existing session backup package is available for this selected session yet. This is expected until the session has been backed up.",
         backupId: match?.backupId,
-        manifestPath: match?.manifestPath,
         snapshot: createSnapshot({
           id: key,
           label: sessionSelection.sessionId || "unresolved-session",
@@ -358,20 +356,54 @@ async function composeProjectBundle(
     });
   }
 
+  const memberInventoryStatusByCategory = new Map<ProjectBundleMemberCategory, ProjectBundleMemberStatus>();
+  const promoteCategoryStatus = (category: ProjectBundleMemberCategory, next: ProjectBundleMemberStatus) => {
+    const current = memberInventoryStatusByCategory.get(category);
+    if (current === "blocked") return;
+    if (current === "warning" && next === "ready") return;
+    if (current === "ready" && next === "ready") return;
+    if (current === "warning" && next === "blocked") {
+      memberInventoryStatusByCategory.set(category, "blocked");
+      return;
+    }
+    if (!current) {
+      memberInventoryStatusByCategory.set(category, next);
+      return;
+    }
+    if (current === "ready" && (next === "warning" || next === "blocked")) {
+      memberInventoryStatusByCategory.set(category, next);
+    }
+  };
+
+  for (const reference of memberReferences) {
+    promoteCategoryStatus(reference.category, reference.status === "resolved" ? "ready" : "warning");
+  }
+
+  for (const item of validationItems) {
+    if (item.id.startsWith("bundle-session-")) {
+      promoteCategoryStatus("sessions", item.severity === "block" ? "blocked" : "warning");
+    } else if (item.id.startsWith("bundle-package-metadata-")) {
+      promoteCategoryStatus("package-metadata", item.severity === "block" ? "blocked" : "warning");
+    } else if (item.id.startsWith("bundle-output-root-")) {
+      promoteCategoryStatus("project-metadata", item.severity === "block" ? "blocked" : "warning");
+    }
+  }
+
   const memberInventory: ProjectBundleMemberInventoryItem[] = PROJECT_BUNDLE_MEMBER_CATEGORIES.map((category) => {
     const selected = selection.includedCategories[category];
     const includedCount =
-      category === "sessions"
+      !selected
+        ? 0
+        : category === "sessions"
         ? sessionSelections.length
         : memberReferences.filter((item) => item.category === category).length;
-    const hasBlocker = validationItems.some((item) => item.severity === "block" && item.id.includes(category));
-    const hasWarning = validationItems.some((item) => item.severity === "warning" && item.id.includes(category));
+    const status = selected ? memberInventoryStatusByCategory.get(category) ?? "ready" : "ready";
 
     return {
       category,
       selected,
       includedCount,
-      status: hasBlocker ? "blocked" : hasWarning ? "warning" : "ready",
+      status,
       detail: !selected
         ? "Excluded from bundle composition."
         : includedCount === 0

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -108,11 +108,20 @@ async function listSessionBackupMatches(): Promise<Map<string, SessionBackupRefe
 async function canPrepareBundleOutputRoot(): Promise<boolean> {
   try {
     const root = getProjectBundlesRoot();
-    const parent = path.dirname(root);
-    await fs.access(parent);
-    return true;
-  } catch {
+    let current = path.dirname(root);
+    while (true) {
+      try {
+        await fs.access(current);
+        return true;
+      } catch {
+        const parent = path.dirname(current);
+        if (parent === current) break;
+        current = parent;
+      }
+    }
     return false;
+  } catch {
+    return true;
   }
 }
 
@@ -186,7 +195,7 @@ function buildContextAssetReferences(
 
       if (!asset.provenance || asset.provenance === "Provenance unavailable.") {
         validationItems.push({
-          id: `bundle-${asset.id}-provenance-missing`,
+          id: `bundle-${category}-${asset.id}-provenance-missing`,
           label: `${asset.title} provenance`,
           severity: "warning",
           detail: "Provenance is incomplete. The bundle remains structurally valid and will preserve a lightweight metadata snapshot.",
@@ -194,7 +203,7 @@ function buildContextAssetReferences(
       }
       if (asset.subtype === "unknown") {
         validationItems.push({
-          id: `bundle-${asset.id}-subtype-unknown`,
+          id: `bundle-${category}-${asset.id}-subtype-unknown`,
           label: `${asset.title} subtype classification`,
           severity: "warning",
           detail: "Subtype classification is uncertain. The bundle remains structurally valid and keeps the member snapshot.",
@@ -202,7 +211,7 @@ function buildContextAssetReferences(
       }
       if (asset.status === "stale" || asset.status === "conflicted" || asset.status === "orphaned" || asset.status === "unknown") {
         validationItems.push({
-          id: `bundle-${asset.id}-state-warning`,
+          id: `bundle-${category}-${asset.id}-state-warning`,
           label: `${asset.title} member state`,
           severity: "warning",
           detail: `Member state is ${asset.status}. The bundle can proceed, but the warning remains visible through confirmation.`,
@@ -398,6 +407,11 @@ async function composeProjectBundle(
       promoteCategoryStatus("sessions", item.severity === "block" ? "blocked" : "warning");
     } else if (item.id.startsWith("bundle-package-metadata-")) {
       promoteCategoryStatus("package-metadata", item.severity === "block" ? "blocked" : "warning");
+    } else {
+      const categoryPrefix = PROJECT_BUNDLE_MEMBER_CATEGORIES.find((category) => item.id.startsWith(`bundle-${category}-`));
+      if (categoryPrefix) {
+        promoteCategoryStatus(categoryPrefix, item.severity === "block" ? "blocked" : "warning");
+      }
     }
   }
 

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -77,6 +77,7 @@ async function listSessionBackupMatches(
   const index = new Map<string, SessionBackupReferenceMatch>();
   const root = getSessionBackupsRoot();
   const requestedKeys = new Set(sessionSelections.map((selection) => formatSessionSelectionLabel(selection)));
+  const remainingKeys = new Set(requestedKeys);
   const requestedSessionIds = new Set(sessionSelections.map((selection) => selection.sessionId));
 
   if (requestedKeys.size === 0) {
@@ -86,11 +87,13 @@ async function listSessionBackupMatches(
   try {
     const entries = await fs.readdir(root, { withFileTypes: true });
     for (const entry of entries) {
+      if (remainingKeys.size === 0) break;
       if (!entry.isDirectory()) continue;
 
       try {
         const manifest = parseSessionBackupManifest(await readBackupManifestFile(entry.name));
         for (const recordEntry of manifest.records) {
+          if (remainingKeys.size === 0) break;
           if (!requestedSessionIds.has(recordEntry.sessionId)) continue;
           const record = parseSessionRecord((await readBackupFile(entry.name, recordEntry.path)).toString("utf8"));
           const key = formatSessionSelectionLabel({
@@ -108,6 +111,7 @@ async function listSessionBackupMatches(
             sessionId: record.session.id,
             rootId: record.session.rootId,
           });
+          remainingKeys.delete(key);
         }
       } catch {
         continue;
@@ -123,6 +127,16 @@ async function listSessionBackupMatches(
 async function canPrepareBundleOutputRoot(): Promise<boolean> {
   try {
     const root = getProjectBundlesRoot();
+    try {
+      const stat = await fs.stat(root);
+      if (stat.isDirectory()) {
+        await fs.access(root, fsConstants.W_OK);
+        return true;
+      }
+      return false;
+    } catch {
+      // Root does not exist yet; fall back to nearest existing writable ancestor.
+    }
     let current = path.dirname(root);
     while (true) {
       try {
@@ -274,8 +288,7 @@ async function composeProjectBundle(
   let packageInfo: Awaited<ReturnType<typeof readPackageMetadata>> | null = null;
   try {
     packageInfo = await readPackageMetadata();
-  } catch (error) {
-    console.error("Failed to read package metadata for project bundle validation.", error);
+  } catch {
     validationItems.push({
       id: "bundle-package-metadata-missing",
       label: "Package metadata",

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -275,11 +275,12 @@ async function composeProjectBundle(
   try {
     packageInfo = await readPackageMetadata();
   } catch (error) {
+    console.error("Failed to read package metadata for project bundle validation.", error);
     validationItems.push({
       id: "bundle-package-metadata-missing",
       label: "Package metadata",
       severity: "block",
-      detail: `Required package metadata could not be read. ${error instanceof Error ? error.message : String(error)}`,
+      detail: "Required package metadata could not be read from the current workspace.",
     });
   }
 

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 
 import {
   PROJECT_BUNDLE_MEMBER_CATEGORIES,
+  PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES,
   buildProjectBundleValidationSummary,
   dedupeSessionSelections,
   deriveValidationResult,
@@ -22,6 +23,7 @@ import {
   type ProjectBundleMetadataSnapshot,
   type ProjectBundlePackageMetadata,
   type ProjectBundleProjectMetadata,
+  type ProjectBundleSelectableMemberCategory,
   type ProjectBundleSelectionState,
   type ProjectBundleValidationResponse,
 } from "@/lib/backupMigration";
@@ -173,7 +175,7 @@ function buildContextAssetReferences(
   validationItems: BackupValidationItem[];
 } {
   const assets = createContextAssetSeeds();
-  const selectedSubtypes = new Map<ProjectBundleMemberCategory, string>([
+  const selectedSubtypes = new Map<ProjectBundleSelectableMemberCategory, string>([
     ["rules", "rule"],
     ["memory", "memory"],
     ["skills", "skill"],
@@ -240,17 +242,23 @@ async function composeProjectBundle(
   selection: ProjectBundleSelectionState,
   configuration: ProjectBundleConfiguration
 ): Promise<ComposeProjectBundleResult> {
-  const selectedCategories = PROJECT_BUNDLE_MEMBER_CATEGORIES.filter((category) => selection.includedCategories[category]);
+  const selectableCategories = PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.filter((category) => selection.includedCategories[category]);
+  const selectedCategories = PROJECT_BUNDLE_MEMBER_CATEGORIES.filter((category) => {
+    if (category === "package-metadata" || category === "project-metadata") {
+      return true;
+    }
+    return selection.includedCategories[category];
+  });
   const validationItems: BackupValidationItem[] = [];
   const memberReferences: ProjectBundleMemberReference[] = [];
   const now = new Date().toISOString();
 
-  if (selectedCategories.length === 0) {
+  if (selectableCategories.length === 0) {
     validationItems.push({
       id: "bundle-no-categories",
       label: "Bundle composition",
       severity: "block",
-      detail: "Select at least one bundle member category before validation.",
+      detail: "Select at least one non-metadata bundle member category before validation.",
     });
   }
 
@@ -352,7 +360,7 @@ async function composeProjectBundle(
   memberReferences.push(...contextAssets.memberReferences);
   validationItems.push(...contextAssets.validationItems);
 
-  if (selection.includedCategories["package-metadata"] && packageInfo) {
+  if (packageInfo) {
     memberReferences.push({
       id: "package-metadata:self",
       category: "package-metadata",
@@ -372,7 +380,7 @@ async function composeProjectBundle(
     });
   }
 
-  if (selection.includedCategories["project-metadata"] && packageInfo) {
+  if (packageInfo) {
     memberReferences.push({
       id: "project-metadata:self",
       category: "project-metadata",
@@ -430,7 +438,10 @@ async function composeProjectBundle(
   }
 
   const memberInventory: ProjectBundleMemberInventoryItem[] = PROJECT_BUNDLE_MEMBER_CATEGORIES.map((category) => {
-    const selected = selection.includedCategories[category];
+    const selected =
+      category === "package-metadata" || category === "project-metadata"
+        ? true
+        : selection.includedCategories[category];
     const includedCount =
       !selected
         ? 0

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import crypto from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -25,8 +26,9 @@ import {
   type ProjectBundleValidationResponse,
 } from "@/lib/backupMigration";
 import { createContextAssetSeeds } from "@/lib/contextAssets";
-import { readSessionBackupPackage } from "@/lib/server/sessionBackupService";
+import { parseSessionBackupManifest, parseSessionRecord } from "@/lib/sessionBackup";
 import { getProjectBundlesRoot, getSessionBackupsRoot } from "@/lib/server/paths";
+import { readBackupFile, readBackupManifestFile } from "@/lib/server/sessionBackupStore";
 
 type SessionBackupReferenceMatch = {
   backupId: string;
@@ -67,9 +69,17 @@ function createSnapshot(input: {
   };
 }
 
-async function listSessionBackupMatches(): Promise<Map<string, SessionBackupReferenceMatch>> {
+async function listSessionBackupMatches(
+  sessionSelections: ProjectBundleSelectionState["sessionSelections"]
+): Promise<Map<string, SessionBackupReferenceMatch>> {
   const index = new Map<string, SessionBackupReferenceMatch>();
   const root = getSessionBackupsRoot();
+  const requestedKeys = new Set(sessionSelections.map((selection) => formatSessionSelectionLabel(selection)));
+  const requestedSessionIds = new Set(sessionSelections.map((selection) => selection.sessionId));
+
+  if (requestedKeys.size === 0) {
+    return index;
+  }
 
   try {
     const entries = await fs.readdir(root, { withFileTypes: true });
@@ -77,18 +87,21 @@ async function listSessionBackupMatches(): Promise<Map<string, SessionBackupRefe
       if (!entry.isDirectory()) continue;
 
       try {
-        const pkg = await readSessionBackupPackage(entry.name);
-        for (const record of pkg.records) {
+        const manifest = parseSessionBackupManifest(await readBackupManifestFile(entry.name));
+        for (const recordEntry of manifest.records) {
+          if (!requestedSessionIds.has(recordEntry.sessionId)) continue;
+          const record = parseSessionRecord((await readBackupFile(entry.name, recordEntry.path)).toString("utf8"));
           const key = formatSessionSelectionLabel({
             sessionId: record.session.id,
             source: record.session.source,
             rootId: record.session.rootId,
           });
+          if (!requestedKeys.has(key)) continue;
           const existing = index.get(key);
-          if (existing && existing.createdAt >= pkg.manifest.createdAt) continue;
+          if (existing && existing.createdAt >= manifest.createdAt) continue;
           index.set(key, {
-            backupId: pkg.manifest.backupId,
-            createdAt: pkg.manifest.createdAt,
+            backupId: manifest.backupId,
+            createdAt: manifest.createdAt,
             source: record.session.source,
             sessionId: record.session.id,
             rootId: record.session.rootId,
@@ -111,7 +124,7 @@ async function canPrepareBundleOutputRoot(): Promise<boolean> {
     let current = path.dirname(root);
     while (true) {
       try {
-        await fs.access(current);
+        await fs.access(current, fsConstants.W_OK);
         return true;
       } catch {
         const parent = path.dirname(current);
@@ -284,7 +297,7 @@ async function composeProjectBundle(
   const sessionSelections = dedupeSessionSelections(selection.sessionSelections);
   const sessionBackupIndex =
     selection.includedCategories.sessions && sessionSelections.length > 0
-      ? await listSessionBackupMatches()
+      ? await listSessionBackupMatches(sessionSelections)
       : new Map<string, SessionBackupReferenceMatch>();
   if (selection.includedCategories.sessions && sessionSelections.length === 0) {
     validationItems.push({

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -84,7 +84,8 @@ async function listSessionBackupMatches(): Promise<Map<string, SessionBackupRefe
             source: record.session.source,
             rootId: record.session.rootId,
           });
-          if (index.has(key)) continue;
+          const existing = index.get(key);
+          if (existing && existing.createdAt >= pkg.manifest.createdAt) continue;
           index.set(key, {
             backupId: pkg.manifest.backupId,
             createdAt: pkg.manifest.createdAt,
@@ -102,6 +103,17 @@ async function listSessionBackupMatches(): Promise<Map<string, SessionBackupRefe
   }
 
   return index;
+}
+
+async function canPrepareBundleOutputRoot(): Promise<boolean> {
+  try {
+    const root = getProjectBundlesRoot();
+    const parent = path.dirname(root);
+    await fs.access(parent);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function readPackageMetadata(): Promise<{
@@ -250,19 +262,21 @@ async function composeProjectBundle(
     });
   }
 
-  try {
-    await fs.mkdir(getProjectBundlesRoot(), { recursive: true });
-  } catch (error) {
+  const outputRootWritable = await canPrepareBundleOutputRoot();
+  if (!outputRootWritable) {
     validationItems.push({
       id: "bundle-output-root-unwritable",
       label: "Bundle output",
       severity: "block",
-      detail: `Bundle output root is not writable. ${error instanceof Error ? error.message : String(error)}`,
+      detail: "Bundle output root cannot be prepared from the current environment.",
     });
   }
 
   const sessionSelections = dedupeSessionSelections(selection.sessionSelections);
-  const sessionBackupIndex = await listSessionBackupMatches();
+  const sessionBackupIndex =
+    selection.includedCategories.sessions && sessionSelections.length > 0
+      ? await listSessionBackupMatches()
+      : new Map<string, SessionBackupReferenceMatch>();
   if (selection.includedCategories.sessions && sessionSelections.length === 0) {
     validationItems.push({
       id: "bundle-sessions-empty",
@@ -384,8 +398,6 @@ async function composeProjectBundle(
       promoteCategoryStatus("sessions", item.severity === "block" ? "blocked" : "warning");
     } else if (item.id.startsWith("bundle-package-metadata-")) {
       promoteCategoryStatus("package-metadata", item.severity === "block" ? "blocked" : "warning");
-    } else if (item.id.startsWith("bundle-output-root-")) {
-      promoteCategoryStatus("project-metadata", item.severity === "block" ? "blocked" : "warning");
     }
   }
 
@@ -494,6 +506,7 @@ export async function generateProjectBundle(
   }
 
   const bundle = createBundleDocument(composed);
+  await fs.mkdir(getProjectBundlesRoot(), { recursive: true });
   const filePath = path.join(getProjectBundlesRoot(), `${composed.packageMetadata.packageId}.bundle.json`);
   await fs.writeFile(filePath, JSON.stringify(bundle, null, 2), "utf8");
 

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -134,7 +134,7 @@ async function canPrepareBundleOutputRoot(): Promise<boolean> {
     }
     return false;
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -544,6 +544,5 @@ export async function generateProjectBundle(
     memberReferences: composed.memberReferences,
     packageId: composed.packageMetadata.packageId,
     filePath,
-    bundle,
   };
 }

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -238,7 +238,7 @@ describe("getStepsForWorkflow", () => {
 });
 
 describe("project bundle model tests", () => {
-  it("creates default project bundle selection with all default categories enabled", () => {
+  it("creates default project bundle selection with selectable categories enabled and foundation metadata implicit", () => {
     const selection = createDefaultProjectBundleSelection({
       origin: "overview",
       subtitle: "Open Project Bundle from overview.",
@@ -248,7 +248,7 @@ describe("project bundle model tests", () => {
     }, []);
 
     expect(selection.includedCategories.sessions).toBe(true);
-    expect(selection.includedCategories["project-metadata"]).toBe(true);
+    expect(Object.keys(selection.includedCategories)).toEqual(["sessions", "rules", "memory", "skills", "commands"]);
     expect(selection.scopeHint).toBe("overview-routed project context");
     expect(selection.objectRefs).toEqual(["asset-rule-project-codex"]);
   });

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   addRecentOperation,
   buildBulkSessionValidationResult,
+  buildProjectBundleValidationSummary,
   buildMigrationPreviewItems,
   buildPackageValidationItems,
+  createDefaultProjectBundleSelection,
   buildBackupHandoffInstanceKey,
   buildSessionBackupExecutionRequest,
   canProceedFromValidation,
   createMigrationPreviewOperationResult,
+  createProjectBundleOperationResult,
   createBulkOperationSummary,
   createOperationResult,
   dedupeSessionSelections,
@@ -189,6 +192,7 @@ describe("formatWorkflowTypeLabel", () => {
     expect(formatWorkflowTypeLabel("import-backup")).toBe("Import Backup");
     expect(formatWorkflowTypeLabel("validate-package")).toBe("Validate Package");
     expect(formatWorkflowTypeLabel("migration-preview")).toBe("Migration Preview");
+    expect(formatWorkflowTypeLabel("project-bundle")).toBe("Project Bundle");
   });
 });
 
@@ -225,6 +229,146 @@ describe("getStepsForWorkflow", () => {
   it("returns steps for migration-preview", () => {
     const steps = getStepsForWorkflow("migration-preview");
     expect(steps).toEqual(["selection", "configuration", "validation", "result"]);
+  });
+
+  it("returns steps for project-bundle", () => {
+    const steps = getStepsForWorkflow("project-bundle");
+    expect(steps).toEqual(["selection", "configuration", "validation", "confirmation", "execution", "result"]);
+  });
+});
+
+describe("project bundle model tests", () => {
+  it("creates default project bundle selection with all default categories enabled", () => {
+    const selection = createDefaultProjectBundleSelection({
+      origin: "overview",
+      subtitle: "Open Project Bundle from overview.",
+      workflowType: "project-bundle",
+      projectBundleScopeHint: "overview-routed project context",
+      projectBundleObjectRefs: ["asset-rule-project-codex"],
+    }, []);
+
+    expect(selection.includedCategories.sessions).toBe(true);
+    expect(selection.includedCategories["project-metadata"]).toBe(true);
+    expect(selection.scopeHint).toBe("overview-routed project context");
+    expect(selection.objectRefs).toEqual(["asset-rule-project-codex"]);
+  });
+
+  it("builds project bundle validation summary counts", () => {
+    const summary = buildProjectBundleValidationSummary({
+      validationItems: [
+        { id: "warning-1", label: "Warn", severity: "warning", detail: "warning" },
+        { id: "block-1", label: "Block", severity: "block", detail: "block" },
+      ],
+      memberReferences: [
+        {
+          id: "ref-1",
+          category: "sessions",
+          label: "session-1",
+          referenceType: "session-backup-package",
+          referenceId: "codex:session-1",
+          status: "resolved",
+          detail: "Resolved",
+          snapshot: { id: "session-1", label: "session-1", category: "sessions" },
+        },
+        {
+          id: "ref-2",
+          category: "sessions",
+          label: "session-2",
+          referenceType: "session-backup-package",
+          referenceId: "codex:session-2",
+          status: "missing-package",
+          detail: "Missing",
+          snapshot: { id: "session-2", label: "session-2", category: "sessions" },
+        },
+      ],
+      memberInventory: [],
+      selectedCategoryCount: 3,
+      selectedSessionCount: 2,
+    });
+
+    expect(summary.warningCount).toBe(1);
+    expect(summary.blockerCount).toBe(1);
+    expect(summary.resolvedReferenceCount).toBe(1);
+    expect(summary.unresolvedReferenceCount).toBe(1);
+  });
+
+  it("creates project bundle operation results with package identity and inventory", () => {
+    const result = createProjectBundleOperationResult({
+      status: "success-with-warnings",
+      packageId: "project-bundle-1",
+      filePath: "/tmp/project-bundle-1.bundle.json",
+      summary: "Project bundle generated.",
+      validationSummary: {
+        warningCount: 1,
+        blockerCount: 0,
+        selectedCategoryCount: 7,
+        selectedSessionCount: 1,
+        resolvedReferenceCount: 6,
+        unresolvedReferenceCount: 1,
+      },
+      memberInventory: [
+        { category: "sessions", selected: true, includedCount: 1, status: "warning", detail: "1 member reference included." },
+      ],
+      memberReferences: [
+        {
+          id: "sessions:codex:session-1",
+          category: "sessions",
+          label: "session-1",
+          referenceType: "session-backup-package",
+          referenceId: "codex:session-1",
+          status: "missing-package",
+          detail: "No existing session backup package is available.",
+          snapshot: { id: "session-1", label: "session-1", category: "sessions" },
+        },
+      ],
+      bundle: {
+        manifest: {
+          schemaVersion: "project-bundle/v1",
+          packageId: "project-bundle-1",
+          createdAt: "2026-04-16T00:00:00.000Z",
+          memberInventory: [],
+          memberReferences: [],
+          validationSummary: {
+            warningCount: 1,
+            blockerCount: 0,
+            selectedCategoryCount: 7,
+            selectedSessionCount: 1,
+            resolvedReferenceCount: 6,
+            unresolvedReferenceCount: 1,
+          },
+        },
+        packageMetadata: {
+          packageId: "project-bundle-1",
+          schemaVersion: "project-bundle/v1",
+          createdAt: "2026-04-16T00:00:00.000Z",
+          createdBy: "agent-storage-manager",
+          bundleName: "Bundle",
+        },
+        projectMetadata: {
+          projectName: "agent-storage-manager",
+          workspacePath: "/workspace",
+          packageName: "agent-storage-manager",
+          packageVersion: "0.1.0",
+          objectRefs: [],
+        },
+        memberInventory: [],
+        memberReferences: [],
+        validationSummary: {
+          warningCount: 1,
+          blockerCount: 0,
+          selectedCategoryCount: 7,
+          selectedSessionCount: 1,
+          resolvedReferenceCount: 6,
+          unresolvedReferenceCount: 1,
+        },
+      },
+      warnings: ["Missing session backup package."],
+    });
+
+    expect(result.workflowType).toBe("project-bundle");
+    expect(result.packageId).toBe("project-bundle-1");
+    expect(result.filePath).toContain("project-bundle-1.bundle.json");
+    expect(result.projectBundleValidationSummary?.warningCount).toBe(1);
   });
 });
 

--- a/tests/backupMigration.test.ts
+++ b/tests/backupMigration.test.ts
@@ -321,47 +321,6 @@ describe("project bundle model tests", () => {
           snapshot: { id: "session-1", label: "session-1", category: "sessions" },
         },
       ],
-      bundle: {
-        manifest: {
-          schemaVersion: "project-bundle/v1",
-          packageId: "project-bundle-1",
-          createdAt: "2026-04-16T00:00:00.000Z",
-          memberInventory: [],
-          memberReferences: [],
-          validationSummary: {
-            warningCount: 1,
-            blockerCount: 0,
-            selectedCategoryCount: 7,
-            selectedSessionCount: 1,
-            resolvedReferenceCount: 6,
-            unresolvedReferenceCount: 1,
-          },
-        },
-        packageMetadata: {
-          packageId: "project-bundle-1",
-          schemaVersion: "project-bundle/v1",
-          createdAt: "2026-04-16T00:00:00.000Z",
-          createdBy: "agent-storage-manager",
-          bundleName: "Bundle",
-        },
-        projectMetadata: {
-          projectName: "agent-storage-manager",
-          workspacePath: "/workspace",
-          packageName: "agent-storage-manager",
-          packageVersion: "0.1.0",
-          objectRefs: [],
-        },
-        memberInventory: [],
-        memberReferences: [],
-        validationSummary: {
-          warningCount: 1,
-          blockerCount: 0,
-          selectedCategoryCount: 7,
-          selectedSessionCount: 1,
-          resolvedReferenceCount: 6,
-          unresolvedReferenceCount: 1,
-        },
-      },
       warnings: ["Missing session backup package."],
     });
 

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -6,6 +6,7 @@ import {
   BackupMigrationFoundation,
   buildBulkConfirmationDetails,
   resolveInitialBulkSelections,
+  resolveInitialProjectBundleSessionSelections,
   OperationResultPanel,
   resolveMigrationPreviewInvalidWorkflowState,
   ValidationPanel,
@@ -167,7 +168,8 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("Start Import Backup");
     expect(html).toContain("Start Validate Package");
     expect(html).toContain("Start Migration Preview");
-    expect(html).toContain("does not support migration apply, project bundle packaging, vendor-runtime restore, or cloud sync");
+    expect(html).toContain("Start Project Bundle");
+    expect(html).toContain("does not support migration apply, vendor-runtime restore, or cloud sync");
   });
 
   it("renders routed session-backup workflow with prefilling context", () => {
@@ -269,6 +271,23 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("session-2");
     expect(html).toContain("Pre-selected from routed handoff.");
   });
+
+  it("renders routed project-bundle workflow without skipping selection", () => {
+    const html = renderBackupMigrationFoundation({
+      origin: "assets",
+      subtitle: "Open Project Bundle with skill asset context starting from asset-skill-global-generated.",
+      workflowType: "project-bundle",
+      projectBundleScopeHint: "skill asset scope",
+      projectBundleObjectRefs: ["asset-skill-global-generated"],
+      continueLabel: "Assets may prefill explicit object references and compact hints only. Final bundle composition still happens in Backup / Migration.",
+      returnLabel: "Return to Assets for object-level review.",
+    });
+
+    expect(html).toContain("Project Bundle");
+    expect(html).toContain("Select Bundle Scope");
+    expect(html).toContain("Final bundle composition still happens");
+    expect(html).toContain("No explicit sessions listed yet");
+  });
 });
 
 describe("BackupMigrationFoundation helpers", () => {
@@ -287,6 +306,21 @@ describe("BackupMigrationFoundation helpers", () => {
     ).toEqual([
       { sessionId: "session-1", source: "codex", rootId: "root-a", includeSourceCopy: false, unresolvedReason: undefined },
       { sessionId: "session-2", source: "windsurf", rootId: undefined, includeSourceCopy: false, unresolvedReason: undefined },
+    ]);
+  });
+
+  it("resolves initial project bundle sessions from routed handoff", () => {
+    expect(
+      resolveInitialProjectBundleSessionSelections({
+        origin: "analysis",
+        subtitle: "Bundle context from analysis.",
+        workflowType: "project-bundle",
+        sessionId: "session-1",
+        source: "codex",
+        rootId: "root-a",
+      })
+    ).toEqual([
+      { sessionId: "session-1", source: "codex", rootId: "root-a", includeSourceCopy: false, unresolvedReason: undefined },
     ]);
   });
 
@@ -349,5 +383,52 @@ describe("BackupMigrationFoundation panels", () => {
     expect(html).toContain("preview-with-blockers");
     expect(html).toContain("blocked");
     expect(html).toContain("missing-asset-ref");
+  });
+
+  it("renders project bundle result details with package identity and unresolved refs", () => {
+    const html = renderToStaticMarkup(
+      <OperationResultPanel
+        result={{
+          id: "op-bundle-1",
+          workflowType: "project-bundle",
+          status: "success-with-warnings",
+          timestamp: "2026-04-16T13:00:00Z",
+          summary: "Project bundle project-bundle-1 generated with 3 member references.",
+          packageId: "project-bundle-1",
+          filePath: "/tmp/project-bundle-1.bundle.json",
+          memberCount: 3,
+          projectBundleValidationSummary: {
+            warningCount: 1,
+            blockerCount: 0,
+            selectedCategoryCount: 7,
+            selectedSessionCount: 1,
+            resolvedReferenceCount: 2,
+            unresolvedReferenceCount: 1,
+          },
+          projectBundleMemberInventory: [
+            { category: "sessions", selected: true, includedCount: 1, status: "warning", detail: "1 member reference included." },
+          ],
+          projectBundleMemberReferences: [
+            {
+              id: "sessions:codex:session-1",
+              category: "sessions",
+              label: "session-1",
+              referenceType: "session-backup-package",
+              referenceId: "codex:session-1",
+              status: "missing-package",
+              detail: "No existing session backup package is available.",
+              snapshot: { id: "session-1", label: "session-1", category: "sessions" },
+            },
+          ],
+        }}
+        onNewWorkflow={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("project-bundle-1");
+    expect(html).toContain("/tmp/project-bundle-1.bundle.json");
+    expect(html).toContain("Bundle member inventory");
+    expect(html).toContain("missing-package");
+    expect(html).toContain("No restore or apply in foundation v1.");
   });
 });

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -288,6 +288,7 @@ describe("BackupMigrationFoundation", () => {
     expect(html).toContain("Final bundle composition still happens");
     expect(html).toContain("No explicit sessions listed yet");
   });
+
 });
 
 describe("BackupMigrationFoundation helpers", () => {

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -206,6 +206,9 @@ describe("project bundle service", () => {
       const projectMetadata = result.memberInventory.find((item) => item.category === "project-metadata");
 
       expect(result.validation.items.some((item) => item.id === "bundle-package-metadata-missing")).toBe(true);
+      expect(
+        result.validation.items.find((item) => item.id === "bundle-package-metadata-missing")?.detail
+      ).toBe("Required package metadata could not be read from the current workspace.");
       expect(packageMetadata?.status).toBe("blocked");
       expect(projectMetadata?.status).toBe("blocked");
     } finally {

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -193,4 +193,23 @@ describe("project bundle service", () => {
       generateProjectBundle(makeSelection(), makeConfig({ bundleName: "" }))
     ).rejects.toThrow(/structurally valid composition/i);
   });
+
+  it("marks both package and project metadata categories blocked when package metadata cannot be read", async () => {
+    const originalCwd = process.cwd();
+    const missingWorkspace = path.join(tmpDir, "missing-workspace");
+    await fs.mkdir(missingWorkspace, { recursive: true });
+    process.chdir(missingWorkspace);
+
+    try {
+      const result = await validateProjectBundle(makeSelection(), makeConfig());
+      const packageMetadata = result.memberInventory.find((item) => item.category === "package-metadata");
+      const projectMetadata = result.memberInventory.find((item) => item.category === "project-metadata");
+
+      expect(result.validation.items.some((item) => item.id === "bundle-package-metadata-missing")).toBe(true);
+      expect(packageMetadata?.status).toBe("blocked");
+      expect(projectMetadata?.status).toBe("blocked");
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
 });

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -125,6 +125,32 @@ describe("project bundle service", () => {
     expect(generated.filePath).toContain("project-bundles");
   });
 
+  it("prefers the newest matching session backup package when multiple matches exist", async () => {
+    await fs.mkdir(path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, "backup-old"), { recursive: true });
+    await fs.mkdir(path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, "backup-new"), { recursive: true });
+    readSessionBackupPackageMock
+      .mockResolvedValueOnce({
+        manifest: {
+          backupId: "backup-old",
+          createdAt: "2026-04-16T09:00:00.000Z",
+        },
+        records: [{ session: { id: "session-1", source: "codex", rootId: "root-1" } }],
+      })
+      .mockResolvedValueOnce({
+        manifest: {
+          backupId: "backup-new",
+          createdAt: "2026-04-16T10:00:00.000Z",
+        },
+        records: [{ session: { id: "session-1", source: "codex", rootId: "root-1" } }],
+      });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+    const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
+
+    expect(sessionReference?.backupId).toBe("backup-new");
+    expect(sessionReference?.detail).toContain("backup-new");
+  });
+
   it("blocks generation when bundle identity is structurally invalid", async () => {
     readSessionBackupPackageMock.mockRejectedValue(new Error("missing"));
 

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -215,4 +215,17 @@ describe("project bundle service", () => {
       process.chdir(originalCwd);
     }
   });
+
+  it("blocks validation when the bundle root path is not a writable directory", async () => {
+    const bundleRoot = process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT!;
+    await fs.writeFile(bundleRoot, "not-a-directory", "utf8");
+
+    try {
+      const result = await validateProjectBundle(makeSelection(), makeConfig());
+      expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+      expect(result.validation.status).toBe("invalid");
+    } finally {
+      await fs.rm(bundleRoot, { force: true });
+    }
+  });
 });

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/contextAssets", () => ({
+  createContextAssetSeeds: () => [
+    {
+      id: "asset-rule-project-codex",
+      title: "Project Rule",
+      subtype: "rule",
+      scope: "project",
+      provenance: "Imported from project context.",
+      status: "active",
+    },
+  ],
+}));
+
+const readSessionBackupPackageMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/server/sessionBackupService", () => ({
+  readSessionBackupPackage: (...args: unknown[]) => readSessionBackupPackageMock(...args),
+}));
+
+import {
+  createDefaultProjectBundleSelection,
+  type ProjectBundleConfiguration,
+} from "@/lib/backupMigration";
+import { generateProjectBundle, validateProjectBundle } from "@/lib/server/projectBundleService";
+
+let tmpDir: string;
+const originalBundleRoot = process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT;
+const originalBackupRoot = process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "asm-project-bundle-"));
+  process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = path.join(tmpDir, "project-bundles");
+  process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT = path.join(tmpDir, "backups");
+  await fs.mkdir(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT, { recursive: true });
+  readSessionBackupPackageMock.mockReset();
+});
+
+afterEach(async () => {
+  if (originalBundleRoot === undefined) {
+    delete process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT;
+  } else {
+    process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = originalBundleRoot;
+  }
+  if (originalBackupRoot === undefined) {
+    delete process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT;
+  } else {
+    process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT = originalBackupRoot;
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function makeSelection() {
+  return createDefaultProjectBundleSelection(
+    {
+      origin: "overview",
+      subtitle: "Open Project Bundle from overview.",
+      workflowType: "project-bundle",
+      projectBundleScopeHint: "overview-routed project context",
+    },
+    [
+      {
+        sessionId: "session-1",
+        source: "codex",
+        rootId: "root-1",
+      },
+    ]
+  );
+}
+
+function makeConfig(overrides?: Partial<ProjectBundleConfiguration>): ProjectBundleConfiguration {
+  return {
+    bundleName: "Current project context bundle",
+    notes: "QA bundle",
+    ...overrides,
+  };
+}
+
+describe("project bundle service", () => {
+  it("returns a warning and unresolved reference when a selected session has no existing backup", async () => {
+    readSessionBackupPackageMock.mockRejectedValue(new Error("missing"));
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("valid-with-warnings");
+    expect(result.validation.items.some((item) => item.id.startsWith("bundle-session-missing-package-"))).toBe(true);
+    const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
+    expect(sessionReference?.status).toBe("missing-package");
+    expect(sessionReference?.detail).toContain("expected until the session has been backed up");
+  });
+
+  it("generates a real local bundle file with the expected minimum structure", async () => {
+    await fs.mkdir(path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, "backup-001"), { recursive: true });
+    readSessionBackupPackageMock.mockResolvedValue({
+      manifest: {
+        backupId: "backup-001",
+        createdAt: "2026-04-16T10:00:00.000Z",
+      },
+      records: [
+        {
+          session: {
+            id: "session-1",
+            source: "codex",
+            rootId: "root-1",
+          },
+        },
+      ],
+    });
+
+    const generated = await generateProjectBundle(makeSelection(), makeConfig());
+    const raw = await fs.readFile(generated.filePath, "utf8");
+    const document = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(generated.validation.status).toBe("valid");
+    expect(document.manifest).toBeTruthy();
+    expect(document.packageMetadata).toBeTruthy();
+    expect(document.projectMetadata).toBeTruthy();
+    expect(document.memberInventory).toBeTruthy();
+    expect(document.memberReferences).toBeTruthy();
+    expect(document.validationSummary).toBeTruthy();
+    expect(generated.filePath).toContain("project-bundles");
+  });
+
+  it("blocks generation when bundle identity is structurally invalid", async () => {
+    readSessionBackupPackageMock.mockRejectedValue(new Error("missing"));
+
+    await expect(
+      generateProjectBundle(makeSelection(), makeConfig({ bundleName: "" }))
+    ).rejects.toThrow(/structurally valid composition/i);
+  });
+});

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -16,16 +16,11 @@ vi.mock("@/lib/contextAssets", () => ({
   ],
 }));
 
-const readSessionBackupPackageMock = vi.hoisted(() => vi.fn());
-
-vi.mock("@/lib/server/sessionBackupService", () => ({
-  readSessionBackupPackage: (...args: unknown[]) => readSessionBackupPackageMock(...args),
-}));
-
 import {
   createDefaultProjectBundleSelection,
   type ProjectBundleConfiguration,
 } from "@/lib/backupMigration";
+import { buildSessionBackupManifest, serializeSessionBackupManifest, serializeSessionRecord } from "@/lib/sessionBackup";
 import { generateProjectBundle, validateProjectBundle } from "@/lib/server/projectBundleService";
 
 let tmpDir: string;
@@ -37,7 +32,6 @@ beforeEach(async () => {
   process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = path.join(tmpDir, "project-bundles");
   process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT = path.join(tmpDir, "backups");
   await fs.mkdir(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT, { recursive: true });
-  readSessionBackupPackageMock.mockReset();
 });
 
 afterEach(async () => {
@@ -80,10 +74,65 @@ function makeConfig(overrides?: Partial<ProjectBundleConfiguration>): ProjectBun
   };
 }
 
+async function writeBackupPackage(input: {
+  backupId: string;
+  createdAt: string;
+  sessionId: string;
+  source: "codex" | "windsurf" | "antigravity";
+  rootId?: string;
+}) {
+  const backupDir = path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, input.backupId);
+  await fs.mkdir(path.join(backupDir, "sessions"), { recursive: true });
+  const manifest = buildSessionBackupManifest([
+    {
+      sessionId: input.sessionId,
+      path: `sessions/${input.sessionId}.record.json`,
+      includesSourceCopy: false,
+    },
+  ]);
+  manifest.backupId = input.backupId;
+  manifest.createdAt = input.createdAt;
+  await fs.writeFile(path.join(backupDir, "manifest.json"), serializeSessionBackupManifest(manifest), "utf8");
+  await fs.writeFile(
+    path.join(backupDir, "sessions", `${input.sessionId}.record.json`),
+    serializeSessionRecord({
+      schemaVersion: "session-record/v1",
+      session: {
+        id: input.sessionId,
+        source: input.source,
+        rootId: input.rootId,
+        title: "Fixture session",
+      },
+      sourceRef: {
+        kind: "file",
+        locator: path.join(tmpDir, `${input.sessionId}.jsonl`),
+      },
+      provenance: {
+        capturedBy: "agent-storage-manager",
+        capturedAt: input.createdAt,
+      },
+      timestamps: {
+        capturedAt: input.createdAt,
+      },
+      summary: {
+        totalSteps: 0,
+        renderedEvents: 0,
+        userCount: 0,
+        assistantCount: 0,
+        thoughtCount: 0,
+        toolCount: 0,
+        commandCount: 0,
+        subagentCount: 0,
+        errorCount: 0,
+      },
+      events: [],
+    }),
+    "utf8"
+  );
+}
+
 describe("project bundle service", () => {
   it("returns a warning and unresolved reference when a selected session has no existing backup", async () => {
-    readSessionBackupPackageMock.mockRejectedValue(new Error("missing"));
-
     const result = await validateProjectBundle(makeSelection(), makeConfig());
 
     expect(result.validation.status).toBe("valid-with-warnings");
@@ -94,21 +143,12 @@ describe("project bundle service", () => {
   });
 
   it("generates a real local bundle file with the expected minimum structure", async () => {
-    await fs.mkdir(path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, "backup-001"), { recursive: true });
-    readSessionBackupPackageMock.mockResolvedValue({
-      manifest: {
-        backupId: "backup-001",
-        createdAt: "2026-04-16T10:00:00.000Z",
-      },
-      records: [
-        {
-          session: {
-            id: "session-1",
-            source: "codex",
-            rootId: "root-1",
-          },
-        },
-      ],
+    await writeBackupPackage({
+      backupId: "backup-001",
+      createdAt: "2026-04-16T10:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
     });
 
     const generated = await generateProjectBundle(makeSelection(), makeConfig());
@@ -126,23 +166,20 @@ describe("project bundle service", () => {
   });
 
   it("prefers the newest matching session backup package when multiple matches exist", async () => {
-    await fs.mkdir(path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, "backup-old"), { recursive: true });
-    await fs.mkdir(path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, "backup-new"), { recursive: true });
-    readSessionBackupPackageMock
-      .mockResolvedValueOnce({
-        manifest: {
-          backupId: "backup-old",
-          createdAt: "2026-04-16T09:00:00.000Z",
-        },
-        records: [{ session: { id: "session-1", source: "codex", rootId: "root-1" } }],
-      })
-      .mockResolvedValueOnce({
-        manifest: {
-          backupId: "backup-new",
-          createdAt: "2026-04-16T10:00:00.000Z",
-        },
-        records: [{ session: { id: "session-1", source: "codex", rootId: "root-1" } }],
-      });
+    await writeBackupPackage({
+      backupId: "backup-old",
+      createdAt: "2026-04-16T09:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+    await writeBackupPackage({
+      backupId: "backup-new",
+      createdAt: "2026-04-16T10:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
 
     const result = await validateProjectBundle(makeSelection(), makeConfig());
     const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
@@ -152,8 +189,6 @@ describe("project bundle service", () => {
   });
 
   it("blocks generation when bundle identity is structurally invalid", async () => {
-    readSessionBackupPackageMock.mockRejectedValue(new Error("missing"));
-
     await expect(
       generateProjectBundle(makeSelection(), makeConfig({ bundleName: "" }))
     ).rejects.toThrow(/structurally valid composition/i);

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -157,4 +157,25 @@ describe("project bundle route", () => {
       hint: "Use mode validate or generate.",
     });
   });
+
+  it("rejects generate mode when explicit selection or configuration is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "generate",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(validateProjectBundleMock).not.toHaveBeenCalled();
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      error: "Generate mode requires explicit selection and configuration.",
+      code: "MISSING_GENERATE_INPUT",
+      title: "Invalid request",
+      hint: "Run explicit composition first, then submit selection and configuration for generation.",
+    });
+  });
 });

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const validateProjectBundleMock = vi.hoisted(() => vi.fn());
+const generateProjectBundleMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/server/projectBundleService", () => ({
+  validateProjectBundle: (...args: unknown[]) => validateProjectBundleMock(...args),
+  generateProjectBundle: (...args: unknown[]) => generateProjectBundleMock(...args),
+}));
+
+// @ts-ignore
+import { POST } from "@/app/api/project-bundles/route";
+
+afterEach(() => {
+  validateProjectBundleMock.mockReset();
+  generateProjectBundleMock.mockReset();
+});
+
+describe("project bundle route", () => {
+  it("routes validate requests to validateProjectBundle", async () => {
+    validateProjectBundleMock.mockResolvedValue({
+      validation: { status: "valid", items: [] },
+      summary: {
+        warningCount: 0,
+        blockerCount: 0,
+        selectedCategoryCount: 2,
+        selectedSessionCount: 0,
+        resolvedReferenceCount: 2,
+        unresolvedReferenceCount: 0,
+      },
+      memberInventory: [],
+      memberReferences: [],
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "validate",
+          selection: {
+            includedCategories: {
+              sessions: false,
+              rules: true,
+            },
+          },
+          configuration: {
+            bundleName: "My bundle",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(validateProjectBundleMock).toHaveBeenCalledTimes(1);
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    const [selection, configuration] = validateProjectBundleMock.mock.calls[0]!;
+    expect(selection.includedCategories.rules).toBe(true);
+    expect(selection.includedCategories.sessions).toBe(false);
+    expect(configuration.bundleName).toBe("My bundle");
+  });
+
+  it("routes generate requests to generateProjectBundle", async () => {
+    generateProjectBundleMock.mockResolvedValue({
+      validation: { status: "valid", items: [] },
+      summary: {
+        warningCount: 0,
+        blockerCount: 0,
+        selectedCategoryCount: 1,
+        selectedSessionCount: 1,
+        resolvedReferenceCount: 1,
+        unresolvedReferenceCount: 0,
+      },
+      memberInventory: [],
+      memberReferences: [],
+      packageId: "project-bundle-1",
+      filePath: "/tmp/project-bundle-1.bundle.json",
+      bundle: {},
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "generate",
+          handoff: {
+            origin: "overview",
+            workflowType: "project-bundle",
+            projectBundleScopeHint: "overview-routed project context",
+          },
+          selection: {
+            sessionSelections: [
+              {
+                sessionId: "session-1",
+                source: "codex",
+              },
+            ],
+          },
+          configuration: {
+            bundleName: "Generated bundle",
+            notes: "  note  ",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(generateProjectBundleMock).toHaveBeenCalledTimes(1);
+    const [selection, configuration] = generateProjectBundleMock.mock.calls[0]!;
+    expect(selection.scopeHint).toBe("overview-routed project context");
+    expect(selection.sessionSelections).toHaveLength(1);
+    expect(configuration.notes).toBe("note");
+  });
+
+  it("returns a structured 400 when the service throws", async () => {
+    validateProjectBundleMock.mockRejectedValue(new Error("bundle failed"));
+
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "validate",
+          configuration: {
+            bundleName: "Broken bundle",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "bundle failed",
+      code: "PROJECT_BUNDLE_FAILED",
+      title: "Bundle validation failed",
+    });
+  });
+});

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/server/projectBundleService", () => ({
   generateProjectBundle: (...args: unknown[]) => generateProjectBundleMock(...args),
 }));
 
-// @ts-ignore
+// @ts-expect-error Next.js route module typing does not match this Vitest import pattern in tests
 import { POST } from "@/app/api/project-bundles/route";
 
 afterEach(() => {
@@ -74,7 +74,6 @@ describe("project bundle route", () => {
       memberReferences: [],
       packageId: "project-bundle-1",
       filePath: "/tmp/project-bundle-1.bundle.json",
-      bundle: {},
     });
 
     const response = await POST(

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -73,7 +73,7 @@ describe("project bundle route", () => {
       memberInventory: [],
       memberReferences: [],
       packageId: "project-bundle-1",
-      filePath: "/tmp/project-bundle-1.bundle.json",
+      filePath: `${process.env.HOME}/.agent-storage-manager/project-bundle-1.bundle.json`,
     });
 
     const response = await POST(
@@ -104,6 +104,8 @@ describe("project bundle route", () => {
 
     expect(response.status).toBe(200);
     expect(generateProjectBundleMock).toHaveBeenCalledTimes(1);
+    const json = await response.json();
+    expect(json.filePath).toBe("~/.agent-storage-manager/project-bundle-1.bundle.json");
     const [selection, configuration] = generateProjectBundleMock.mock.calls[0]!;
     expect(selection.scopeHint).toBe("overview-routed project context");
     expect(selection.sessionSelections).toHaveLength(1);

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const validateProjectBundleMock = vi.hoisted(() => vi.fn());
@@ -73,7 +74,7 @@ describe("project bundle route", () => {
       memberInventory: [],
       memberReferences: [],
       packageId: "project-bundle-1",
-      filePath: `${process.env.HOME}/.agent-storage-manager/project-bundle-1.bundle.json`,
+      filePath: `${os.homedir()}/.agent-storage-manager/project-bundle-1.bundle.json`,
     });
 
     const response = await POST(

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -129,9 +129,10 @@ describe("project bundle route", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: "bundle failed",
+      error: "Project bundle validation failed.",
       code: "PROJECT_BUNDLE_FAILED",
       title: "Bundle validation failed",
+      hint: "Review bundle selection and configuration, then retry validation.",
     });
   });
 

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -133,4 +133,28 @@ describe("project bundle route", () => {
       title: "Bundle validation failed",
     });
   });
+
+  it("rejects unknown mode values instead of silently treating them as validation", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "oops",
+          configuration: {
+            bundleName: "Broken mode",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(validateProjectBundleMock).not.toHaveBeenCalled();
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      error: "Unsupported mode: oops",
+      code: "INVALID_MODE",
+      title: "Invalid request",
+      hint: "Use mode validate or generate.",
+    });
+  });
 });

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -363,6 +363,24 @@ describe("backup handoff builders", () => {
     expect(handoff).not.toHaveProperty("migrationPreviewTargetContext");
   });
 
+  it("builds an assets project-bundle handoff with explicit refs only", () => {
+    const handoff = buildBackupHandoffFromAssets({
+      assetId: "asset-skill-global-generated",
+      subtype: "skill",
+      workflowType: "project-bundle",
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "assets",
+      workflowType: "project-bundle",
+      assetId: "asset-skill-global-generated",
+      assetSubtype: "skill",
+      projectBundleObjectRefs: ["asset-skill-global-generated"],
+      projectBundleScopeHint: "skill asset scope",
+    });
+    expect(handoff).not.toHaveProperty("migrationPreviewTargetContext");
+  });
+
   it("keeps preservation-oriented analysis backup handoff on session backup", () => {
     const handoff = buildBackupHandoffFromAnalysis({
       findingId: "finding-preserve-before-migration",
@@ -402,6 +420,24 @@ describe("backup handoff builders", () => {
     expect(handoff.subtitle).toContain("Preview migration compatibility");
   });
 
+  it("builds an analysis project-bundle handoff without auto-deciding composition", () => {
+    const handoff = buildBackupHandoffFromAnalysis({
+      findingId: "finding-conflicted-skill",
+      title: "Conflicted OpenSpec helper skill",
+      routeLabel: "Bundle project context",
+      backupWorkflowType: "project-bundle",
+    });
+
+    expect(handoff).toMatchObject({
+      origin: "analysis",
+      workflowType: "project-bundle",
+      findingId: "finding-conflicted-skill",
+      issueLabel: "Conflicted OpenSpec helper skill",
+      projectBundleObjectRefs: ["finding-conflicted-skill"],
+    });
+    expect(handoff.subtitle).toContain("Bundle project context");
+  });
+
   it("builds an overview handoff with an explicit workflow type", () => {
     const handoff = buildBackupHandoffFromOverview("import-backup");
 
@@ -438,5 +474,18 @@ describe("backup handoff builders", () => {
     expect(handoff).not.toHaveProperty("migrationPreviewTargetContext");
     expect(handoff).not.toHaveProperty("migrationPreviewScope");
     expect(handoff.subtitle).toContain("migration preview workflow");
+  });
+
+  it("builds an overview handoff for project bundle without inventing member refs", () => {
+    const handoff = buildBackupHandoffFromOverview("project-bundle");
+
+    expect(handoff).toMatchObject({
+      origin: "overview",
+      workflowType: "project-bundle",
+      projectBundleScopeHint: "overview-routed project context",
+    });
+    expect(handoff).not.toHaveProperty("sessions");
+    expect(handoff).not.toHaveProperty("projectBundleObjectRefs");
+    expect(handoff.subtitle).toContain("project bundle workflow");
   });
 });


### PR DESCRIPTION
## Summary
- add bounded project-bundle workflow to Backup / Migration
- generate local project-bundle/v1 files with manifest, metadata, member inventory/references, and validation summary
- reuse existing session backup packages for session members and preserve missing-package sessions as unresolved warnings
- add routed handoff from overview, assets, and analysis without allowing implicit composition or direct generation

## Validation
- pnpm test -- tests/backupMigration.test.ts tests/backupMigrationFoundation.test.tsx tests/projectShellClient.test.ts
- pnpm exec tsc --noEmit
- OPENSPEC_TELEMETRY=0 openspec validate project-bundle-foundation --strict