### PR TITLE
feat: harden project bundle validation and API boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-04-18` — Project bundle hardening
+  - Hardened `/api/project-bundles` so generation requires explicit selection/configuration, invalid modes return structured errors, and generate responses expose summary-shaped display data only
+  - Strengthened project bundle validation for global output-root blockers, structural blockers, missing-package warnings, safe diagnostics, and deterministic newest matching session backup reuse
+  - Updated result rendering and QA coverage so unresolved references and display-safe bundle locations remain visible without raw local path leakage
+
 - `2026-04-18` — Project Overview governance foundation
   - Replaced the static `Project Overview` cards with a project-scoped governance module spine for context snapshot, in-effect assets, recent sessions, attention items, and route-first quick actions
   - Added a local Overview summary model that derives compact cues from existing Sessions, Assets, Analysis, and Backup / Migration foundation data without fabricating missing provider evidence

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - bulk session backup requires explicit session selection, validates each selected session independently, and fans out through the existing single-session backup execution path
   - bulk results show aggregate status plus per-session detail, while recent operations record one compact batch entry instead of one entry per session
   - migration preview requires explicit source context, target context, and bounded scope, and ends at preview-only validation/result states without migration apply or bundle generation
-  - project bundle requires explicit composition and validation before generation, writes a real local `project-bundle/v1` file, and reuses existing session backup packages instead of inventing a second session archive format
+  - project bundle requires explicit composition and validation before generation, writes a real local `project-bundle/v1` file, shows display-safe bundle locations, preserves missing session packages as unresolved references, and reuses existing session backup packages instead of inventing a second session archive format
   - the foundation still does not implement migration apply, restore/apply for project bundles, vendor-runtime reopen, or cloud sync
 
 For detailed view semantics and cross-source alignment notes, see `docs/viewer/trajectory-view.md`.

--- a/docs/viewer/backup-migration-foundation-qa-prompt.md
+++ b/docs/viewer/backup-migration-foundation-qa-prompt.md
@@ -158,11 +158,14 @@ Project bundle workflow checks:
 7. Confirm warnings remain visible through confirmation and do not silently remove the selected session.
 8. Execute generation and confirm the result shows:
    - package identity
-   - local file path
+   - display-safe file location
    - member count
    - validation summary
    - member inventory / references
-9. Confirm result copy does not promise:
+9. Confirm result display does not expose raw absolute local paths, usernames, temporary directories, or exception text.
+10. Confirm unresolved or `missing-package` session references remain visible in result metadata instead of being silently omitted.
+11. If an output-root failure can be simulated, confirm it appears as a global blocking validation item and not as a member-category inventory failure.
+12. Confirm result copy does not promise:
    - restore/apply
    - vendor-runtime reopen
    - cloud sync

--- a/openspec/changes/project-bundle-hardening/tasks.md
+++ b/openspec/changes/project-bundle-hardening/tasks.md
@@ -1,47 +1,47 @@
 ## 1. API Boundary Hardening
 
-- [ ] 1.1 Add or confirm structured `400` handling for invalid JSON and unsupported `/api/project-bundles` modes.
-- [ ] 1.2 Require explicit `selection` and `configuration` for `mode: "generate"` and prevent default-selection generation bypass.
-- [ ] 1.3 Ensure `mode: "validate"` remains side-effect free and does not write bundle files.
-- [ ] 1.4 Add route-level tests for invalid mode, missing generate input, validate-only behavior, and structured error payloads.
+- [x] 1.1 Add or confirm structured `400` handling for invalid JSON and unsupported `/api/project-bundles` modes.
+- [x] 1.2 Require explicit `selection` and `configuration` for `mode: "generate"` and prevent default-selection generation bypass.
+- [x] 1.3 Ensure `mode: "validate"` remains side-effect free and does not write bundle files.
+- [x] 1.4 Add route-level tests for invalid mode, missing generate input, validate-only behavior, and structured error payloads.
 
 ## 2. Validation Severity and Output Root Handling
 
-- [ ] 2.1 Harden project bundle output-root readiness checks for missing roots, existing directories, invalid targets, and unwritable ancestors.
-- [ ] 2.2 Represent output-root failures as global blocking validation items, not member-category inventory status.
-- [ ] 2.3 Preserve warning-level handling for selected sessions that lack existing backup packages.
-- [ ] 2.4 Ensure structural preconditions such as empty composition, empty bundle name, and unreadable package metadata block generation.
-- [ ] 2.5 Add service tests for output-root blockers, structural blockers, missing-package warnings, and validation summary counts.
+- [x] 2.1 Harden project bundle output-root readiness checks for missing roots, existing directories, invalid targets, and unwritable ancestors.
+- [x] 2.2 Represent output-root failures as global blocking validation items, not member-category inventory status.
+- [x] 2.3 Preserve warning-level handling for selected sessions that lack existing backup packages.
+- [x] 2.4 Ensure structural preconditions such as empty composition, empty bundle name, and unreadable package metadata block generation.
+- [x] 2.5 Add service tests for output-root blockers, structural blockers, missing-package warnings, and validation summary counts.
 
 ## 3. Safe Generation Result Shape
 
-- [ ] 3.1 Redact or convert client-facing bundle file locations to display-safe paths.
-- [ ] 3.2 Avoid returning raw exception details, usernames, temporary paths, or host-specific filesystem diagnostics to API clients.
-- [ ] 3.3 Return a summary-shaped generation response instead of echoing the full bundle document when result UI fields are sufficient.
-- [ ] 3.4 Preserve `missing-package` or unresolved member references in generated metadata without silently omitting selected sessions.
-- [ ] 3.5 Add tests for generation response shape, path redaction, unresolved references, and no raw path leakage in rendered results.
+- [x] 3.1 Redact or convert client-facing bundle file locations to display-safe paths.
+- [x] 3.2 Avoid returning raw exception details, usernames, temporary paths, or host-specific filesystem diagnostics to API clients.
+- [x] 3.3 Return a summary-shaped generation response instead of echoing the full bundle document when result UI fields are sufficient.
+- [x] 3.4 Preserve `missing-package` or unresolved member references in generated metadata without silently omitting selected sessions.
+- [x] 3.5 Add tests for generation response shape, path redaction, unresolved references, and no raw path leakage in rendered results.
 
 ## 4. Session Backup Reuse Determinism
 
-- [ ] 4.1 Match existing backup packages by explicit session identity: `source`, `sessionId`, and optional `rootId`.
-- [ ] 4.2 Select the newest matching backup package by manifest creation timestamp when multiple packages match.
-- [ ] 4.3 Avoid reading unrelated backup payload records when manifest metadata already excludes a package from the requested sessions.
-- [ ] 4.4 Treat malformed unrelated backup packages as ignored candidates rather than project bundle validation failures.
-- [ ] 4.5 Add tests for newest-match selection, traversal-order stability, unrelated package filtering, and malformed unrelated packages.
+- [x] 4.1 Match existing backup packages by explicit session identity: `source`, `sessionId`, and optional `rootId`.
+- [x] 4.2 Select the newest matching backup package by manifest creation timestamp when multiple packages match.
+- [x] 4.3 Avoid reading unrelated backup payload records when manifest metadata already excludes a package from the requested sessions.
+- [x] 4.4 Treat malformed unrelated backup packages as ignored candidates rather than project bundle validation failures.
+- [x] 4.5 Add tests for newest-match selection, traversal-order stability, unrelated package filtering, and malformed unrelated packages.
 
 ## 5. UI and QA Coverage
 
-- [ ] 5.1 Ensure `BackupMigrationFoundation` renders project bundle global blockers, warning-level member issues, unresolved references, and display-safe paths clearly.
-- [ ] 5.2 Add component tests for project bundle validation/result hardening states.
-- [ ] 5.3 Update `docs/viewer/backup-migration-foundation-qa-prompt.md` with project bundle hardening smoke checks if browser QA should cover them.
-- [ ] 5.4 Run browser QA or document why unit/service/API coverage is sufficient for this non-visual hardening slice.
+- [x] 5.1 Ensure `BackupMigrationFoundation` renders project bundle global blockers, warning-level member issues, unresolved references, and display-safe paths clearly.
+- [x] 5.2 Add component tests for project bundle validation/result hardening states.
+- [x] 5.3 Update `docs/viewer/backup-migration-foundation-qa-prompt.md` with project bundle hardening smoke checks if browser QA should cover them.
+- [x] 5.4 Run browser QA or document why unit/service/API coverage is sufficient for this non-visual hardening slice.
 
 ## 6. Validation and Documentation
 
-- [ ] 6.1 Run `pnpm test`.
-- [ ] 6.2 Run `pnpm exec tsc --noEmit`.
-- [ ] 6.3 Run `pnpm build`.
-- [ ] 6.4 Run `OPENSPEC_TELEMETRY=0 openspec validate project-bundle-hardening --strict`.
-- [ ] 6.5 Update `README.md` only if user-facing project bundle behavior or prerequisites changed.
-- [ ] 6.6 Update `CHANGELOG.md` under `## Unreleased` for shipped hardening behavior.
-- [ ] 6.7 Add an issue comment to #67 summarizing the selected hardening scope and PR link when implementation begins.
+- [x] 6.1 Run `pnpm test`.
+- [x] 6.2 Run `pnpm exec tsc --noEmit`.
+- [x] 6.3 Run `pnpm build`.
+- [x] 6.4 Run `OPENSPEC_TELEMETRY=0 openspec validate project-bundle-hardening --strict`.
+- [x] 6.5 Update `README.md` only if user-facing project bundle behavior or prerequisites changed.
+- [x] 6.6 Update `CHANGELOG.md` under `## Unreleased` for shipped hardening behavior.
+- [x] 6.7 Add an issue comment to #67 summarizing the selected hardening scope and PR link when implementation begins.

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -57,6 +57,7 @@ function hasExplicitComposition(selection: ProjectBundleRequestBody["selection"]
 
   return PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.every((category) =>
     Object.prototype.hasOwnProperty.call(selection.includedCategories, category)
+      && typeof selection.includedCategories?.[category] === "boolean"
   );
 }
 
