### PR TITLE
spec: propose context assets governance hardening

### DIFF
--- a/openspec/changes/context-assets-governance-hardening/.openspec.yaml
+++ b/openspec/changes/context-assets-governance-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/context-assets-governance-hardening/design.md
+++ b/openspec/changes/context-assets-governance-hardening/design.md
@@ -1,0 +1,145 @@
+## Context
+
+`Assets` already exposes reusable context assets as local objects with subtype,
+scope, source, status, provenance, usage, inventory filters, selected detail,
+and routed handoff cues. `Project Overview` now summarizes governance issues
+and routes affected assets into `Assets`, which raises the bar for what the
+Assets page must explain when an item is stale, conflicted, orphaned, unknown,
+or in effect.
+
+The current implementation is intentionally seed/provider based. This hardening
+should improve semantics and user-facing explanation without adding a new
+scanner, editor, sync layer, package distribution system, or source-runtime
+mutation path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give each asset a clear governance interpretation: severity, reason, affected
+  evidence, and owning route for next inspection.
+- Explain active and in-effect assets with enough context that users understand
+  why the asset matters to the current project.
+- Explain stale, conflicted, orphaned, and unknown assets without implying that
+  `Assets` can directly fix or edit them.
+- Preserve compact routed issue context from `Project Overview` and `Analysis`
+  until the user intentionally changes focus.
+- Add testable model and component states for health summaries, issue detail,
+  and route continuity.
+
+**Non-Goals:**
+
+- Full asset editing, conflict resolution, or canonical source mutation.
+- Cross-agent sync, deployment, package distribution, MCP management, or
+  runtime restore.
+- Privacy redaction beyond existing local/path safety conventions.
+- New backend APIs, storage formats, or broad source adapters.
+- Turning `Assets` into a replacement for `Analysis`, `Sessions`, or
+  `Backup / Migration`.
+
+## Decisions
+
+### Decision 1: Add governance interpretation as a view-model layer
+
+Keep the existing `ContextAsset` model stable and derive a small governance
+view model from it. The derived model should include severity, reason,
+recommended route target, route label, and issue category where applicable.
+
+Rationale: hardening should clarify behavior without forcing a storage or data
+adapter migration. A derived layer is easier to test and can be replaced when
+real source providers mature.
+
+Alternative considered: expand each seed object with more required fields.
+Rejected because it would mix canonical asset facts with UI interpretation and
+make future provider integration harder.
+
+### Decision 2: Use status plus usage/provenance to explain health
+
+Health classification should start from existing status values:
+
+- `active` with in-effect data means healthy/in-effect.
+- `stale` means freshness review is needed.
+- `conflicted` means multiple local copies or interpretations disagree.
+- `orphaned` means evidence exists but no durable canonical owner is known.
+- `unknown` means the system lacks enough metadata and must say so explicitly.
+
+Usage and provenance should refine the explanation, not silently override the
+status.
+
+Alternative considered: invent a new independent health enum immediately.
+Rejected for v1 because it duplicates status without proving which distinctions
+are needed.
+
+### Decision 3: Preserve route ownership boundaries
+
+`Assets` explains the asset and offers bounded next routes:
+
+- `Sessions` owns source evidence reading.
+- `Analysis` owns grouped interpretation and issue triage.
+- `Backup / Migration` owns workflow execution.
+- `Project Overview` owns summary-level governance return context.
+
+The Assets page must not execute fixes or mutate third-party runtime state.
+
+Alternative considered: put "resolve conflict", "refresh", or "deploy" actions
+inside the asset detail panel. Rejected because the product does not yet have
+safe mutation semantics or source-runtime ownership.
+
+### Decision 4: Keep routed issue context compact and dismissible
+
+Overview and Analysis handoffs may carry origin, issue label, subtype/scope,
+status, asset id, and a short continue label. They must not carry full overview
+summary state, full finding tables, transcript state, or workflow execution
+state. The cue should remain visible until the user changes filters or object
+focus intentionally.
+
+Alternative considered: durable URL state for all routed context. Useful later,
+but not required for this hardening slice and risks expanding route semantics.
+
+### Decision 5: Treat seed data honesty as part of governance hardening
+
+If Assets still uses seed/provider data, the page should not imply that every
+count is a live project scan. It can still demonstrate governance semantics,
+but unknown/unavailable data must stay visible.
+
+Alternative considered: wait for real inventory before hardening Assets.
+Rejected because Project Overview already routes into Assets and needs a
+coherent destination now.
+
+## Risks / Trade-offs
+
+- [Risk] Governance copy may look authoritative while backed by seed/provider
+  data. -> Mitigation: preserve explicit provenance, unknown, unavailable, and
+  routed-context labels.
+- [Risk] Detail panels become noisy. -> Mitigation: group health explanation,
+  provenance, usage, and next routes into distinct compact sections.
+- [Risk] Route buttons drift into workflow execution. -> Mitigation: require
+  route labels and keep execution in owning surfaces.
+- [Risk] Status and health semantics diverge. -> Mitigation: derive health from
+  status in this slice and cover the mapping with model tests.
+- [Risk] Future editing/sync work becomes harder if copy promises fixes. ->
+  Mitigation: use "inspect", "review", and "prepare" language, not "repair" or
+  "sync" commands.
+
+## Migration Plan
+
+1. Add governance derivation helpers and route descriptors in the asset model
+   layer.
+2. Update `AssetsFoundation` summary/detail/routed cue rendering to consume the
+   derived interpretation.
+3. Extend shell handoff builders only for compact issue context that already
+   exists.
+4. Add model, component, and shell routing tests.
+5. Update README / CHANGELOG / QA prompt or QA report if the behavior ships.
+
+Rollback is front-end/model-local: remove the derived governance layer and
+return Assets to the prior inventory/detail rendering. No storage formats or
+backend APIs are affected.
+
+## Open Questions
+
+- Whether the first implementation should add a visible "sample/provider data"
+  cue on Assets similar to Project Overview, or defer that until a live asset
+  inventory provider exists.
+- Whether `unknown` should be visually neutral or warning-level in the summary.
+  The spec treats it as explicit but not automatically blocking.

