### PR TITLE
spec: propose project bundle hardening

### DIFF
--- a/openspec/changes/project-bundle-hardening/.openspec.yaml
+++ b/openspec/changes/project-bundle-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/project-bundle-hardening/design.md
+++ b/openspec/changes/project-bundle-hardening/design.md
@@ -1,0 +1,124 @@
+## Context
+
+`project-bundle` is now part of the accepted `Backup / Migration` workflow set.
+It validates an explicit composition, confirms generation, and writes a local
+`project-bundle/v1` JSON file. Review follow-up #67 identified hardening work
+around API bypasses, output-root validation, missing package handling, path
+privacy, deterministic session backup reuse, and coverage gaps.
+
+This design keeps the existing v1 product boundary intact:
+
+- local-only bundle generation
+- explicit composition before generation
+- reuse of existing session backup packages
+- no restore, migration apply, cloud sync, or runtime continuation
+- no non-core member toggles
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `/api/project-bundles` reject malformed modes and generation requests
+  that skip explicit composition/configuration.
+- Represent validation failures and warnings at the correct level: global
+  blockers for structural/output-root failures, member warnings for recoverable
+  object issues, and unresolved session references for missing backup packages.
+- Keep client-facing responses and UI display free of raw absolute local paths
+  and raw exception text.
+- Ensure generation responses return only the summary, package identity,
+  validation summary, inventory, and member references needed by the UI.
+- Make session backup reference lookup deterministic by selecting the newest
+  matching backup package for each explicit session selection.
+- Add focused tests that exercise service, API, and UI behavior around these
+  hardening guarantees.
+
+**Non-Goals:**
+
+- No new bundle member categories.
+- No source-copy, cache, index, app-state, token, or secret inclusion toggles.
+- No project bundle import/restore flow.
+- No migration apply or cross-machine transfer behavior.
+- No privacy-redaction feature line beyond avoiding accidental local path or
+  exception disclosure in this workflow.
+- No replacement of session backup package format or session backup generation.
+
+## Decisions
+
+### 1. Treat API hardening as workflow boundary enforcement
+
+`validate` can continue to derive a default selection when the UI is browsing or
+previewing bundle composition. `generate` MUST require explicit `selection` and
+`configuration` in the request body. This prevents API callers from bypassing
+the composition/configuration workflow by invoking generation with defaults.
+
+Alternative considered: require explicit inputs for both `validate` and
+`generate`. That is stricter but would make the interactive UI more brittle
+because validation is also used to explain the starting composition. The
+security-relevant boundary is generation.
+
+### 2. Use structured errors instead of exception-shaped errors
+
+The API should return stable `code`, `title`, and `hint` fields for invalid JSON,
+unknown modes, missing generation inputs, validation failure, or generation
+failure. It should not return raw thrown messages or filesystem paths. Service
+validation items should likewise use product terms such as "project bundle
+output root is not writable" rather than raw OS exceptions.
+
+Alternative considered: expose raw service messages for faster debugging. That
+is inappropriate for this local-first app because paths, usernames, ports, and
+diagnostics can be sensitive.
+
+### 3. Keep output-root failures global
+
+Output-root readiness is a structural precondition for generation, not a
+specific member category problem. Validation should model it as a global blocker
+so the UI does not imply that a category such as `package-metadata` or
+`sessions` is at fault.
+
+Alternative considered: attach output failures to package metadata because the
+bundle file includes project/package metadata. That hides the real remediation:
+choose or fix a writable bundle output location.
+
+### 4. Preserve missing session backup intent as an unresolved reference
+
+When a selected session lacks an existing backup package, validation should warn
+and generated metadata should preserve a `missing-package`/unresolved member
+reference. The bundle must not silently omit the session and must not generate a
+new session backup payload as a side effect.
+
+Alternative considered: block generation when any selected session lacks a
+backup package. That is safer but conflicts with the accepted foundation
+decision that this is a warning-level composition issue in v1.
+
+### 5. Return summary-shaped generation responses
+
+The generated bundle file can contain the full bundle document, but the API
+response should return only the fields needed for result display and inspection:
+package identity, display-safe file location, timestamp, validation summary,
+member inventory, member references, and counts. The UI does not need the full
+bundle document echoed back after writing.
+
+Alternative considered: return the full document for easier debugging. That
+increases response size and risks leaking future sensitive metadata.
+
+### 6. Select newest matching session backup package deterministically
+
+Session backup reuse should match by explicit session identity (`source`,
+`sessionId`, and optional `rootId`) and choose the newest matching manifest by
+creation timestamp. Lookup should avoid reading every backup payload when the
+manifest already cannot match the requested session IDs.
+
+Alternative considered: use first filesystem traversal match. That is
+non-deterministic and can select stale backup packages.
+
+## Risks / Trade-offs
+
+- **Existing behavior may already satisfy some hardening items** -> Keep tests
+  as the acceptance mechanism and avoid no-op rewrites.
+- **Path redaction can hide useful debugging context** -> Use display-safe paths
+  in API/UI while preserving local file writes and package IDs for inspection.
+- **Filesystem permission behavior differs by OS** -> Unit tests should mock
+  filesystem conditions rather than relying only on host permissions.
+- **Session backup stores can become large** -> This slice improves deterministic
+  matching and avoids obvious unnecessary reads, but deeper indexing can remain a
+  future performance improvement if real usage warrants it.

