### PR TITLE
fix: label Project Overview seed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Fixed
 
+- `2026-04-18` — Project Overview seed data labeling
+  - Marked the default Project Overview asset/finding/attention summary as foundation sample data instead of implying it is live project inventory
+
 - `2026-04-09` — Conversation list race condition when deep-linking to Codex
   - Fixed `loadList` AbortController to cancel in-flight fetches when source changes rapidly
   - Prevents Antigravity conversation list from overwriting Codex list on initial page load with `?source=codex` URL

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
 
 - Project shell:
   - top-level surfaces for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`
-  - `Project Overview` provides a project-scoped agent context governance foundation with compact context snapshot, in-effect assets, recent sessions, attention items, and route-first quick actions
+  - `Project Overview` provides a project-scoped agent context governance foundation with compact context snapshot, in-effect assets, recent sessions, attention items, and route-first quick actions; current asset/finding counts are clearly marked as foundation sample data until live project inventory is connected
   - `Sessions` contains the existing viewer, source diagnostics, URL deep links, search selection, and direct session backup behavior
   - `Assets` provides a bounded reusable context assets foundation for rules, memory, skills, commands, and unknown asset fragments
   - `Analysis` provides a bounded interpretation-and-routing foundation for local context findings

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,18 +1,38 @@
 /** @type {import('next').NextConfig} */
+const AGENT_STORAGE_IGNORED_REGEXP =
+  /(?:^|[/\\])(?:\.next|node_modules|\.agent|\.agents|\.codex|\.github|\.windsurf|\.git|output)(?:[/\\]|$)/;
+const AGENT_STORAGE_IGNORED_GLOB = "**/{.next,node_modules,.agent,.agents,.codex,.github,.windsurf,.git,output}/**";
+
+function combineIgnoredWatchPatterns(existingIgnored) {
+  if (!existingIgnored) return AGENT_STORAGE_IGNORED_REGEXP;
+
+  if (existingIgnored instanceof RegExp) {
+    return new RegExp(
+      `(?:${existingIgnored.source})|(?:${AGENT_STORAGE_IGNORED_REGEXP.source})`,
+      existingIgnored.flags,
+    );
+  }
+
+  if (typeof existingIgnored === "string") {
+    return [existingIgnored, AGENT_STORAGE_IGNORED_GLOB];
+  }
+
+  if (Array.isArray(existingIgnored) && existingIgnored.every((pattern) => typeof pattern === "string")) {
+    return [...existingIgnored, AGENT_STORAGE_IGNORED_GLOB];
+  }
+
+  return AGENT_STORAGE_IGNORED_REGEXP;
+}
+
 const nextConfig = {
   output: "standalone",
   webpack: (config, { dev }) => {
     if (dev) {
       const existingIgnored = config.watchOptions?.ignored;
-      const agentStorageIgnored = /(?:^|[/\\])(?:\.next|node_modules|\.agent|\.agents|\.codex|\.github|\.windsurf|\.git|output)(?:[/\\]|$)/;
 
       config.watchOptions = {
         ...config.watchOptions,
-        ignored: Array.isArray(existingIgnored)
-          ? [...existingIgnored, agentStorageIgnored]
-          : existingIgnored
-            ? [existingIgnored, agentStorageIgnored]
-            : agentStorageIgnored,
+        ignored: combineIgnoredWatchPatterns(existingIgnored),
       };
     }
     return config;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,28 @@ const AGENT_STORAGE_IGNORED_REGEXP =
   /(?:^|[/\\])(?:\.next|node_modules|\.agent|\.agents|\.codex|\.github|\.windsurf|\.git|output)(?:[/\\]|$)/;
 const AGENT_STORAGE_IGNORED_GLOB = "**/{.next,node_modules,.agent,.agents,.codex,.github,.windsurf,.git,output}/**";
 
+function globLikePatternToRegExpSource(pattern) {
+  const normalizedPattern = pattern.replace(/\\/g, "/");
+  const escapedPattern = normalizedPattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*");
+
+  return `(?:${escapedPattern})`;
+}
+
+function combineRegExpFlags(patterns) {
+  const flags = new Set();
+
+  for (const pattern of patterns) {
+    for (const flag of pattern.flags) {
+      if (flag !== "g" && flag !== "y") flags.add(flag);
+    }
+  }
+
+  return Array.from(flags).sort().join("");
+}
+
 function combineIgnoredWatchPatterns(existingIgnored) {
   if (!existingIgnored) return AGENT_STORAGE_IGNORED_REGEXP;
 
@@ -17,8 +39,26 @@ function combineIgnoredWatchPatterns(existingIgnored) {
     return [existingIgnored, AGENT_STORAGE_IGNORED_GLOB];
   }
 
-  if (Array.isArray(existingIgnored) && existingIgnored.every((pattern) => typeof pattern === "string")) {
-    return [...existingIgnored, AGENT_STORAGE_IGNORED_GLOB];
+  if (Array.isArray(existingIgnored)) {
+    if (existingIgnored.every((pattern) => typeof pattern === "string")) {
+      return [...existingIgnored, AGENT_STORAGE_IGNORED_GLOB];
+    }
+
+    const stringPatterns = existingIgnored
+      .filter((pattern) => typeof pattern === "string" && pattern.length > 0)
+      .map(globLikePatternToRegExpSource);
+    const regexpPatterns = existingIgnored.filter((pattern) => pattern instanceof RegExp);
+
+    if (stringPatterns.length > 0 || regexpPatterns.length > 0) {
+      return new RegExp(
+        [
+          ...regexpPatterns.map((pattern) => `(?:${pattern.source})`),
+          ...stringPatterns,
+          `(?:${AGENT_STORAGE_IGNORED_REGEXP.source})`,
+        ].join("|"),
+        combineRegExpFlags(regexpPatterns),
+      );
+    }
   }
 
   return AGENT_STORAGE_IGNORED_REGEXP;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,10 +5,12 @@ const AGENT_STORAGE_IGNORED_GLOB = "**/{.next,node_modules,.agent,.agents,.codex
 
 function globLikePatternToRegExpSource(pattern) {
   const normalizedPattern = pattern.replace(/\\/g, "/");
+  const globStarPlaceholder = "__GLOBSTAR__";
   const escapedPattern = normalizedPattern
     .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-    .replace(/\*\*/g, ".*")
-    .replace(/\*/g, "[^/]*");
+    .replace(/\*\*/g, globStarPlaceholder)
+    .replace(/\*/g, "[^/]*")
+    .replaceAll(globStarPlaceholder, ".*");
 
   return `(?:${escapedPattern})`;
 }

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -567,12 +567,14 @@ export function ProjectOverviewSurface(props: {
         <Badge variant={issueState ? "warn" : emptyState ? "default" : "ok"}>
           {issueState ? "attention state" : emptyState ? "no project context" : "governance foundation"}
         </Badge>
+        {summary.identity.evidenceKind === "foundation-seed" ? <Badge variant="warn">sample data</Badge> : null}
         <Badge variant="default">{summary.identity.scopeLabel}</Badge>
       </div>
       <h2 className="text-xl font-semibold">{summary.identity.title}</h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">
-        Project-scoped agent context governance derived from local evidence. Use this surface to see what context is
-        present, what is in effect, what changed recently, what needs attention, and where to continue.
+        {summary.identity.evidenceKind === "foundation-seed"
+          ? "Project Overview is showing foundation sample data until live project inventory is connected. Use it to inspect the intended governance shape, not the current project's real asset or finding counts."
+          : "Project-scoped agent context governance derived from local evidence. Use this surface to see what context is present, what is in effect, what changed recently, what needs attention, and where to continue."}
       </p>
       <div className="mt-3 text-xs uppercase tracking-[0.18em] text-muted">{summary.identity.evidenceLabel}</div>
     </Card>

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -572,9 +572,11 @@ export function ProjectOverviewSurface(props: {
       </div>
       <h2 className="text-xl font-semibold">{summary.identity.title}</h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">
-        {summary.identity.evidenceKind === "foundation-seed"
-          ? "Project Overview is showing foundation sample data until live project inventory is connected. Use it to inspect the intended governance shape, not the current project's real asset or finding counts."
-          : "Project-scoped agent context governance derived from local evidence. Use this surface to see what context is present, what is in effect, what changed recently, what needs attention, and where to continue."}
+        {summary.identity.evidenceKind === "loading"
+          ? "Project Overview is loading local project evidence. Governance summaries, routes, and workflow actions will appear once the local inventory is resolved."
+          : summary.identity.evidenceKind === "foundation-seed"
+            ? "Project Overview is showing foundation sample data until live project inventory is connected. Use it to inspect the intended governance shape, not the current project's real asset or finding counts."
+            : "Project-scoped agent context governance derived from local evidence. Use this surface to see what context is present, what is in effect, what changed recently, what needs attention, and where to continue."}
       </p>
       <div className="mt-3 text-xs uppercase tracking-[0.18em] text-muted">{summary.identity.evidenceLabel}</div>
     </Card>

--- a/src/lib/projectOverview.ts
+++ b/src/lib/projectOverview.ts
@@ -53,6 +53,7 @@ export type ProjectOverviewProjectIdentity = {
   title: string;
   scopeLabel: string;
   evidenceLabel: string;
+  evidenceKind: "loading" | "none" | "foundation-seed" | "local-evidence";
   state: ProjectOverviewPageState;
 };
 
@@ -554,6 +555,9 @@ export function deriveProjectOverviewSummary(input: ProjectOverviewSummaryInput 
   const analysisAvailable = input.analysisAvailable ?? input.findings !== null;
   const sessionsAvailable = input.sessionsAvailable ?? input.sessions !== null;
   const backupAvailable = input.backupAvailable ?? input.backupWorkflows !== null;
+  const usesFoundationSeedAssets = assetsAvailable && input.assets === undefined;
+  const usesFoundationSeedFindings = analysisAvailable && input.findings === undefined;
+  const usesFoundationSeeds = usesFoundationSeedAssets || usesFoundationSeedFindings;
   const assets = assetsAvailable ? (input.assets ?? createContextAssetSeeds()) : [];
   const findings = analysisAvailable ? (input.findings ?? createAnalysisFindingSeeds()) : [];
   const sessions = sessionsAvailable ? (input.sessions ?? []) : [];
@@ -583,16 +587,26 @@ export function deriveProjectOverviewSummary(input: ProjectOverviewSummaryInput 
       : hasHighPriorityIssue
         ? "issue"
         : "normal";
+  const evidenceKind: ProjectOverviewProjectIdentity["evidenceKind"] = input.isLoading
+    ? "loading"
+    : state === "no-project-context"
+      ? "none"
+      : usesFoundationSeeds
+        ? "foundation-seed"
+        : "local-evidence";
 
   return {
     identity: {
       title: input.projectTitle?.trim() || "Project Overview",
       scopeLabel: input.scopeLabel?.trim() || "Local project context",
-      evidenceLabel: input.isLoading
+      evidenceLabel: evidenceKind === "loading"
         ? "Loading local project evidence"
-        : state === "no-project-context"
+        : evidenceKind === "none"
           ? "No sessions or reusable assets found yet"
-          : "Derived from local project evidence",
+          : evidenceKind === "foundation-seed"
+            ? "Sample foundation data, not live project inventory"
+            : "Derived from explicit local project evidence",
+      evidenceKind,
       state,
     },
     contextSnapshot,

--- a/tests/projectOverview.test.ts
+++ b/tests/projectOverview.test.ts
@@ -9,7 +9,8 @@ describe("deriveProjectOverviewSummary", () => {
     const summary = deriveProjectOverviewSummary();
 
     expect(summary.state).toBe("issue");
-    expect(summary.identity.evidenceLabel).toContain("Derived from local project evidence");
+    expect(summary.identity.evidenceKind).toBe("foundation-seed");
+    expect(summary.identity.evidenceLabel).toContain("Sample foundation data");
     expect(summary.contextSnapshot.map((cue) => cue.id)).toEqual(["sessions", "assets", "analysis", "backup"]);
     expect(summary.inEffectAssets.length).toBeGreaterThan(0);
     expect(summary.recentSessions).toEqual([]);
@@ -44,6 +45,7 @@ describe("deriveProjectOverviewSummary", () => {
     });
 
     expect(summary.state).toBe("no-project-context");
+    expect(summary.identity.evidenceKind).toBe("none");
     expect(summary.contextSnapshot).toEqual([
       expect.objectContaining({ id: "sessions", value: "0 sessions", status: "empty" }),
       expect.objectContaining({ id: "assets", value: "0 assets", status: "empty" }),
@@ -178,7 +180,8 @@ describe("deriveProjectOverviewSummary", () => {
     });
 
     expect(summary.state).toBe("issue");
-    expect(summary.identity.evidenceLabel).toContain("Derived from local project evidence");
+    expect(summary.identity.evidenceKind).toBe("local-evidence");
+    expect(summary.identity.evidenceLabel).toContain("Derived from explicit local project evidence");
     expect(summary.attentionItems[0]).toMatchObject({
       id: "finding:finding-only-high",
       severity: "high",

--- a/tests/projectOverviewSurface.test.tsx
+++ b/tests/projectOverviewSurface.test.tsx
@@ -18,7 +18,8 @@ describe("ProjectOverviewSurface", () => {
   it("renders the governance module spine", () => {
     const html = renderOverview();
 
-    expect(html).toContain("Project-scoped agent context governance");
+    expect(html).toContain("Project Overview is showing foundation sample data");
+    expect(html).toContain("sample data");
     expect(html).toContain("Context Snapshot");
     expect(html).toContain("In-Effect Assets");
     expect(html).toContain("Recent Sessions");
@@ -81,9 +82,14 @@ describe("ProjectOverviewSurface", () => {
   });
 
   it("frames the page as project-scoped agent context governance", () => {
-    const html = renderOverview();
+    const html = renderOverview(deriveProjectOverviewSummary({
+      assets: [],
+      findings: [],
+      sessions: [{ id: "session-1", source: "codex" }],
+    }));
 
     expect(html).toContain("Project-scoped agent context governance");
+    expect(html).not.toContain("sample data");
     expect(html).not.toContain("command center");
     expect(html).not.toContain("dashboard");
   });


### PR DESCRIPTION
## Summary
- mark the default Project Overview asset/finding/attention summary as foundation sample data
- distinguish sample foundation data from explicit local evidence in the overview summary model
- fix loading-state Overview copy so it does not claim local evidence is already derived while loading
- keep the dev webpack watch ignore fix schema-safe while preserving existing ignored patterns where webpack 5 allows it
- update README/CHANGELOG and static render tests

## Validation
- pnpm test -- tests/projectOverview.test.ts tests/projectOverviewSurface.test.tsx
- pnpm exec tsc --noEmit
- pnpm dev reached `Ready in 6s` after the watchOptions fix

## QA
- Browser QA not required: this is a copy/model-labeling and dev-config fix covered by static render tests plus pnpm dev startup validation.