@@ -103,10 +104,12 @@ export async function POST(req: Request) {
   const configuration = normalizeConfiguration(body.configuration);
   const selection = createDefaultProjectBundleSelection(body.handoff ?? null, body.selection?.sessionSelections ?? []);
 
-  selection.includedCategories = {
-    ...selection.includedCategories,
-    ...(body.selection?.includedCategories ?? {}),
-  };
+  for (const category of PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES) {
+    const explicitValue = body.selection?.includedCategories?.[category];
+    if (typeof explicitValue === "boolean") {
+      selection.includedCategories[category] = explicitValue;
+    }
+  }
   selection.objectRefs = Array.from(new Set((body.selection?.objectRefs ?? selection.objectRefs).map((item) => item.trim()).filter(Boolean)));
   selection.originCue = body.selection?.originCue?.trim() || selection.originCue;
   selection.scopeHint = body.selection?.scopeHint?.trim() || selection.scopeHint;

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -55,7 +55,7 @@ function hasExplicitComposition(selection: ProjectBundleRequestBody["selection"]
     return false;
   }
 
-  return PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.some((category) =>
+  return PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.every((category) =>
     Object.prototype.hasOwnProperty.call(selection.includedCategories, category)
   );
 }

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -44,7 +44,14 @@ function toDisplaySafeBundlePath(filePath: string): string {
     : normalized;
 
   if (!homeRelative.startsWith("~")) {
-    return `project-bundles/${path.basename(normalized)}`;
+    const fileName = path.posix.basename(normalized);
+    const parentName = path.posix.basename(path.posix.dirname(normalized));
+
+    if (parentName && parentName !== ".") {
+      return `${parentName}/${fileName}`;
+    }
+
+    return fileName;
   }
 
   return homeRelative;

--- a/src/app/api/project-bundles/route.ts
+++ b/src/app/api/project-bundles/route.ts
@@ -1,8 +1,10 @@
 import os from "node:os";
+import path from "node:path";
 
 import { NextResponse } from "next/server";
 
 import {
+  PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES,
   createDefaultProjectBundleSelection,
   type BackupMigrationHandoff,
   type BackupSessionSelection,
@@ -34,10 +36,28 @@ function normalizeConfiguration(input?: ProjectBundleConfiguration | null): Proj
   };
 }
 
-function redactDisplayPath(filePath: string): string {
-  return filePath
-    .replace(os.homedir(), "~")
-    .replace(/\\/g, "/");
+function toDisplaySafeBundlePath(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const normalizedHome = os.homedir().replace(/\\/g, "/");
+  const homeRelative = normalized === normalizedHome || normalized.startsWith(`${normalizedHome}/`)
+    ? normalized.replace(normalizedHome, "~")
+    : normalized;
+
+  if (!homeRelative.startsWith("~")) {
+    return `project-bundles/${path.basename(normalized)}`;
+  }
+
+  return homeRelative;
+}
+
+function hasExplicitComposition(selection: ProjectBundleRequestBody["selection"]): boolean {
+  if (!selection?.includedCategories) {
+    return false;
+  }
+
+  return PROJECT_BUNDLE_SELECTABLE_MEMBER_CATEGORIES.some((category) =>
+    Object.prototype.hasOwnProperty.call(selection.includedCategories, category)
+  );
 }
 
 export async function POST(req: Request) {
@@ -56,10 +76,10 @@ export async function POST(req: Request) {
     );
   }
 
-  if (body.mode !== undefined && body.mode !== "validate" && body.mode !== "generate") {
+  if (body.mode !== "validate" && body.mode !== "generate") {
     return NextResponse.json(
       {
-        error: `Unsupported mode: ${String(body.mode)}`,
+        error: "Unsupported project bundle mode.",
         code: "INVALID_MODE",
         title: "Invalid request",
         hint: "Use mode validate or generate.",
@@ -68,7 +88,7 @@ export async function POST(req: Request) {
     );
   }
 
-  if (body.mode === "generate" && (!body.selection || !body.configuration)) {
+  if (body.mode === "generate" && (!body.selection || !body.configuration || !hasExplicitComposition(body.selection))) {
     return NextResponse.json(
       {
         error: "Generate mode requires explicit selection and configuration.",
@@ -96,8 +116,13 @@ export async function POST(req: Request) {
     if (body.mode === "generate") {
       const generated = await generateProjectBundle(selection, configuration);
       return NextResponse.json({
-        ...generated,
-        filePath: redactDisplayPath(generated.filePath),
+        validation: generated.validation,
+        summary: generated.summary,
+        memberInventory: generated.memberInventory,
+        memberReferences: generated.memberReferences,
+        packageId: generated.packageId,
+        createdAt: generated.createdAt,
+        filePath: toDisplaySafeBundlePath(generated.filePath),
       });
     }
 

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -207,6 +207,7 @@ export type ProjectBundleValidationResponse = {
 
 export type ProjectBundleGenerateResponse = ProjectBundleValidationResponse & {
   packageId: string;
+  createdAt: string;
   filePath: string;
 };
 

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -160,7 +160,7 @@ async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> 
     try {
       const stat = await fs.stat(root);
       if (stat.isDirectory()) {
-        await fs.access(root, fsConstants.W_OK);
+        await fs.access(root, fsConstants.W_OK | fsConstants.X_OK);
         return null;
       }
       return createOutputRootBlocker();
@@ -174,7 +174,7 @@ async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> 
         if (!stat.isDirectory()) {
           return createOutputRootBlocker();
         }
-        await fs.access(current, fsConstants.W_OK);
+        await fs.access(current, fsConstants.W_OK | fsConstants.X_OK);
         return null;
       } catch {
         const parent = path.dirname(current);

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -168,7 +168,7 @@ function createOutputRootBlocker(): BackupValidationItem {
     id: "bundle-output-root-unwritable",
     label: "Project bundle output destination",
     severity: "block",
-    detail: "Project bundle output root is unavailable or not writable. Choose a writable local output location and retry.",
+    detail: "Project bundle output root is unavailable or not writable. Fix permissions for the configured output root, or set AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT to a writable local directory, then retry.",
   };
 }
 

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -181,39 +181,59 @@ function isMissingPathError(error: unknown): boolean {
   );
 }
 
+async function checkWritableOutputDirectory(candidate: string): Promise<"ok" | "missing" | "blocked"> {
+  let entryStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    entryStat = await fs.lstat(candidate);
+  } catch (error) {
+    return isMissingPathError(error) ? "missing" : "blocked";
+  }
+
+  let targetStat = entryStat;
+  if (entryStat.isSymbolicLink()) {
+    try {
+      targetStat = await fs.stat(candidate);
+    } catch {
+      return "blocked";
+    }
+  }
+
+  if (!targetStat.isDirectory()) {
+    return "blocked";
+  }
+
+  try {
+    await fs.access(candidate, fsConstants.W_OK | fsConstants.X_OK);
+    return "ok";
+  } catch {
+    return "blocked";
+  }
+}
+
 async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> {
   try {
     const root = getProjectBundlesRoot();
-    try {
-      const stat = await fs.stat(root);
-      if (stat.isDirectory()) {
-        await fs.access(root, fsConstants.W_OK | fsConstants.X_OK);
-        return null;
-      }
-      return createOutputRootBlocker();
-    } catch (error) {
-      if (!isMissingPathError(error)) {
-        return createOutputRootBlocker();
-      }
-      // Root does not exist yet; fall back to nearest existing writable ancestor.
+    const rootCheck = await checkWritableOutputDirectory(root);
+    if (rootCheck === "ok") {
+      return null;
     }
+    if (rootCheck === "blocked") {
+      return createOutputRootBlocker();
+    }
+
+    // Root does not exist yet; fall back to nearest existing writable ancestor.
     let current = path.dirname(root);
     while (true) {
-      try {
-        const stat = await fs.stat(current);
-        if (!stat.isDirectory()) {
-          return createOutputRootBlocker();
-        }
-        await fs.access(current, fsConstants.W_OK | fsConstants.X_OK);
+      const currentCheck = await checkWritableOutputDirectory(current);
+      if (currentCheck === "ok") {
         return null;
-      } catch (error) {
-        if (!isMissingPathError(error)) {
-          return createOutputRootBlocker();
-        }
-        const parent = path.dirname(current);
-        if (parent === current) break;
-        current = parent;
       }
+      if (currentCheck === "blocked") {
+        return createOutputRootBlocker();
+      }
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
     }
     return createOutputRootBlocker();
   } catch {

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -45,14 +45,32 @@ type ComposeProjectBundleResult = ProjectBundleValidationResponse & {
   projectMetadata: ProjectBundleProjectMetadata;
 };
 
+function parseComparableTimestamp(value: string): number | undefined {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
 function isPreferredSessionBackupMatch(
   candidate: Pick<SessionBackupReferenceMatch, "backupId" | "createdAt">,
   existing?: Pick<SessionBackupReferenceMatch, "backupId" | "createdAt">
 ): boolean {
   if (!existing) return true;
-  if (candidate.createdAt !== existing.createdAt) {
-    return candidate.createdAt > existing.createdAt;
+
+  const candidateTimestamp = parseComparableTimestamp(candidate.createdAt);
+  const existingTimestamp = parseComparableTimestamp(existing.createdAt);
+
+  if (
+    candidateTimestamp !== undefined &&
+    existingTimestamp !== undefined &&
+    candidateTimestamp !== existingTimestamp
+  ) {
+    return candidateTimestamp > existingTimestamp;
   }
+
+  if (candidateTimestamp !== existingTimestamp) {
+    return candidateTimestamp !== undefined;
+  }
+
   return candidate.backupId > existing.backupId;
 }
 

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -172,6 +172,15 @@ function createOutputRootBlocker(): BackupValidationItem {
   };
 }
 
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
 async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> {
   try {
     const root = getProjectBundlesRoot();
@@ -182,7 +191,10 @@ async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> 
         return null;
       }
       return createOutputRootBlocker();
-    } catch {
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        return createOutputRootBlocker();
+      }
       // Root does not exist yet; fall back to nearest existing writable ancestor.
     }
     let current = path.dirname(root);
@@ -194,7 +206,10 @@ async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> 
         }
         await fs.access(current, fsConstants.W_OK | fsConstants.X_OK);
         return null;
-      } catch {
+      } catch (error) {
+        if (!isMissingPathError(error)) {
+          return createOutputRootBlocker();
+        }
         const parent = path.dirname(current);
         if (parent === current) break;
         current = parent;

--- a/src/lib/server/projectBundleService.ts
+++ b/src/lib/server/projectBundleService.ts
@@ -45,6 +45,17 @@ type ComposeProjectBundleResult = ProjectBundleValidationResponse & {
   projectMetadata: ProjectBundleProjectMetadata;
 };
 
+function isPreferredSessionBackupMatch(
+  candidate: Pick<SessionBackupReferenceMatch, "backupId" | "createdAt">,
+  existing?: Pick<SessionBackupReferenceMatch, "backupId" | "createdAt">
+): boolean {
+  if (!existing) return true;
+  if (candidate.createdAt !== existing.createdAt) {
+    return candidate.createdAt > existing.createdAt;
+  }
+  return candidate.backupId > existing.backupId;
+}
+
 function createPackageId(): string {
   return `project-bundle-${new Date().toISOString().replace(/[:.]/g, "-")}-${crypto.randomUUID().slice(0, 8)}`;
 }
@@ -77,8 +88,14 @@ async function listSessionBackupMatches(
   const index = new Map<string, SessionBackupReferenceMatch>();
   const root = getSessionBackupsRoot();
   const requestedKeys = new Set(sessionSelections.map((selection) => formatSessionSelectionLabel(selection)));
-  const remainingKeys = new Set(requestedKeys);
   const requestedSessionIds = new Set(sessionSelections.map((selection) => selection.sessionId));
+  const requestedKeysBySessionId = new Map<string, string[]>();
+
+  for (const selection of sessionSelections) {
+    const keys = requestedKeysBySessionId.get(selection.sessionId) ?? [];
+    keys.push(formatSessionSelectionLabel(selection));
+    requestedKeysBySessionId.set(selection.sessionId, keys);
+  }
 
   if (requestedKeys.size === 0) {
     return index;
@@ -87,14 +104,19 @@ async function listSessionBackupMatches(
   try {
     const entries = await fs.readdir(root, { withFileTypes: true });
     for (const entry of entries) {
-      if (remainingKeys.size === 0) break;
       if (!entry.isDirectory()) continue;
 
       try {
         const manifest = parseSessionBackupManifest(await readBackupManifestFile(entry.name));
         for (const recordEntry of manifest.records) {
-          if (remainingKeys.size === 0) break;
           if (!requestedSessionIds.has(recordEntry.sessionId)) continue;
+          const possibleKeys = requestedKeysBySessionId.get(recordEntry.sessionId) ?? [];
+          if (possibleKeys.length > 0 && possibleKeys.every((key) => {
+            const existing = index.get(key);
+            return existing ? !isPreferredSessionBackupMatch(manifest, existing) : false;
+          })) {
+            continue;
+          }
           const record = parseSessionRecord((await readBackupFile(entry.name, recordEntry.path)).toString("utf8"));
           const key = formatSessionSelectionLabel({
             sessionId: record.session.id,
@@ -103,7 +125,7 @@ async function listSessionBackupMatches(
           });
           if (!requestedKeys.has(key)) continue;
           const existing = index.get(key);
-          if (existing && existing.createdAt >= manifest.createdAt) continue;
+          if (!isPreferredSessionBackupMatch(manifest, existing)) continue;
           index.set(key, {
             backupId: manifest.backupId,
             createdAt: manifest.createdAt,
@@ -111,7 +133,6 @@ async function listSessionBackupMatches(
             sessionId: record.session.id,
             rootId: record.session.rootId,
           });
-          remainingKeys.delete(key);
         }
       } catch {
         continue;
@@ -124,33 +145,46 @@ async function listSessionBackupMatches(
   return index;
 }
 
-async function canPrepareBundleOutputRoot(): Promise<boolean> {
+function createOutputRootBlocker(): BackupValidationItem {
+  return {
+    id: "bundle-output-root-unwritable",
+    label: "Project bundle output destination",
+    severity: "block",
+    detail: "Project bundle output root is unavailable or not writable. Choose a writable local output location and retry.",
+  };
+}
+
+async function validateBundleOutputRoot(): Promise<BackupValidationItem | null> {
   try {
     const root = getProjectBundlesRoot();
     try {
       const stat = await fs.stat(root);
       if (stat.isDirectory()) {
         await fs.access(root, fsConstants.W_OK);
-        return true;
+        return null;
       }
-      return false;
+      return createOutputRootBlocker();
     } catch {
       // Root does not exist yet; fall back to nearest existing writable ancestor.
     }
     let current = path.dirname(root);
     while (true) {
       try {
+        const stat = await fs.stat(current);
+        if (!stat.isDirectory()) {
+          return createOutputRootBlocker();
+        }
         await fs.access(current, fsConstants.W_OK);
-        return true;
+        return null;
       } catch {
         const parent = path.dirname(current);
         if (parent === current) break;
         current = parent;
       }
     }
-    return false;
+    return createOutputRootBlocker();
   } catch {
-    return false;
+    return createOutputRootBlocker();
   }
 }
 
@@ -306,14 +340,9 @@ async function composeProjectBundle(
     });
   }
 
-  const outputRootWritable = await canPrepareBundleOutputRoot();
-  if (!outputRootWritable) {
-    validationItems.push({
-      id: "bundle-output-root-unwritable",
-      label: "Bundle output",
-      severity: "block",
-      detail: "Bundle output root cannot be prepared from the current environment.",
-    });
+  const outputRootBlocker = await validateBundleOutputRoot();
+  if (outputRootBlocker) {
+    validationItems.push(outputRootBlocker);
   }
 
   const sessionSelections = dedupeSessionSelections(selection.sessionSelections);
@@ -400,15 +429,15 @@ async function composeProjectBundle(
       category: "project-metadata",
       label: packageInfo.projectName,
       referenceType: "project-metadata",
-      referenceId: packageInfo.workspacePath,
+      referenceId: packageInfo.projectName,
       status: "resolved",
       detail: "Include project-level metadata snapshot for the current workspace.",
       snapshot: createSnapshot({
-        id: packageInfo.workspacePath,
+        id: packageInfo.projectName,
         label: packageInfo.projectName,
         category: "project-metadata",
         scope: "project",
-        provenanceSummary: packageInfo.workspacePath,
+        provenanceSummary: "Current workspace metadata.",
         status: "active",
       }),
     });
@@ -569,6 +598,7 @@ export async function generateProjectBundle(
     memberInventory: composed.memberInventory,
     memberReferences: composed.memberReferences,
     packageId: composed.packageMetadata.packageId,
+    createdAt: composed.packageMetadata.createdAt,
     filePath,
   };
 }

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -481,7 +481,7 @@ describe("BackupMigrationFoundation panels", () => {
               id: "bundle-output-root-unwritable",
               label: "Project bundle output destination",
               severity: "block",
-              detail: "Project bundle output root is unavailable or not writable. Choose a writable local output location and retry.",
+              detail: "Project bundle output root is unavailable or not writable. Fix permissions for the configured output root, or set AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT to a writable local directory, then retry.",
             },
           ],
         }}
@@ -490,7 +490,7 @@ describe("BackupMigrationFoundation panels", () => {
 
     expect(html).toContain("Project bundle output destination");
     expect(html).toContain("block");
-    expect(html).toContain("Choose a writable local output location");
+    expect(html).toContain("AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT");
     expect(html).not.toContain("/Users/");
     expect(html).not.toContain("/tmp/");
   });

--- a/tests/backupMigrationFoundation.test.tsx
+++ b/tests/backupMigrationFoundation.test.tsx
@@ -433,7 +433,7 @@ describe("BackupMigrationFoundation panels", () => {
           timestamp: "2026-04-16T13:00:00Z",
           summary: "Project bundle project-bundle-1 generated with 3 member references.",
           packageId: "project-bundle-1",
-          filePath: "/tmp/project-bundle-1.bundle.json",
+          filePath: "project-bundles/project-bundle-1.bundle.json",
           memberCount: 3,
           projectBundleValidationSummary: {
             warningCount: 1,
@@ -464,10 +464,35 @@ describe("BackupMigrationFoundation panels", () => {
     );
 
     expect(html).toContain("project-bundle-1");
-    expect(html).toContain("/tmp/project-bundle-1.bundle.json");
+    expect(html).toContain("project-bundles/project-bundle-1.bundle.json");
+    expect(html).not.toContain("/tmp/");
     expect(html).toContain("Bundle member inventory");
     expect(html).toContain("missing-package");
     expect(html).toContain("No restore or apply in foundation v1.");
+  });
+
+  it("renders project bundle global blockers without assigning them to member inventory", () => {
+    const html = renderToStaticMarkup(
+      <ValidationPanel
+        result={{
+          status: "invalid",
+          items: [
+            {
+              id: "bundle-output-root-unwritable",
+              label: "Project bundle output destination",
+              severity: "block",
+              detail: "Project bundle output root is unavailable or not writable. Choose a writable local output location and retry.",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(html).toContain("Project bundle output destination");
+    expect(html).toContain("block");
+    expect(html).toContain("Choose a writable local output location");
+    expect(html).not.toContain("/Users/");
+    expect(html).not.toContain("/tmp/");
   });
 
   it("renders validate-package terminal vocabulary instead of generic success wording", () => {

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -260,6 +260,28 @@ describe("project bundle service", () => {
     expect(sessionReference?.backupId).toBe("zzz-same-time");
   });
 
+  it("compares backup timestamps numerically before using backup id tie-breaker", async () => {
+    await writeBackupPackage({
+      backupId: "zzz-offset-time",
+      createdAt: "2026-04-16T12:00:00+02:00",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+    await writeBackupPackage({
+      backupId: "aaa-utc-later",
+      createdAt: "2026-04-16T10:30:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+    const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
+
+    expect(sessionReference?.backupId).toBe("aaa-utc-later");
+  });
+
   it("does not expose the raw workspace path in validation member references", async () => {
     const result = await validateProjectBundle(makeSelection(), makeConfig());
     const serialized = JSON.stringify(result);

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -35,6 +35,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   if (originalBundleRoot === undefined) {
     delete process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT;
   } else {
@@ -375,6 +376,44 @@ describe("project bundle service", () => {
     const blockedAncestor = path.join(tmpDir, "not-a-directory");
     await fs.writeFile(blockedAncestor, "not a directory", "utf8");
     process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = path.join(blockedAncestor, "project-bundles");
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("invalid");
+    expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+  });
+
+  it("blocks validation when output root stat fails with a permission error", async () => {
+    const bundleRoot = process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT!;
+    const originalStat = fs.stat.bind(fs);
+    vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (String(target) === bundleRoot) {
+        const error = new Error("permission denied") as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      }
+      return originalStat(target, options);
+    });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("invalid");
+    expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+  });
+
+  it("blocks validation when an existing output root ancestor is not accessible", async () => {
+    const inaccessibleAncestor = path.join(tmpDir, "inaccessible");
+    await fs.mkdir(inaccessibleAncestor, { recursive: true });
+    process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = path.join(inaccessibleAncestor, "project-bundles");
+    const originalAccess = fs.access.bind(fs);
+    vi.spyOn(fs, "access").mockImplementation(async (target, mode) => {
+      if (String(target) === inaccessibleAncestor) {
+        const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+        error.code = "EPERM";
+        throw error;
+      }
+      return originalAccess(target, mode);
+    });
 
     const result = await validateProjectBundle(makeSelection(), makeConfig());
 

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -383,17 +383,38 @@ describe("project bundle service", () => {
     expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
   });
 
-  it("blocks validation when output root stat fails with a permission error", async () => {
+  it("blocks validation when output root lstat fails with a permission error", async () => {
     const bundleRoot = process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT!;
-    const originalStat = fs.stat.bind(fs);
-    vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+    const originalLstat = fs.lstat.bind(fs);
+    vi.spyOn(fs, "lstat").mockImplementation(async (target, options) => {
       if (String(target) === bundleRoot) {
         const error = new Error("permission denied") as NodeJS.ErrnoException;
         error.code = "EACCES";
         throw error;
       }
-      return originalStat(target, options);
+      return originalLstat(target, options);
     });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("invalid");
+    expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+  });
+
+  it("blocks validation when the configured output root is a broken symlink", async () => {
+    const bundleRoot = process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT!;
+    await fs.symlink(path.join(tmpDir, "missing-target"), bundleRoot, "dir");
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("invalid");
+    expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+  });
+
+  it("blocks validation when a missing output root has a broken symlink ancestor", async () => {
+    const brokenAncestor = path.join(tmpDir, "broken-ancestor");
+    await fs.symlink(path.join(tmpDir, "missing-target"), brokenAncestor, "dir");
+    process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = path.join(brokenAncestor, "project-bundles");
 
     const result = await validateProjectBundle(makeSelection(), makeConfig());
 

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -132,7 +132,7 @@ async function writeBackupPackage(input: {
   );
 }
 
-async function writeMalformedUnrelatedBackupPackage(input: {
+async function writeIncompleteUnrelatedBackupPackage(input: {
   backupId: string;
   sessionId: string;
 }) {
@@ -315,8 +315,8 @@ describe("project bundle service", () => {
     expect(sessionReference?.backupId).toBe("backup-right-root");
   });
 
-  it("ignores malformed unrelated backup packages instead of failing validation", async () => {
-    await writeMalformedUnrelatedBackupPackage({
+  it("ignores incomplete unrelated backup packages instead of failing validation", async () => {
+    await writeIncompleteUnrelatedBackupPackage({
       backupId: "backup-unrelated",
       sessionId: "other-session",
     });

--- a/tests/projectBundleService.test.ts
+++ b/tests/projectBundleService.test.ts
@@ -131,6 +131,32 @@ async function writeBackupPackage(input: {
   );
 }
 
+async function writeMalformedUnrelatedBackupPackage(input: {
+  backupId: string;
+  sessionId: string;
+}) {
+  const backupDir = path.join(process.env.AGENT_STORAGE_MANAGER_BACKUP_ROOT!, input.backupId);
+  await fs.mkdir(backupDir, { recursive: true });
+  await fs.writeFile(
+    path.join(backupDir, "manifest.json"),
+    JSON.stringify({
+      schemaVersion: "session-backup/v1",
+      backupId: input.backupId,
+      createdAt: "2026-04-16T08:00:00.000Z",
+      createdBy: "agent-storage-manager",
+      sessionCount: 1,
+      records: [
+        {
+          sessionId: input.sessionId,
+          path: "sessions/missing.record.json",
+          includesSourceCopy: false,
+        },
+      ],
+    }),
+    "utf8"
+  );
+}
+
 describe("project bundle service", () => {
   it("returns a warning and unresolved reference when a selected session has no existing backup", async () => {
     const result = await validateProjectBundle(makeSelection(), makeConfig());
@@ -156,6 +182,7 @@ describe("project bundle service", () => {
     const document = JSON.parse(raw) as Record<string, unknown>;
 
     expect(generated.validation.status).toBe("valid");
+    expect(generated.createdAt).toMatch(/^20/);
     expect(document.manifest).toBeTruthy();
     expect(document.packageMetadata).toBeTruthy();
     expect(document.projectMetadata).toBeTruthy();
@@ -186,6 +213,95 @@ describe("project bundle service", () => {
 
     expect(sessionReference?.backupId).toBe("backup-new");
     expect(sessionReference?.detail).toContain("backup-new");
+  });
+
+  it("keeps newest-match selection stable when traversal sees an older match first", async () => {
+    await writeBackupPackage({
+      backupId: "aaa-old",
+      createdAt: "2026-04-16T09:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+    await writeBackupPackage({
+      backupId: "zzz-new",
+      createdAt: "2026-04-16T11:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+    const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
+
+    expect(sessionReference?.backupId).toBe("zzz-new");
+    expect(result.summary.resolvedReferenceCount).toBeGreaterThan(0);
+  });
+
+  it("uses backup id as a deterministic tie-breaker when matching timestamps are equal", async () => {
+    await writeBackupPackage({
+      backupId: "aaa-same-time",
+      createdAt: "2026-04-16T11:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+    await writeBackupPackage({
+      backupId: "zzz-same-time",
+      createdAt: "2026-04-16T11:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+    const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
+
+    expect(sessionReference?.backupId).toBe("zzz-same-time");
+  });
+
+  it("does not expose the raw workspace path in validation member references", async () => {
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain(process.cwd());
+    const projectReference = result.memberReferences.find((item) => item.category === "project-metadata");
+    expect(projectReference?.referenceId).toBe(path.basename(process.cwd()));
+    expect(projectReference?.snapshot?.provenanceSummary).toBe("Current workspace metadata.");
+  });
+
+  it("matches backup packages by source and root identity, not session id alone", async () => {
+    await writeBackupPackage({
+      backupId: "backup-wrong-root",
+      createdAt: "2026-04-16T12:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "other-root",
+    });
+    await writeBackupPackage({
+      backupId: "backup-right-root",
+      createdAt: "2026-04-16T10:00:00.000Z",
+      sessionId: "session-1",
+      source: "codex",
+      rootId: "root-1",
+    });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+    const sessionReference = result.memberReferences.find((item) => item.category === "sessions");
+
+    expect(sessionReference?.backupId).toBe("backup-right-root");
+  });
+
+  it("ignores malformed unrelated backup packages instead of failing validation", async () => {
+    await writeMalformedUnrelatedBackupPackage({
+      backupId: "backup-unrelated",
+      sessionId: "other-session",
+    });
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("valid-with-warnings");
+    expect(result.validation.items.some((item) => item.id.startsWith("bundle-session-missing-package-"))).toBe(true);
   });
 
   it("blocks generation when bundle identity is structurally invalid", async () => {
@@ -222,10 +338,42 @@ describe("project bundle service", () => {
 
     try {
       const result = await validateProjectBundle(makeSelection(), makeConfig());
-      expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+      const outputBlocker = result.validation.items.find((item) => item.id === "bundle-output-root-unwritable");
+      expect(outputBlocker).toBeTruthy();
+      expect(outputBlocker?.label).toBe("Project bundle output destination");
+      expect(outputBlocker?.detail).not.toContain(tmpDir);
       expect(result.validation.status).toBe("invalid");
+      expect(result.memberInventory.find((item) => item.category === "package-metadata")?.status).not.toBe("blocked");
     } finally {
       await fs.rm(bundleRoot, { force: true });
     }
+  });
+
+  it("blocks validation when a missing output root has a non-directory ancestor", async () => {
+    const blockedAncestor = path.join(tmpDir, "not-a-directory");
+    await fs.writeFile(blockedAncestor, "not a directory", "utf8");
+    process.env.AGENT_STORAGE_MANAGER_PROJECT_BUNDLE_ROOT = path.join(blockedAncestor, "project-bundles");
+
+    const result = await validateProjectBundle(makeSelection(), makeConfig());
+
+    expect(result.validation.status).toBe("invalid");
+    expect(result.validation.items.some((item) => item.id === "bundle-output-root-unwritable")).toBe(true);
+  });
+
+  it("blocks validation when no selectable project bundle category is selected", async () => {
+    const selection = makeSelection();
+    selection.includedCategories = {
+      sessions: false,
+      rules: false,
+      memory: false,
+      skills: false,
+      commands: false,
+    };
+
+    const result = await validateProjectBundle(selection, makeConfig());
+
+    expect(result.validation.status).toBe("invalid");
+    expect(result.validation.items.some((item) => item.id === "bundle-no-categories")).toBe(true);
+    expect(result.summary.blockerCount).toBeGreaterThan(0);
   });
 });

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -332,4 +332,49 @@ describe("project bundle route", () => {
     expect(json.filePath).toBe("project-bundles/project-bundle-2.bundle.json");
     expect(JSON.stringify(json)).not.toContain("/tmp/private-user");
   });
+
+  it("derives non-home display path prefixes from the actual bundle directory", async () => {
+    generateProjectBundleMock.mockResolvedValue({
+      validation: { status: "valid", items: [] },
+      summary: {
+        warningCount: 0,
+        blockerCount: 0,
+        selectedCategoryCount: 1,
+        selectedSessionCount: 0,
+        resolvedReferenceCount: 1,
+        unresolvedReferenceCount: 0,
+      },
+      memberInventory: [],
+      memberReferences: [],
+      packageId: "project-bundle-3",
+      createdAt: "2026-04-18T06:02:00.000Z",
+      filePath: "/tmp/private-user/custom-bundles/project-bundle-3.bundle.json",
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "generate",
+          selection: {
+            includedCategories: {
+              sessions: false,
+              rules: true,
+              memory: false,
+              skills: false,
+              commands: false,
+            },
+          },
+          configuration: {
+            bundleName: "Generated bundle",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.filePath).toBe("custom-bundles/project-bundle-3.bundle.json");
+    expect(JSON.stringify(json)).not.toContain("/tmp/private-user");
+  });
 });

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -75,6 +75,8 @@ describe("project bundle route", () => {
       memberReferences: [],
       packageId: "project-bundle-1",
       filePath: `${os.homedir()}/.agent-storage-manager/project-bundle-1.bundle.json`,
+      createdAt: "2026-04-18T06:00:00.000Z",
+      document: { shouldNotLeak: true },
     });
 
     const response = await POST(
@@ -88,6 +90,13 @@ describe("project bundle route", () => {
             projectBundleScopeHint: "overview-routed project context",
           },
           selection: {
+            includedCategories: {
+              sessions: true,
+              rules: false,
+              memory: false,
+              skills: false,
+              commands: false,
+            },
             sessionSelections: [
               {
                 sessionId: "session-1",
@@ -107,6 +116,8 @@ describe("project bundle route", () => {
     expect(generateProjectBundleMock).toHaveBeenCalledTimes(1);
     const json = await response.json();
     expect(json.filePath).toBe("~/.agent-storage-manager/project-bundle-1.bundle.json");
+    expect(json.createdAt).toBe("2026-04-18T06:00:00.000Z");
+    expect(json.document).toBeUndefined();
     const [selection, configuration] = generateProjectBundleMock.mock.calls[0]!;
     expect(selection.scopeHint).toBe("overview-routed project context");
     expect(selection.sessionSelections).toHaveLength(1);
@@ -154,11 +165,48 @@ describe("project bundle route", () => {
     expect(validateProjectBundleMock).not.toHaveBeenCalled();
     expect(generateProjectBundleMock).not.toHaveBeenCalled();
     expect(await response.json()).toEqual({
-      error: "Unsupported mode: oops",
+      error: "Unsupported project bundle mode.",
       code: "INVALID_MODE",
       title: "Invalid request",
       hint: "Use mode validate or generate.",
     });
+  });
+
+  it("returns a structured 400 for invalid JSON", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: "{not json",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(validateProjectBundleMock).not.toHaveBeenCalled();
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      error: "Invalid JSON body",
+      code: "INVALID_REQUEST",
+      title: "Invalid request",
+      hint: "Send a JSON body with mode, selection, and configuration.",
+    });
+  });
+
+  it("rejects missing mode values instead of defaulting to validation", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          configuration: {
+            bundleName: "Missing mode",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(validateProjectBundleMock).not.toHaveBeenCalled();
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    expect((await response.json()).code).toBe("INVALID_MODE");
   });
 
   it("rejects generate mode when explicit selection or configuration is missing", async () => {
@@ -180,5 +228,74 @@ describe("project bundle route", () => {
       title: "Invalid request",
       hint: "Run explicit composition first, then submit selection and configuration for generation.",
     });
+  });
+
+  it("rejects generate mode when selection omits explicit category composition", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "generate",
+          selection: {
+            sessionSelections: [
+              {
+                sessionId: "session-1",
+                source: "codex",
+              },
+            ],
+          },
+          configuration: {
+            bundleName: "Generated bundle",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(validateProjectBundleMock).not.toHaveBeenCalled();
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    expect((await response.json()).code).toBe("MISSING_GENERATE_INPUT");
+  });
+
+  it("converts non-home bundle file locations to display-safe paths", async () => {
+    generateProjectBundleMock.mockResolvedValue({
+      validation: { status: "valid", items: [] },
+      summary: {
+        warningCount: 0,
+        blockerCount: 0,
+        selectedCategoryCount: 1,
+        selectedSessionCount: 0,
+        resolvedReferenceCount: 1,
+        unresolvedReferenceCount: 0,
+      },
+      memberInventory: [],
+      memberReferences: [],
+      packageId: "project-bundle-2",
+      createdAt: "2026-04-18T06:01:00.000Z",
+      filePath: "/tmp/private-user/project-bundles/project-bundle-2.bundle.json",
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "generate",
+          selection: {
+            includedCategories: {
+              sessions: false,
+              rules: true,
+            },
+          },
+          configuration: {
+            bundleName: "Generated bundle",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.filePath).toBe("project-bundles/project-bundle-2.bundle.json");
+    expect(JSON.stringify(json)).not.toContain("/tmp/private-user");
   });
 });

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -260,6 +260,34 @@ describe("project bundle route", () => {
     expect((await response.json()).code).toBe("MISSING_GENERATE_INPUT");
   });
 
+  it("rejects generate mode when explicit category composition values are not booleans", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/project-bundles", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "generate",
+          selection: {
+            includedCategories: {
+              sessions: "false",
+              rules: true,
+              memory: false,
+              skills: false,
+              commands: false,
+              __proto__: { polluted: true },
+            },
+          },
+          configuration: {
+            bundleName: "Generated bundle",
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(generateProjectBundleMock).not.toHaveBeenCalled();
+    expect((await response.json()).code).toBe("MISSING_GENERATE_INPUT");
+  });
+
   it("converts non-home bundle file locations to display-safe paths", async () => {
     generateProjectBundleMock.mockResolvedValue({
       validation: { status: "valid", items: [] },

--- a/tests/projectBundlesRoute.test.ts
+++ b/tests/projectBundlesRoute.test.ts
@@ -42,6 +42,9 @@ describe("project bundle route", () => {
             includedCategories: {
               sessions: false,
               rules: true,
+              memory: false,
+              skills: false,
+              commands: false,
             },
           },
           configuration: {
@@ -284,6 +287,9 @@ describe("project bundle route", () => {
             includedCategories: {
               sessions: false,
               rules: true,
+              memory: false,
+              skills: false,
+              commands: false,
             },
           },
           configuration: {


### PR DESCRIPTION
## Summary
- enforce explicit project bundle generate inputs and structured project-bundle API errors
- return summary-shaped generate responses with display-safe bundle paths
- harden output-root validation, missing-package warnings, unresolved references, and deterministic newest backup reuse
- add focused route/service/component tests and update OpenSpec tasks, README, CHANGELOG, and QA prompt

## Validation
- pnpm test
- pnpm exec tsc --noEmit
- pnpm build
- OPENSPEC_TELEMETRY=0 openspec validate project-bundle-hardening --strict

## QA
- Browser QA not run; this is primarily API/service/result hardening and is covered by focused route, service, and component tests. QA prompt was updated for optional browser smoke coverage.

Refs #67