--- a/openspec/changes/project-bundle-hardening/proposal.md
+++ b/openspec/changes/project-bundle-hardening/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+`Project Bundle` now generates real local bundle files, so its validation,
+output, and API boundaries need to be hardened before additional bundle
+features build on top of it. The current follow-up line comes from review
+feedback on the shipped foundation and should stay bounded to correctness,
+privacy-safe display, and deterministic behavior rather than expanding bundle
+scope.
+
+## What Changes
+
+- Harden `/api/project-bundles` request handling so unknown modes and missing
+  explicit generate inputs return structured `400` responses.
+- Keep generation gated by explicit composition and configuration; API callers
+  must not bypass the workflow by relying on implicit defaults for `generate`.
+- Strengthen project bundle validation so global blockers, warning-level
+  member issues, missing session backup packages, and output-root problems are
+  represented consistently.
+- Ensure bundle output responses and UI-facing result data avoid raw absolute
+  local path exposure, raw exception details, or misleading filesystem
+  diagnostics.
+- Make session backup package lookup deterministic and reasonably scalable for
+  selected sessions by preferring the newest matching package and avoiding
+  unnecessary payload work.
+- Add focused tests for service, API, and UI/result behavior around the
+  hardening cases.
+- Do not add restore, migration apply, cloud sync, privacy redaction,
+  non-core member toggles, or new project bundle product scope.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `backup-migration`: Adds hardening requirements for `project-bundle`
+  validation, generation API boundaries, safe output display, deterministic
+  session backup reuse, and structured error behavior.
+
+## Impact
+
+- `src/app/api/project-bundles/route.ts`
+- `src/lib/server/projectBundleService.ts`
+- `src/lib/server/paths.ts` if output-root validation needs path handling
+  support
+- `src/lib/backupMigration.ts`
+- `src/components/BackupMigrationFoundation.tsx`
+- Tests for project bundle model, service, route, and rendered result states
+- `docs/viewer/backup-migration-foundation-qa-prompt.md` if QA coverage needs
+  hardening-specific checks
+- `README.md` / `CHANGELOG.md` only if user-facing behavior or shipped history
+  changes