--- a/openspec/changes/context-assets-governance-hardening/design.md
+++ b/openspec/changes/context-assets-governance-hardening/design.md
@@ -57,11 +57,16 @@ make future provider integration harder.
 
 Health classification should start from existing status values:
 
-- `active` with in-effect data means healthy/in-effect.
-- `stale` means freshness review is needed.
-- `conflicted` means multiple local copies or interpretations disagree.
-- `orphaned` means evidence exists but no durable canonical owner is known.
-- `unknown` means the system lacks enough metadata and must say so explicitly.
+- `active` with in-effect data maps to `healthy`.
+- `active` without in-effect data maps to `informational`; it is active
+  inventory, not proof that the asset currently affects the project.
+- `stale` maps to `warning` because freshness review is needed.
+- `conflicted` maps to `warning` because multiple local copies or
+  interpretations disagree.
+- `orphaned` maps to `warning` because evidence exists but no durable
+  canonical owner is known.
+- `unknown` maps to `unknown`; it must be explicit, but it is not
+  automatically blocking.
 
 Usage and provenance should refine the explanation, not silently override the
 status.
@@ -98,9 +103,10 @@ but not required for this hardening slice and risks expanding route semantics.
 
 ### Decision 5: Treat seed data honesty as part of governance hardening
 
-If Assets still uses seed/provider data, the page should not imply that every
-count is a live project scan. It can still demonstrate governance semantics,
-but unknown/unavailable data must stay visible.
+If Assets still uses seed/provider data, the page should show an explicit
+foundation/provider data cue similar to Project Overview. It can still
+demonstrate governance semantics, but unknown/unavailable data must stay
+visible and counts must not be framed as a complete live project scan.
 
 Alternative considered: wait for real inventory before hardening Assets.
 Rejected because Project Overview already routes into Assets and needs a