--- a/openspec/changes/project-bundle-hardening/specs/backup-migration/spec.md
+++ b/openspec/changes/project-bundle-hardening/specs/backup-migration/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Project bundle API SHALL enforce explicit generation boundaries
+The system SHALL reject project bundle API requests that would bypass explicit composition, configuration, or known operation modes.
+
+#### Scenario: Unknown project bundle mode is rejected
+- **WHEN** a caller posts to `/api/project-bundles` with a `mode` other than `validate` or `generate`
+- **THEN** the API returns a structured `400` response
+- **AND** the response includes a stable error code and remediation hint
+- **AND** no validation or generation side effect is performed
+
+#### Scenario: Generate requires explicit selection and configuration
+- **WHEN** a caller posts to `/api/project-bundles` with `mode` set to `generate` but omits explicit `selection` or `configuration`
+- **THEN** the API returns a structured `400` response
+- **AND** the response explains that generation requires prior explicit composition
+- **AND** the system does not create a project bundle file from default selection values
+
+#### Scenario: Validate can explain starting composition
+- **WHEN** the workflow asks the API to validate the current project bundle composition before generation
+- **THEN** the API may derive the bounded default composition used by the UI
+- **AND** the response remains a validation result only
+- **AND** no project bundle file is written
+
+### Requirement: Project bundle validation SHALL distinguish global blockers from member warnings
+The system SHALL classify project bundle validation issues at the level where the user can remediate them.
+
+#### Scenario: Output root failure is a global blocker
+- **WHEN** the project bundle output root is unavailable, unwritable, or resolves to an invalid filesystem target
+- **THEN** validation returns an invalid result with a global blocking item
+- **AND** the item identifies the output destination as the failing precondition
+- **AND** it is not attached to a specific member category or shown as member inventory status
+
+#### Scenario: Missing session backup package is warning-level
+- **WHEN** a selected session does not have an existing matching session backup package
+- **THEN** validation returns a warning-level item for that session
+- **AND** confirmation remains available if no blocking items exist
+- **AND** the warning explains that the bundle will preserve an unresolved member reference rather than generate a session backup payload
+
+#### Scenario: Empty or structurally impossible composition blocks generation
+- **WHEN** project bundle composition has no selected member categories, an empty bundle name, unreadable package metadata, or another structural precondition failure
+- **THEN** validation returns an invalid result
+- **AND** generation is blocked until the user repairs the composition or environment
+
+### Requirement: Project bundle generation SHALL preserve unresolved member intent without leaking local details
+The system SHALL generate project bundle summaries that preserve selected member intent while keeping client-facing output safe.
+
+#### Scenario: Missing session package becomes unresolved reference
+- **WHEN** the user confirms generation with a selected session that lacks an existing backup package warning
+- **THEN** the generated bundle metadata includes an explicit unresolved or `missing-package` member reference for that session
+- **AND** the system does not silently omit that selected session
+- **AND** the system does not create an ad-hoc session backup package as a side effect
+
+#### Scenario: Generation response is summary-shaped
+- **WHEN** project bundle generation succeeds
+- **THEN** the API response includes package identity, display-safe file location, timestamp, validation summary, member inventory, member references, and relevant counts
+- **AND** it does not echo the full bundle document when summary data is sufficient for the result UI
+
+#### Scenario: Client-facing paths are display-safe
+- **WHEN** validation or generation returns output location or diagnostic information to the UI
+- **THEN** local filesystem paths are redacted or converted to display-safe paths
+- **AND** raw exception messages, usernames, temporary paths, or host-specific diagnostic details are not exposed to the client
+
+### Requirement: Project bundle session backup reuse SHALL be deterministic
+The system SHALL reuse existing session backup packages deterministically for explicit project bundle session members.
+
+#### Scenario: Newest matching backup package is selected
+- **WHEN** multiple existing session backup packages match the same selected session identity
+- **THEN** the project bundle references the newest matching backup package by creation timestamp
+- **AND** the result remains stable regardless of filesystem traversal order
+
+#### Scenario: Lookup avoids unnecessary payload reads
+- **WHEN** the session backup store contains packages unrelated to the selected sessions
+- **THEN** lookup filters candidates by manifest metadata before reading session payload records when possible
+- **AND** missing or malformed unrelated packages do not fail the project bundle validation
+
+### Requirement: Project bundle hardening SHALL be covered by focused tests
+The system SHALL include tests that lock the project bundle hardening boundaries.
+
+#### Scenario: API boundary tests cover invalid requests
+- **WHEN** tests exercise unknown mode and generate-without-explicit-input requests
+- **THEN** they assert structured `400` responses and no file creation behavior
+
+#### Scenario: Service tests cover validation and output behavior
+- **WHEN** tests exercise output-root failures, missing package warnings, newest backup package selection, and malformed unrelated packages
+- **THEN** they assert global blockers, warning-level unresolved references, deterministic reuse, and safe failure behavior
+
+#### Scenario: UI tests cover safe result display
+- **WHEN** tests render project bundle validation and generation results
+- **THEN** they assert warning/blocker visibility, unresolved references, and display-safe output paths without raw local path leakage

--- a/openspec/changes/project-bundle-hardening/specs/backup-migration/spec.md
+++ b/openspec/changes/project-bundle-hardening/specs/backup-migration/spec.md
@@ -21,34 +21,8 @@ The system SHALL reject project bundle API requests that would bypass explicit c
 - **AND** the response remains a validation result only
 - **AND** no project bundle file is written
 
-### Requirement: Project bundle validation SHALL distinguish global blockers from member warnings
-The system SHALL classify project bundle validation issues at the level where the user can remediate them.
-
-#### Scenario: Output root failure is a global blocker
-- **WHEN** the project bundle output root is unavailable, unwritable, or resolves to an invalid filesystem target
-- **THEN** validation returns an invalid result with a global blocking item
-- **AND** the item identifies the output destination as the failing precondition
-- **AND** it is not attached to a specific member category or shown as member inventory status
-
-#### Scenario: Missing session backup package is warning-level
-- **WHEN** a selected session does not have an existing matching session backup package
-- **THEN** validation returns a warning-level item for that session
-- **AND** confirmation remains available if no blocking items exist
-- **AND** the warning explains that the bundle will preserve an unresolved member reference rather than generate a session backup payload
-
-#### Scenario: Empty or structurally impossible composition blocks generation
-- **WHEN** project bundle composition has no selected member categories, an empty bundle name, unreadable package metadata, or another structural precondition failure
-- **THEN** validation returns an invalid result
-- **AND** generation is blocked until the user repairs the composition or environment
-
-### Requirement: Project bundle generation SHALL preserve unresolved member intent without leaking local details
-The system SHALL generate project bundle summaries that preserve selected member intent while keeping client-facing output safe.
-
-#### Scenario: Missing session package becomes unresolved reference
-- **WHEN** the user confirms generation with a selected session that lacks an existing backup package warning
-- **THEN** the generated bundle metadata includes an explicit unresolved or `missing-package` member reference for that session
-- **AND** the system does not silently omit that selected session
-- **AND** the system does not create an ad-hoc session backup package as a side effect
+### Requirement: Project bundle generation API SHALL return summary-shaped safe output
+The system SHALL return project bundle generation responses that are sufficient for result display without exposing unnecessary bundle document content or raw local diagnostics.
 
 #### Scenario: Generation response is summary-shaped
 - **WHEN** project bundle generation succeeds
@@ -73,17 +47,80 @@ The system SHALL reuse existing session backup packages deterministically for ex
 - **THEN** lookup filters candidates by manifest metadata before reading session payload records when possible
 - **AND** missing or malformed unrelated packages do not fail the project bundle validation
 
-### Requirement: Project bundle hardening SHALL be covered by focused tests
-The system SHALL include tests that lock the project bundle hardening boundaries.
+## MODIFIED Requirements
 
-#### Scenario: API boundary tests cover invalid requests
-- **WHEN** tests exercise unknown mode and generate-without-explicit-input requests
-- **THEN** they assert structured `400` responses and no file creation behavior
+### Requirement: Project bundle SHALL require explicit composition before generation
+The system SHALL require explicit composition — selection and configuration — and validation before generating any bundle package file.
 
-#### Scenario: Service tests cover validation and output behavior
-- **WHEN** tests exercise output-root failures, missing package warnings, newest backup package selection, and malformed unrelated packages
-- **THEN** they assert global blockers, warning-level unresolved references, deterministic reuse, and safe failure behavior
+#### Scenario: Missing selection blocks generation
+- **WHEN** the user starts the project bundle workflow without selecting any members
+- **THEN** the workflow remains in selection state
+- **AND** it explains that member selection is required before validation
 