@@ -138,8 +144,5 @@ backend APIs are affected.
 
 ## Open Questions
 
-- Whether the first implementation should add a visible "sample/provider data"
-  cue on Assets similar to Project Overview, or defer that until a live asset
-  inventory provider exists.
-- Whether `unknown` should be visually neutral or warning-level in the summary.
-  The spec treats it as explicit but not automatically blocking.
+None for this slice. Future source-provider work may revisit whether
+`unknown` deserves stronger visual emphasis once live inventory evidence exists.

--- a/openspec/changes/context-assets-governance-hardening/proposal.md
+++ b/openspec/changes/context-assets-governance-hardening/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+`Project Overview` now routes governance attention into `Assets`, but the
+Assets surface still treats status, provenance, and in-effect relevance as
+thin inventory metadata. This change hardens Assets into a clearer governance
+surface so users can understand what is active, stale, conflicted, orphaned,
+or unresolved without adding editing, sync, deployment, or runtime controls.
+
+## What Changes
+
+- Tighten reusable asset health semantics with explicit severity,
+  explanation, and recommended route ownership.
+- Clarify in-effect and provenance explanations so active assets explain why
+  they matter and issue assets explain why they need attention.
+- Improve routed continuity from `Project Overview` and `Analysis` by keeping
+  issue context visible without carrying full overview or findings state.
+- Add detail inspection affordances for affected object, source reference,
+  freshness, conflict/orphan cues, and bounded next routes.
+- Preserve zero/unknown states and avoid silently inferring missing source,
+  scope, usage, or health data.
+- Keep `Assets` bounded: no full editing, cross-agent sync, deployment,
+  privacy redaction, vendor-runtime restore, or workflow execution in this
+  change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `context-assets`: Adds governance hardening requirements for health
+  semantics, in-effect/provenance explanation, routed issue continuity, detail
+  inspection, and bounded next routes.
+- `project-shell`: Clarifies that Overview/Analysis-to-Assets handoffs may
+  carry compact issue context, but not full source page state or executable
+  asset operations.
+
+## Impact
+
+- Affected model code: `src/lib/contextAssets.ts` and any related overview or
+  analysis handoff builders.
+- Affected UI code: `src/components/AssetsFoundation.tsx` and shell routes in
+  `src/components/ProjectShellClient.tsx`.
+- Affected tests: asset model tests, Assets component rendering tests, and
+  shell handoff tests.
+- Affected docs: README / CHANGELOG if user-facing behavior changes, and a
+  focused QA prompt or report for Assets governance hardening.
+- No new backend APIs, external services, storage formats, cloud dependencies,
+  or source-runtime mutation.

--- a/openspec/changes/context-assets-governance-hardening/specs/context-assets/spec.md
+++ b/openspec/changes/context-assets-governance-hardening/specs/context-assets/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Assets SHALL derive explicit governance health
+The system SHALL derive a governance health interpretation for each reusable
+context asset from its status, provenance, and in-effect metadata without
+silently inventing missing source facts.
+
+#### Scenario: Active in-effect asset is explained as healthy
+- **WHEN** an asset has `active` status and in-effect usage metadata
+- **THEN** the Assets surface explains that the asset is currently in effect
+- **AND** it shows the provenance or usage reason that supports that claim
+
+#### Scenario: Stale asset explains freshness risk
+- **WHEN** an asset has `stale` status
+- **THEN** the Assets surface marks it as needing freshness review
+- **AND** it explains which provenance or usage signal is stale when known
+- **AND** it offers a bounded route to inspect source evidence or grouped
+  analysis when available
+
+#### Scenario: Conflicted asset explains disagreement
+- **WHEN** an asset has `conflicted` status
+- **THEN** the Assets surface marks it as a governance issue
+- **AND** it explains that multiple local copies or interpretations disagree
+- **AND** it routes interpretation to `Analysis` rather than offering an inline
+  conflict-resolution editor
+
+#### Scenario: Orphaned asset explains missing owner
+- **WHEN** an asset has `orphaned` status
+- **THEN** the Assets surface explains that evidence exists without a durable
+  canonical owner
+- **AND** it offers source inspection when source evidence exists
+- **AND** it does not imply that the asset can be restored into a third-party
+  runtime from the Assets page
+
+#### Scenario: Unknown health remains explicit
+- **WHEN** an asset lacks enough metadata to classify health beyond `unknown`
+- **THEN** the Assets surface shows an explicit unknown or unavailable
+  explanation
+- **AND** it does not treat the asset as active, unused, stale, or conflicted
+  by inference alone
+
+### Requirement: Assets SHALL summarize governance issues by class
+The system SHALL summarize affected reusable context assets by governance issue
+class while keeping the inventory and filters visible.
+
+#### Scenario: Issue summary names affected classes
+- **WHEN** the filtered inventory contains stale, conflicted, orphaned, or
+  unknown assets
+- **THEN** the summary shows compact issue counts by class
+- **AND** the summary keeps subtype, scope, source, and status filters visible
+
+#### Scenario: No issue summary does not imply complete scan
+- **WHEN** the filtered inventory contains no known issue assets
+- **THEN** the summary may show no known issues
+- **AND** it does not claim that every local source runtime has been completely
+  scanned unless provider evidence exists
+
+### Requirement: Asset detail SHALL show bounded governance inspection
+The system SHALL make selected asset detail sufficient for bounded governance
+inspection without adding editing or sync controls.
+
+#### Scenario: Detail includes health, provenance, and route owner
+- **WHEN** the user selects an asset
+- **THEN** the detail panel shows the asset identity, subtype, scope, source,
+  status, provenance, in-effect state, and governance health explanation
+- **AND** each recommended next action is labeled as a route to its owning
+  surface
+
+#### Scenario: Detail keeps workflow execution out of Assets
+- **WHEN** an asset offers backup, migration preview, or project bundle
+  preparation
+- **THEN** the detail panel routes to `Backup / Migration`
+- **AND** it does not render validation, confirmation, execution, or result
+  workflow state inside Assets
+
+#### Scenario: Detail avoids mutation promises
+- **WHEN** an asset is stale, conflicted, orphaned, or unknown
+- **THEN** the detail panel uses inspection or review language
+- **AND** it does not offer inline repair, sync, deploy, restore, or edit
+  controls as part of this hardening slice
+
+### Requirement: Routed asset issue context SHALL remain compact and bounded
+The system SHALL preserve compact routed issue context when entering Assets
+from Overview or Analysis without carrying full source-page state.
+
+#### Scenario: Overview issue handoff preserves compact cue
+- **WHEN** the user opens Assets from a Project Overview attention item
+- **THEN** Assets applies any valid subtype, scope, status, or asset selection
+  supplied by the handoff
+- **AND** it shows a compact cue describing the overview issue context
+- **AND** it does not carry full overview summary state
+
+#### Scenario: Analysis issue handoff preserves compact cue
+- **WHEN** the user opens Assets from an Analysis finding
+- **THEN** Assets applies any valid affected asset, subtype, status, or issue
+  context supplied by the handoff
+- **AND** it shows a compact cue describing the analysis issue context
+- **AND** it does not carry the full findings table or evidence chain
+
+#### Scenario: Routed issue cue clears on intentional focus change
+- **WHEN** the user changes asset filters or selects a different asset outside
+  the routed issue context
+- **THEN** the routed cue is cleared
+- **AND** the Assets page continues using the user's new local focus
+
+#### Scenario: Stale routed object degrades safely
+- **WHEN** routed context references an asset that is no longer available
+- **THEN** Assets keeps still-valid filters and issue labels visible
+- **AND** it explains that the original asset could not be selected
+- **AND** it does not fabricate a replacement asset

--- a/openspec/changes/context-assets-governance-hardening/specs/context-assets/spec.md
+++ b/openspec/changes/context-assets-governance-hardening/specs/context-assets/spec.md
@@ -10,6 +10,12 @@ silently inventing missing source facts.
 - **THEN** the Assets surface explains that the asset is currently in effect
 - **AND** it shows the provenance or usage reason that supports that claim
 