-#### Scenario: UI tests cover safe result display
-- **WHEN** tests render project bundle validation and generation results
-- **THEN** they assert warning/blocker visibility, unresolved references, and display-safe output paths without raw local path leakage
+#### Scenario: Validation must occur before confirmation
+- **WHEN** the user completes selection and configuration
+- **THEN** the workflow runs validation before offering confirmation
+- **AND** the user can inspect intended bundle scope, included members, excluded members, warning state, blocker state, and validation summary before proceeding
+
+#### Scenario: Direct generation is not allowed
+- **WHEN** any page, routed entry, or API caller attempts to bypass explicit composition and validation
+- **THEN** the workflow or API does not proceed to execution or file generation
+- **AND** it returns to the appropriate composition or validation step, or returns a structured invalid-request response
+
+### Requirement: Project bundle sessions SHALL reuse session backup package semantics
+The system SHALL reference existing `session backup package` objects for sessions included in a project bundle instead of redefining canonical session payload or creating a second session archive format.
+
+#### Scenario: Session members reference session backup packages
+- **WHEN** selected sessions are included in a project bundle
+- **THEN** the bundle references existing session backup package artifacts for those sessions
+- **AND** the bundle does not redefine or duplicate the canonical session payload format
+
+#### Scenario: Sessions without existing backup produce validation warning
+- **WHEN** a selected session does not have an existing session backup package
+- **THEN** the validation step produces a warning identifying the session
+- **AND** the warning does not block the bundle workflow unless the session reference makes the bundle structurally invalid
+- **AND** the warning explains that generation will preserve an unresolved member reference rather than generate a session backup payload
+
+#### Scenario: Sessions without existing backup remain unresolved references
+- **WHEN** bundle generation proceeds after validation warned that a selected session lacks an existing session backup package
+- **THEN** the generated bundle preserves that session as an unresolved or missing-package member reference with a lightweight metadata snapshot
+- **AND** the bundle does not silently omit the session
+- **AND** the workflow does not generate an ad hoc session backup payload during project bundle execution
+
+### Requirement: Project bundle validation SHALL use permissive severity
+The system SHALL classify validation issues as warnings or blockers using a permissive severity strategy.
+
+#### Scenario: Warning-level issues do not block generation
+- **WHEN** validation finds missing or incomplete provenance summary, uncertain subtype classification, stale member state, or missing member references that leave the bundle structurally valid
+- **THEN** these issues are classified as warnings
+- **AND** warnings remain visible through confirmation but do not prevent proceeding
+
+#### Scenario: Blocker-level issues prevent generation
+- **WHEN** validation finds that the bundle manifest cannot be formed legally, required package identity or metadata is missing to the point that no valid bundle can be generated, no valid bundle output can be written, or workflow input is invalid to the point that no legal bundle can be created
+- **THEN** these issues are classified as blockers
+- **AND** the workflow does not offer execution until all blockers are resolved
+
+#### Scenario: Output root failure is a global blocker
+- **WHEN** the project bundle output root is unavailable, unwritable, or resolves to an invalid filesystem target
+- **THEN** validation returns an invalid result with a global blocking item
+- **AND** the item identifies the output destination as the failing precondition
+- **AND** it is not attached to a specific member category or shown as member inventory status
+
+#### Scenario: Empty or structurally impossible composition blocks generation
+- **WHEN** project bundle composition has no selected member categories, an empty bundle name, unreadable package metadata, or another structural precondition failure
+- **THEN** validation returns an invalid result
+- **AND** generation is blocked until the user repairs the composition or environment
+
+### Requirement: Project bundle result SHALL expose package identity and outcome
+The system SHALL present a result state after bundle generation with package identity, generation outcome, and inspection routes.
+
+#### Scenario: Successful generation shows result
+- **WHEN** project bundle generation completes successfully
+- **THEN** the result state shows bundle package identity, display-safe file location, generation timestamp, member count, warning count, and validation summary
+- **AND** the user can inspect bundle contents
+
+#### Scenario: Failed generation shows actionable diagnostics
+- **WHEN** project bundle generation fails
+- **THEN** the result state shows the failure reason with actionable diagnostics
+- **AND** it offers routes to inspect or repair the blocking issue
+- **AND** the result does not expose raw exception messages, usernames, temporary paths, or host-specific filesystem diagnostics