+#### Scenario: Active asset without usage metadata stays informational
+- **WHEN** an asset has `active` status but lacks in-effect usage metadata
+- **THEN** the Assets surface may show it as active inventory
+- **AND** it does not claim that the asset is currently in effect by inference
+  alone
+
 #### Scenario: Stale asset explains freshness risk
 - **WHEN** an asset has `stale` status
 - **THEN** the Assets surface marks it as needing freshness review
@@ -38,6 +44,7 @@ silently inventing missing source facts.
   explanation
 - **AND** it does not treat the asset as active, unused, stale, or conflicted
   by inference alone
+- **AND** it offers source inspection only when source evidence exists
 
 ### Requirement: Assets SHALL summarize governance issues by class
 The system SHALL summarize affected reusable context assets by governance issue
@@ -54,6 +61,12 @@ class while keeping the inventory and filters visible.
 - **THEN** the summary may show no known issues
 - **AND** it does not claim that every local source runtime has been completely
   scanned unless provider evidence exists
+
+#### Scenario: Foundation provider data is labeled
+- **WHEN** the Assets surface is backed by foundation seed or partial provider
+  data rather than a complete live project inventory
+- **THEN** the page shows a visible foundation or provider data cue
+- **AND** it keeps unknown, unavailable, or unsupported evidence visible
 
 ### Requirement: Asset detail SHALL show bounded governance inspection
 The system SHALL make selected asset detail sufficient for bounded governance

--- a/openspec/changes/context-assets-governance-hardening/specs/project-shell/spec.md
+++ b/openspec/changes/context-assets-governance-hardening/specs/project-shell/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Shell SHALL route compact asset governance context
+The project shell SHALL route compact asset governance context from Overview
+and Analysis into Assets without transferring full source page state or
+executing asset operations.
+
+#### Scenario: Overview routes an asset governance issue
+- **WHEN** Project Overview opens Assets for an in-effect asset or asset-class
+  attention item
+- **THEN** the shell handoff includes only compact routing context such as
+  origin, issue label, subtype, scope, status, asset id, and continue label
+- **AND** it does not include full overview summary state, workflow state, or
+  executable asset operations
+
+#### Scenario: Analysis routes an affected asset issue
+- **WHEN** Analysis opens Assets for an affected reusable context asset or
+  asset class
+- **THEN** the shell handoff includes only compact routing context such as
+  origin, issue label, affected asset id, subtype, status, and continue label
+- **AND** it does not include the full findings table, full evidence chain, or
+  mutation instructions
+
+#### Scenario: Assets remains the destination owner after routing
+- **WHEN** the shell routes compact asset governance context into Assets
+- **THEN** Assets owns the rendered filters, selected object, stale-context
+  message, and route cue
+- **AND** the source page remains responsible only for initiating the handoff