--- a/openspec/changes/project-bundle-hardening/tasks.md
+++ b/openspec/changes/project-bundle-hardening/tasks.md
@@ -1,0 +1,47 @@
+## 1. API Boundary Hardening
+
+- [ ] 1.1 Add or confirm structured `400` handling for invalid JSON and unsupported `/api/project-bundles` modes.
+- [ ] 1.2 Require explicit `selection` and `configuration` for `mode: "generate"` and prevent default-selection generation bypass.
+- [ ] 1.3 Ensure `mode: "validate"` remains side-effect free and does not write bundle files.
+- [ ] 1.4 Add route-level tests for invalid mode, missing generate input, validate-only behavior, and structured error payloads.
+
+## 2. Validation Severity and Output Root Handling
+
+- [ ] 2.1 Harden project bundle output-root readiness checks for missing roots, existing directories, invalid targets, and unwritable ancestors.
+- [ ] 2.2 Represent output-root failures as global blocking validation items, not member-category inventory status.
+- [ ] 2.3 Preserve warning-level handling for selected sessions that lack existing backup packages.
+- [ ] 2.4 Ensure structural preconditions such as empty composition, empty bundle name, and unreadable package metadata block generation.
+- [ ] 2.5 Add service tests for output-root blockers, structural blockers, missing-package warnings, and validation summary counts.
+
+## 3. Safe Generation Result Shape
+
+- [ ] 3.1 Redact or convert client-facing bundle file locations to display-safe paths.
+- [ ] 3.2 Avoid returning raw exception details, usernames, temporary paths, or host-specific filesystem diagnostics to API clients.
+- [ ] 3.3 Return a summary-shaped generation response instead of echoing the full bundle document when result UI fields are sufficient.
+- [ ] 3.4 Preserve `missing-package` or unresolved member references in generated metadata without silently omitting selected sessions.
+- [ ] 3.5 Add tests for generation response shape, path redaction, unresolved references, and no raw path leakage in rendered results.
+
+## 4. Session Backup Reuse Determinism
+
+- [ ] 4.1 Match existing backup packages by explicit session identity: `source`, `sessionId`, and optional `rootId`.
+- [ ] 4.2 Select the newest matching backup package by manifest creation timestamp when multiple packages match.
+- [ ] 4.3 Avoid reading unrelated backup payload records when manifest metadata already excludes a package from the requested sessions.
+- [ ] 4.4 Treat malformed unrelated backup packages as ignored candidates rather than project bundle validation failures.
+- [ ] 4.5 Add tests for newest-match selection, traversal-order stability, unrelated package filtering, and malformed unrelated packages.
+
+## 5. UI and QA Coverage
+
+- [ ] 5.1 Ensure `BackupMigrationFoundation` renders project bundle global blockers, warning-level member issues, unresolved references, and display-safe paths clearly.
+- [ ] 5.2 Add component tests for project bundle validation/result hardening states.
+- [ ] 5.3 Update `docs/viewer/backup-migration-foundation-qa-prompt.md` with project bundle hardening smoke checks if browser QA should cover them.
+- [ ] 5.4 Run browser QA or document why unit/service/API coverage is sufficient for this non-visual hardening slice.
+
+## 6. Validation and Documentation
+
+- [ ] 6.1 Run `pnpm test`.
+- [ ] 6.2 Run `pnpm exec tsc --noEmit`.
+- [ ] 6.3 Run `pnpm build`.
+- [ ] 6.4 Run `OPENSPEC_TELEMETRY=0 openspec validate project-bundle-hardening --strict`.
+- [ ] 6.5 Update `README.md` only if user-facing project bundle behavior or prerequisites changed.
+- [ ] 6.6 Update `CHANGELOG.md` under `## Unreleased` for shipped hardening behavior.
+- [ ] 6.7 Add an issue comment to #67 summarizing the selected hardening scope and PR link when implementation begins.


### PR DESCRIPTION
## Summary
- propose bounded Project Bundle hardening scope for issue #67
- add OpenSpec proposal, design, delta spec, and tasks for API boundaries, validation severity, safe output display, deterministic session-backup reuse, and tests

## Validation
- OPENSPEC_TELEMETRY=0 openspec validate project-bundle-hardening --strict

## Scope
- no restore/apply/cloud behavior
- no new bundle member categories
- no privacy-redaction feature line beyond avoiding local path/exception leakage in this workflow

Closes follow-up planning for #67 once implemented and archived.