--- a/openspec/changes/context-assets-governance-hardening/tasks.md
+++ b/openspec/changes/context-assets-governance-hardening/tasks.md
@@ -1,0 +1,45 @@
+## 1. Model Semantics
+
+- [ ] 1.1 Add derived asset governance health types and route descriptor types in `src/lib/contextAssets.ts`.
+- [ ] 1.2 Implement a helper that derives health severity, issue class, explanation, and recommended route owner from status, provenance, usage, and source reference.
+- [ ] 1.3 Implement summary helpers that count governance issue classes for filtered asset inventories.
+- [ ] 1.4 Preserve existing normalization behavior for unknown subtype, scope, source, status, provenance, and usage fields.
+
+## 2. Assets UI
+
+- [ ] 2.1 Update `AssetsFoundation` summary to show governance issue counts by class without hiding existing filters.
+- [ ] 2.2 Update selected asset detail to show health explanation, provenance, in-effect relevance, and route ownership.
+- [ ] 2.3 Keep recommended actions as routes to Sessions, Analysis, Backup / Migration, or Overview; do not add inline edit, repair, sync, deploy, restore, or workflow execution controls.
+- [ ] 2.4 Ensure stale/conflicted/orphaned/unknown assets use inspection or review copy rather than mutation promises.
+- [ ] 2.5 Decide and implement whether Assets needs an explicit seed/provider data cue similar to Project Overview, based on design open question and current UI copy.
+
+## 3. Routed Continuity
+
+- [ ] 3.1 Review Overview-to-Assets and Analysis-to-Assets handoff builders for compact issue context only.
+- [ ] 3.2 Preserve valid subtype, scope, status, asset id, issue label, and continue label from routed handoff context.
+- [ ] 3.3 Ensure full overview summary state, full findings tables, evidence chains, and mutation instructions are not carried into Assets.
+- [ ] 3.4 Keep routed issue cues visible until the user intentionally changes filters or selected asset focus.
+- [ ] 3.5 Preserve safe degradation when routed asset ids are stale or missing.
+
+## 4. Tests
+
+- [ ] 4.1 Add or update model tests for health derivation across active, stale, conflicted, orphaned, and unknown assets.
+- [ ] 4.2 Add or update model tests for governance issue summary counts.
+- [ ] 4.3 Add or update component tests for summary, selected detail, bounded action copy, and routed issue cue behavior.
+- [ ] 4.4 Add or update shell tests for Overview/Analysis compact asset handoffs.
+- [ ] 4.5 Confirm existing Sessions, Analysis, Backup / Migration, and Project Overview routing tests continue to pass.
+
+## 5. Documentation and QA
+
+- [ ] 5.1 Update README if user-facing Assets behavior or limitations change.
+- [ ] 5.2 Update CHANGELOG under `## Unreleased` for shipped Assets governance hardening behavior.
+- [ ] 5.3 Add or update an Assets governance QA prompt/report under `docs/viewer/` if browser QA is needed for the UI flow.
+- [ ] 5.4 Keep external QA reports historical if failures are found; add retest notes rather than deleting original findings.
+
+## 6. Validation
+
+- [ ] 6.1 Run targeted model/component/shell tests for the changed files.
+- [ ] 6.2 Run `pnpm exec tsc --noEmit`.
+- [ ] 6.3 Run `pnpm build` if UI or Next configuration changes.
+- [ ] 6.4 Run `OPENSPEC_TELEMETRY=0 openspec validate context-assets-governance-hardening --strict`.
+- [ ] 6.5 Before PR readiness, request OpenSpec artifact review and address only necessary review feedback.

--- a/openspec/changes/context-assets-governance-hardening/tasks.md
+++ b/openspec/changes/context-assets-governance-hardening/tasks.md
@@ -11,7 +11,7 @@
 - [ ] 2.2 Update selected asset detail to show health explanation, provenance, in-effect relevance, and route ownership.
 - [ ] 2.3 Keep recommended actions as routes to Sessions, Analysis, Backup / Migration, or Overview; do not add inline edit, repair, sync, deploy, restore, or workflow execution controls.
 - [ ] 2.4 Ensure stale/conflicted/orphaned/unknown assets use inspection or review copy rather than mutation promises.
-- [ ] 2.5 Decide and implement whether Assets needs an explicit seed/provider data cue similar to Project Overview, based on design open question and current UI copy.
+- [ ] 2.5 Add an explicit foundation/provider data cue when Assets is backed by seed or partial provider data rather than complete live project inventory.
 
 ## 3. Routed Continuity
 


### PR DESCRIPTION
## Summary
- propose the `context-assets-governance-hardening` OpenSpec change
- add delta requirements for Assets governance health, issue summaries, bounded detail inspection, and routed issue continuity
- add project-shell delta requirements for compact Overview/Analysis-to-Assets governance handoffs
- include implementation tasks for model, UI, routing, tests, docs, QA, and validation

## Validation
- OPENSPEC_TELEMETRY=0 openspec validate context-assets-governance-hardening --strict
- OpenSpec reviewer subagent re-review: approved

## Notes
- This is spec-only. Implementation should follow in a separate feature PR after artifact acceptance.