### PR TITLE
feat: harden assets governance surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-04-19` — Assets governance hardening
+  - Added derived governance health semantics for reusable context assets, including healthy, informational, warning, and unknown states
+  - Updated `Assets` summary and detail views with governance issue class counts, provenance/in-effect explanations, route ownership, and foundation data cues
+  - Preserved compact Overview/Analysis issue handoffs into `Assets` while keeping editing, repair, sync, deploy, restore, and workflow execution outside the Assets surface
+
 - `2026-04-18` — Project bundle hardening
   - Hardened `/api/project-bundles` so generation requires explicit selection/configuration, invalid modes return structured errors, and generate responses expose summary-shaped display data only
   - Strengthened project bundle validation for global output-root blockers, structural blockers, missing-package warnings, safe diagnostics, and deterministic newest matching session backup reuse

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - `Analysis` provides a bounded interpretation-and-routing foundation for local context findings
   - `Backup / Migration` provides bounded workflow-first backup and migration-preview surfaces without turning into a generic tools drawer or migration apply UI
 - Assets foundation:
-  - local-first reusable context asset model with subtype, scope, source, status, provenance, optional body summary, and in-effect/usage metadata
-  - subtype/scope/source/status filtering with asset summary, inventory, selected detail, provenance, and in-effect/usage regions
-  - routed handoff into `Assets` from Sessions, Project Overview, and Analysis without carrying full transcript or trajectory state
+  - local-first reusable context asset model with subtype, scope, source, status, provenance, optional body summary, in-effect/usage metadata, and derived governance health
+  - subtype/scope/source/status filtering with asset summary, governance issue class counts, inventory, selected detail, provenance, and in-effect/usage regions
+  - route-only governance inspection for Sessions, Analysis, Backup / Migration, or Project Overview without inline edit, repair, sync, deploy, restore, or workflow execution controls
+  - routed handoff into `Assets` from Sessions, Project Overview, and Analysis with compact issue context only, without carrying full transcript, overview summary state, findings tables, or trajectory state
 - Analysis foundation:
   - local-first analysis finding model with issue class, severity, status, affected object, evidence references, route targets, and preservation warnings
   - context health summary, findings inventory, selected finding detail, evidence context, and route-only recommended actions

--- a/docs/viewer/assets-governance-hardening-qa-prompt.md
+++ b/docs/viewer/assets-governance-hardening-qa-prompt.md
@@ -1,0 +1,41 @@
+# Assets Governance Hardening QA Prompt
+
+Use this prompt to run a focused QA pass for Assets governance hardening.
+
+## Scope
+
+- Verify `Assets` shows a foundation/provider data cue and does not imply a complete live project scan.
+- Verify the summary keeps subtype/scope/source/status filters visible while showing governance issue counts for freshness, conflict, orphaned, and unknown classes.
+- Verify selected detail explains governance health, provenance, in-effect relevance, and the route owner.
+- Verify stale, conflicted, orphaned, and unknown assets use inspection/review language only.
+- Verify Overview and Analysis routes into `Assets` preserve compact issue context without carrying full overview summaries, findings tables, evidence chains, mutation instructions, or workflow state.
+
+## Expected Boundaries
+
+- `Assets` may route to `Sessions`, `Analysis`, `Backup / Migration`, or `Project Overview`.
+- `Assets` must not render inline edit, repair, sync, deploy, restore, validation, confirmation, execution, or workflow result controls.
+- Unknown health should remain explicit and non-blocking.
+- Seed/provider-backed data must stay labeled as incomplete foundation data.
+
+## Suggested Flow
+
+1. Open the app at `/` and confirm `Project Overview` is selected by default.
+2. Open `Assets` from the top-level navigation.
+3. Confirm the foundation data cue is visible near the Assets header.
+4. Confirm filters remain visible and the summary shows governance issue class counts.
+5. Select an active in-effect rule and confirm it shows `healthy`, an in-effect explanation, source/provenance context, and route ownership.
+6. Select or route to a stale memory and confirm it shows freshness review copy and route-only actions.
+7. Select or route to a conflicted skill and confirm it routes interpretation to `Analysis` rather than offering inline conflict resolution.
+8. Select or route to an orphaned command and confirm it explains the missing canonical owner without implying runtime restore.
+9. Select or route to an unknown imported fragment and confirm unknown metadata stays explicit and non-blocking.
+10. From `Project Overview`, open an in-effect asset or attention item into `Assets`; confirm only compact issue context appears.
+11. From `Analysis`, open an affected asset route into `Assets`; confirm only compact issue context appears.
+12. Change an Assets filter or select a different asset; confirm the routed cue clears and the new local focus remains active.
+
+## Report Format
+
+- Environment: branch, commit, browser, date
+- Pass/fail summary
+- Evidence notes for health mapping, issue counts, detail route ownership, and bounded action copy
+- Routed continuity notes for Overview -> Assets and Analysis -> Assets
+- Regressions in neighboring `Sessions`, `Analysis`, `Backup / Migration`, or shell navigation

--- a/docs/viewer/assets-governance-hardening-qa.md
+++ b/docs/viewer/assets-governance-hardening-qa.md
@@ -1,0 +1,69 @@
+# Assets Governance Hardening QA Report
+
+**Branch**: `feat/context-assets-governance-hardening`  
+**PR**: `#74`  
+**Date**: 2026-04-19  
+**QA Method**: local browser automation against `http://127.0.0.1:3000` using `agent-browser`
+
+## Verdict
+
+**PASS**
+
+I verified the Assets governance hardening flow in a real browser, including the provider-data cue, governance issue counts, selected detail health/provenance/in-effect explanations, route-only actions, compact routed context from Overview, and cue clearing after local focus changes.
+
+## Environment
+
+- Local app: `http://127.0.0.1:3000`
+- Server start command: `pnpm exec next dev -H 127.0.0.1 -p 3000`
+- Browser runner: `agent-browser`
+
+## What I Verified
+
+- Assets shows the local seed/provider-shaped foundation cue instead of pretending to be a full live scan.
+- Governance issue counts are visible and update with filter changes.
+- Selected asset detail shows identity, scope, source, status, provenance, governance health, route owner, and in-effect usage explanation.
+- Route actions remain bounded to navigation into `Sessions`, `Analysis`, or `Backup / Migration`.
+- No inline edit, repair, sync, deploy, restore, validation, confirmation, execution, or result UI appears inside Assets.
+- Overview-to-Assets routed context is compact and labeled `from overview`.
+- Routed cue clears when local focus changes.
+
+## Findings
+
+### Verified detail behavior
+
+Selected the `Project coding rules` asset by DOM click and confirmed:
+
+- governance health shows `Active and currently in effect`
+- route owner is `Sessions`
+- provenance is shown as extracted from the current project instruction set
+- in-effect/usage explanation is present
+- only route actions are exposed
+
+Then selected the `User review preference memory` asset after changing subtype to `Memory` and confirmed:
+
+- governance health explains freshness risk
+- route owner is `Sessions`
+- the in-effect section says the asset is unavailable instead of inferring active use
+- route-only actions remain bounded
+
+### Verified cue clearing
+
+Starting from an overview-routed Assets view, I changed subtype from `Rule` to `Memory` through the DOM. The routed cue strip cleared as expected and the page continued with the new local focus.
+
+## Commands Used
+
+- `pnpm exec next dev -H 127.0.0.1 -p 3000`
+- `agent-browser open http://127.0.0.1:3000`
+- `agent-browser snapshot -i`
+- `agent-browser click @e26`
+- `agent-browser eval '(() => { const btn = [...document.querySelectorAll("button")].find(b => b.textContent.includes("Project coding rules")); if (!btn) return "not found"; btn.click(); return btn.textContent; })()'`
+- `agent-browser eval '(() => { const select = document.querySelectorAll("select")[0]; if (!select) return "no-select"; select.value = "memory"; select.dispatchEvent(new Event("change", { bubbles: true })); return select.value; })()'`
+- `agent-browser eval '(() => { const btn = [...document.querySelectorAll("button")].find(b => b.textContent.includes("User review preference memory")); if (!btn) return "not found"; btn.click(); return btn.textContent; })()'`
+
+## Browser-Tooling Note
+
+Plain `agent-browser click @e15` was not reliable for the Assets row selection in this run, so I switched to fresh snapshots and direct DOM clicks via `agent-browser eval`. The app behavior itself was correct once the element was clicked directly.
+
+## PR Readiness
+
+No blockers remain for PR `#74` on the verified Assets governance hardening scope.

--- a/openspec/changes/context-assets-governance-hardening/tasks.md
+++ b/openspec/changes/context-assets-governance-hardening/tasks.md
@@ -1,45 +1,46 @@
 ## 1. Model Semantics
 
-- [ ] 1.1 Add derived asset governance health types and route descriptor types in `src/lib/contextAssets.ts`.
-- [ ] 1.2 Implement a helper that derives health severity, issue class, explanation, and recommended route owner from status, provenance, usage, and source reference.
-- [ ] 1.3 Implement summary helpers that count governance issue classes for filtered asset inventories.
-- [ ] 1.4 Preserve existing normalization behavior for unknown subtype, scope, source, status, provenance, and usage fields.
+- [x] 1.1 Add derived asset governance health types and route descriptor types in `src/lib/contextAssets.ts`.
+- [x] 1.2 Implement a helper that derives health severity, issue class, explanation, and recommended route owner from status, provenance, usage, and source reference.
+- [x] 1.3 Implement summary helpers that count governance issue classes for filtered asset inventories.
+- [x] 1.4 Preserve existing normalization behavior for unknown subtype, scope, source, status, provenance, and usage fields.
 
 ## 2. Assets UI
 
-- [ ] 2.1 Update `AssetsFoundation` summary to show governance issue counts by class without hiding existing filters.
-- [ ] 2.2 Update selected asset detail to show health explanation, provenance, in-effect relevance, and route ownership.
-- [ ] 2.3 Keep recommended actions as routes to Sessions, Analysis, Backup / Migration, or Overview; do not add inline edit, repair, sync, deploy, restore, or workflow execution controls.
-- [ ] 2.4 Ensure stale/conflicted/orphaned/unknown assets use inspection or review copy rather than mutation promises.
-- [ ] 2.5 Add an explicit foundation/provider data cue when Assets is backed by seed or partial provider data rather than complete live project inventory.
+- [x] 2.1 Update `AssetsFoundation` summary to show governance issue counts by class without hiding existing filters.
+- [x] 2.2 Update selected asset detail to show health explanation, provenance, in-effect relevance, and route ownership.
+- [x] 2.3 Keep recommended actions as routes to Sessions, Analysis, Backup / Migration, or Overview; do not add inline edit, repair, sync, deploy, restore, or workflow execution controls.
+- [x] 2.4 Ensure stale/conflicted/orphaned/unknown assets use inspection or review copy rather than mutation promises.
+- [x] 2.5 Add an explicit foundation/provider data cue when Assets is backed by seed or partial provider data rather than complete live project inventory.
 
 ## 3. Routed Continuity
 
-- [ ] 3.1 Review Overview-to-Assets and Analysis-to-Assets handoff builders for compact issue context only.
-- [ ] 3.2 Preserve valid subtype, scope, status, asset id, issue label, and continue label from routed handoff context.
-- [ ] 3.3 Ensure full overview summary state, full findings tables, evidence chains, and mutation instructions are not carried into Assets.
-- [ ] 3.4 Keep routed issue cues visible until the user intentionally changes filters or selected asset focus.
-- [ ] 3.5 Preserve safe degradation when routed asset ids are stale or missing.
+- [x] 3.1 Review Overview-to-Assets and Analysis-to-Assets handoff builders for compact issue context only.
+- [x] 3.2 Preserve valid subtype, scope, status, asset id, issue label, and continue label from routed handoff context.
+- [x] 3.3 Ensure full overview summary state, full findings tables, evidence chains, and mutation instructions are not carried into Assets.
+- [x] 3.4 Keep routed issue cues visible until the user intentionally changes filters or selected asset focus.
+- [x] 3.5 Preserve safe degradation when routed asset ids are stale or missing.
 
 ## 4. Tests
 
-- [ ] 4.1 Add or update model tests for health derivation across active, stale, conflicted, orphaned, and unknown assets.
-- [ ] 4.2 Add or update model tests for governance issue summary counts.
-- [ ] 4.3 Add or update component tests for summary, selected detail, bounded action copy, and routed issue cue behavior.
-- [ ] 4.4 Add or update shell tests for Overview/Analysis compact asset handoffs.
-- [ ] 4.5 Confirm existing Sessions, Analysis, Backup / Migration, and Project Overview routing tests continue to pass.
+- [x] 4.1 Add or update model tests for health derivation across active, stale, conflicted, orphaned, and unknown assets.
+- [x] 4.2 Add or update model tests for governance issue summary counts.
+- [x] 4.3 Add or update component tests for summary, selected detail, bounded action copy, and routed issue cue behavior.
+- [x] 4.4 Add or update shell tests for Overview/Analysis compact asset handoffs.
+- [x] 4.5 Confirm existing Sessions, Analysis, Backup / Migration, and Project Overview routing tests continue to pass.
 
 ## 5. Documentation and QA
 
-- [ ] 5.1 Update README if user-facing Assets behavior or limitations change.
-- [ ] 5.2 Update CHANGELOG under `## Unreleased` for shipped Assets governance hardening behavior.
-- [ ] 5.3 Add or update an Assets governance QA prompt/report under `docs/viewer/` if browser QA is needed for the UI flow.
-- [ ] 5.4 Keep external QA reports historical if failures are found; add retest notes rather than deleting original findings.
+- [x] 5.1 Update README if user-facing Assets behavior or limitations change.
+- [x] 5.2 Update CHANGELOG under `## Unreleased` for shipped Assets governance hardening behavior.
+- [x] 5.3 Add or update an Assets governance QA prompt/report under `docs/viewer/` if browser QA is needed for the UI flow.
+- [x] 5.4 Keep external QA reports historical if failures are found; add retest notes rather than deleting original findings.
 
 ## 6. Validation
 
-- [ ] 6.1 Run targeted model/component/shell tests for the changed files.
-- [ ] 6.2 Run `pnpm exec tsc --noEmit`.
-- [ ] 6.3 Run `pnpm build` if UI or Next configuration changes.
-- [ ] 6.4 Run `OPENSPEC_TELEMETRY=0 openspec validate context-assets-governance-hardening --strict`.
-- [ ] 6.5 Before PR readiness, request OpenSpec artifact review and address only necessary review feedback.
+- [x] 6.1 Run targeted model/component/shell tests for the changed files.
+- [x] 6.2 Run `pnpm exec tsc --noEmit`.
+- [x] 6.3 Run `pnpm build` if UI or Next configuration changes.
+- [x] 6.4 Run `OPENSPEC_TELEMETRY=0 openspec validate context-assets-governance-hardening --strict`.
+- [x] 6.5 Before PR readiness, request OpenSpec artifact review and address only necessary review feedback.
+  - Volta reviewed the artifacts before implementation and approved after the necessary severity/provider-cue revisions.

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -269,7 +269,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                   <div className="mt-1 font-semibold text-foreground">{summary.inEffect}</div>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/15 px-3 py-2">
-                  <div className="text-xs uppercase tracking-[0.18em]">Governance issues</div>
+                  <div className="text-xs uppercase tracking-[0.18em]">Warning issues</div>
                   <div className="mt-1 font-semibold text-foreground">{summary.issueCount}</div>
                 </div>
               </div>
@@ -392,7 +392,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                         </div>
                         <div className="flex shrink-0 flex-wrap gap-2">
                           {asset.usage.state === "in_effect" ? <Badge variant="ok">in effect</Badge> : null}
-                          {isIssueContextAsset(asset) ? <Badge variant="warn">needs attention</Badge> : null}
+                          {health.severity === "warning" ? <Badge variant="warn">needs attention</Badge> : null}
                           {health.severity === "unknown" ? <Badge variant="default">non-blocking unknown</Badge> : null}
                         </div>
                       </div>

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -40,6 +40,7 @@ export type AssetsFoundationProps = {
   onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
   onOpenAnalysis(context: { issueLabel: string; assetId?: string; subtype?: ContextAssetSubtype; status?: ContextAssetStatus }): void;
   onOpenBackup(context: { assetId?: string; subtype?: ContextAssetSubtype; workflowType?: "migration-preview" | "project-bundle" }): void;
+  onOpenOverview?(): void;
   loadingDelayMs?: number;
 };
 
@@ -111,7 +112,7 @@ function renderSeverityBadge(severity: ContextAssetGovernanceSeverity) {
   return <Badge variant="default">informational</Badge>;
 }
 
-export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpenBackup, loadingDelayMs = LOADING_DELAY_MS }: AssetsFoundationProps) {
+export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpenBackup, onOpenOverview, loadingDelayMs = LOADING_DELAY_MS }: AssetsFoundationProps) {
   const assets = useMemo(() => createContextAssetSeeds(), []);
   const initialFilters = buildFiltersFromAssetsHandoff(handoff, createDefaultContextAssetFilters());
   const initialFilteredAssets = applyContextAssetFilters(assets, initialFilters);
@@ -451,7 +452,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                   <div className="text-xs uppercase tracking-[0.18em] text-muted">Provenance</div>
                   <div className="leading-6 text-muted">{selectedAssetHealth?.provenanceExplanation}</div>
                   <div className="flex flex-wrap gap-2">
-                    {selectedAsset.sourceReference?.target === "session" && selectedAsset.sourceReference.sessionId && selectedAsset.sourceReference.source ? (
+                    {(selectedAsset.sourceReference?.target === "session" || selectedAsset.sourceReference?.target === "source") && selectedAsset.sourceReference.sessionId && selectedAsset.sourceReference.source ? (
                       <Button
                         size="sm"
                         variant="outline"
@@ -480,6 +481,11 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                         }
                       >
                         Route to Analysis: {selectedAsset.sourceReference.label}
+                      </Button>
+                    ) : null}
+                    {selectedAssetHealth?.recommendedRoute.target === "overview" && onOpenOverview ? (
+                      <Button size="sm" variant="outline" onClick={onOpenOverview}>
+                        Route to Project Overview: review governance context
                       </Button>
                     ) : null}
                   </div>
@@ -516,7 +522,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                 {selectedAssetHealth?.inEffectExplanation}
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
-                {selectedAsset.sourceReference?.target === "session" && selectedAsset.sourceReference.sessionId && selectedAsset.sourceReference.source ? (
+                {(selectedAsset.sourceReference?.target === "session" || selectedAsset.sourceReference?.target === "source") && selectedAsset.sourceReference.sessionId && selectedAsset.sourceReference.source ? (
                   <Button
                     size="sm"
                     variant="outline"

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -21,7 +21,6 @@ import {
   formatContextAssetSourceLabel,
   formatContextAssetStatusLabel,
   formatContextAssetSubtypeLabel,
-  isIssueContextAsset,
   resolveContextAssetSelection,
   summarizeContextAssets,
   type AssetsHandoff,

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -291,7 +291,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
               <Badge variant={summary.governanceIssueCounts.orphaned > 0 ? "warn" : "default"}>
                 Orphaned {summary.governanceIssueCounts.orphaned}
               </Badge>
-              <Badge variant={summary.governanceIssueCounts.unknown > 0 ? "default" : "default"}>
+              <Badge variant="default">
                 Unknown {summary.governanceIssueCounts.unknown}
               </Badge>
             </div>

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -15,6 +15,7 @@ import {
   buildFiltersFromAssetsHandoff,
   createContextAssetSeeds,
   createDefaultContextAssetFilters,
+  deriveContextAssetGovernanceHealth,
   deriveAssetsSurfaceState,
   formatContextAssetScopeLabel,
   formatContextAssetSourceLabel,
@@ -26,6 +27,7 @@ import {
   type AssetsHandoff,
   type ContextAsset,
   type ContextAssetFilters,
+  type ContextAssetGovernanceSeverity,
   type ContextAssetScope,
   type ContextAssetSource,
   type ContextAssetStatus,
@@ -102,6 +104,13 @@ function renderStatusBadge(status: ContextAssetStatus) {
   return <Badge variant="warn">{formatContextAssetStatusLabel(status)}</Badge>;
 }
 
+function renderSeverityBadge(severity: ContextAssetGovernanceSeverity) {
+  if (severity === "healthy") return <Badge variant="ok">healthy</Badge>;
+  if (severity === "warning") return <Badge variant="warn">warning</Badge>;
+  if (severity === "unknown") return <Badge variant="default">unknown</Badge>;
+  return <Badge variant="default">informational</Badge>;
+}
+
 export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpenBackup, loadingDelayMs = LOADING_DELAY_MS }: AssetsFoundationProps) {
   const assets = useMemo(() => createContextAssetSeeds(), []);
   const initialFilters = buildFiltersFromAssetsHandoff(handoff, createDefaultContextAssetFilters());
@@ -158,6 +167,10 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
     () => filteredAssets.find((asset) => asset.id === selectedAssetId) ?? null,
     [filteredAssets, selectedAssetId]
   );
+  const selectedAssetHealth = useMemo(
+    () => selectedAsset ? deriveContextAssetGovernanceHealth(selectedAsset) : null,
+    [selectedAsset]
+  );
   const summary = useMemo(() => summarizeContextAssets(filteredAssets), [filteredAssets]);
   const surfaceState = deriveAssetsSurfaceState({
     isLoading,
@@ -203,6 +216,9 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
             <p className="max-w-3xl text-sm leading-6 text-muted">
               Inspect rules, memory, skills, and commands by subtype, scope, source, status, provenance, and in-effect relevance without turning this page into a generic editor or migration workflow.
             </p>
+            <div className="rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-2 text-xs leading-5 text-muted">
+              Foundation data cue: this Assets inventory is backed by local seed/provider-shaped data, not a complete live project scan. Unknown, unavailable, and unsupported evidence remains visible.
+            </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <FilterSelect
@@ -252,7 +268,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                   <div className="mt-1 font-semibold text-foreground">{summary.inEffect}</div>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/15 px-3 py-2">
-                  <div className="text-xs uppercase tracking-[0.18em]">Needs review</div>
+                  <div className="text-xs uppercase tracking-[0.18em]">Governance issues</div>
                   <div className="mt-1 font-semibold text-foreground">{summary.issueCount}</div>
                 </div>
               </div>
@@ -264,10 +280,27 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                 </Badge>
               ))}
             </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Badge variant={summary.governanceIssueCounts.freshness > 0 ? "warn" : "default"}>
+                Freshness {summary.governanceIssueCounts.freshness}
+              </Badge>
+              <Badge variant={summary.governanceIssueCounts.conflict > 0 ? "warn" : "default"}>
+                Conflict {summary.governanceIssueCounts.conflict}
+              </Badge>
+              <Badge variant={summary.governanceIssueCounts.orphaned > 0 ? "warn" : "default"}>
+                Orphaned {summary.governanceIssueCounts.orphaned}
+              </Badge>
+              <Badge variant={summary.governanceIssueCounts.unknown > 0 ? "default" : "default"}>
+                Unknown {summary.governanceIssueCounts.unknown}
+              </Badge>
+            </div>
+            <p className="mt-3 text-xs leading-5 text-muted">
+              No known issue count means no stale, conflicted, orphaned, or unknown asset in the filtered seed/provider inventory; it does not prove every local runtime has been scanned.
+            </p>
             {surfaceState === "issue" ? (
               <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-3 text-sm text-muted">
                 <div>
-                  The current inventory contains stale, conflicted, or orphaned assets. Use Analysis for grouped interpretation when object-level review is not enough.
+                  The current inventory contains warning-class assets. Use Analysis for grouped interpretation when object-level inspection is not enough.
                 </div>
                 <Button
                   size="sm"
@@ -281,7 +314,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                     })
                   }
                 >
-                  Open Analysis
+                  Route to Analysis
                 </Button>
               </div>
             ) : null}
@@ -327,6 +360,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
               <div className="space-y-3">
                 {filteredAssets.map((asset) => {
                   const selected = asset.id === selectedAssetId;
+                  const health = deriveContextAssetGovernanceHealth(asset);
                   return (
                     <button
                       key={asset.id}
@@ -347,6 +381,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                             <div className="font-medium text-foreground">{asset.title}</div>
                             <Badge variant="default">{formatContextAssetSubtypeLabel(asset.subtype)}</Badge>
                             {renderStatusBadge(asset.status)}
+                            {renderSeverityBadge(health.severity)}
                           </div>
                           <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted">
                             <span>{formatContextAssetScopeLabel(asset.scope)}</span>
@@ -357,6 +392,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                         <div className="flex shrink-0 flex-wrap gap-2">
                           {asset.usage.state === "in_effect" ? <Badge variant="ok">in effect</Badge> : null}
                           {isIssueContextAsset(asset) ? <Badge variant="warn">needs attention</Badge> : null}
+                          {health.severity === "unknown" ? <Badge variant="default">non-blocking unknown</Badge> : null}
                         </div>
                       </div>
                     </button>
@@ -385,6 +421,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                     <Badge variant="default">{formatContextAssetScopeLabel(selectedAsset.scope)}</Badge>
                     <Badge variant="default">{formatContextAssetSourceLabel(selectedAsset.source)}</Badge>
                     {renderStatusBadge(selectedAsset.status)}
+                    {selectedAssetHealth ? renderSeverityBadge(selectedAssetHealth.severity) : null}
                   </div>
                 </div>
 
@@ -399,8 +436,20 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                 )}
 
                 <div className="space-y-2 rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
+                  <div className="text-xs uppercase tracking-[0.18em] text-muted">Governance Health</div>
+                  <div className="leading-6 text-muted">{selectedAssetHealth?.explanation}</div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant={selectedAssetHealth?.issueClass === "none" ? "ok" : selectedAssetHealth?.issueClass === "unknown" ? "default" : "warn"}>
+                      issue class: {selectedAssetHealth?.issueClass}
+                    </Badge>
+                    <Badge variant="default">route owner: {selectedAssetHealth?.recommendedRoute.owner}</Badge>
+                  </div>
+                  <div className="text-xs leading-5 text-muted">{selectedAssetHealth?.recommendedRoute.reason}</div>
+                </div>
+
+                <div className="space-y-2 rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm">
                   <div className="text-xs uppercase tracking-[0.18em] text-muted">Provenance</div>
-                  <div className="leading-6 text-muted">{selectedAsset.provenance}</div>
+                  <div className="leading-6 text-muted">{selectedAssetHealth?.provenanceExplanation}</div>
                   <div className="flex flex-wrap gap-2">
                     {selectedAsset.sourceReference?.target === "session" && selectedAsset.sourceReference.sessionId && selectedAsset.sourceReference.source ? (
                       <Button
@@ -414,7 +463,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                           })
                         }
                       >
-                        {selectedAsset.sourceReference.label}
+                        Route to Sessions: {selectedAsset.sourceReference.label}
                       </Button>
                     ) : null}
                     {selectedAsset.sourceReference?.target === "analysis" ? (
@@ -430,7 +479,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                           })
                         }
                       >
-                        {selectedAsset.sourceReference.label}
+                        Route to Analysis: {selectedAsset.sourceReference.label}
                       </Button>
                     ) : null}
                   </div>
@@ -438,10 +487,10 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
 
                 <div className="flex flex-wrap gap-2">
                   <Button size="sm" variant="outline" onClick={() => onOpenBackup({ assetId: selectedAsset.id, subtype: selectedAsset.subtype, workflowType: "migration-preview" })}>
-                    Preview in Backup / Migration
+                    Route to Backup / Migration: preview scope
                   </Button>
                   <Button size="sm" variant="outline" onClick={() => onOpenBackup({ assetId: selectedAsset.id, subtype: selectedAsset.subtype, workflowType: "project-bundle" })}>
-                    Open Project Bundle
+                    Route to Backup / Migration: project bundle
                   </Button>
                 </div>
               </div>
@@ -464,7 +513,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                 {selectedAsset.usage.state === "unknown" ? <Badge variant="default">unavailable</Badge> : null}
               </div>
               <div className="rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-sm leading-6 text-muted">
-                {selectedAsset.usage.summary}
+                {selectedAssetHealth?.inEffectExplanation}
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
                 {selectedAsset.sourceReference?.target === "session" && selectedAsset.sourceReference.sessionId && selectedAsset.sourceReference.source ? (
@@ -479,7 +528,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                       })
                     }
                   >
-                    Review related session
+                    Route to Sessions: review related session
                   </Button>
                 ) : null}
                 <Button
@@ -494,7 +543,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
                     })
                   }
                 >
-                  Review in Analysis
+                  Route to Analysis: review usage context
                 </Button>
               </div>
             </Card>

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -1023,6 +1023,7 @@ export default function ProjectShellClient() {
               onOpenSession={handleOpenSessionFromContext}
               onOpenAnalysis={handleOpenAnalysisFromAssets}
               onOpenBackup={handleOpenBackupFromAssets}
+              onOpenOverview={() => handleNavigate("overview")}
             />
           ) : null}
           {activePage === "analysis" ? (

--- a/src/lib/contextAssets.ts
+++ b/src/lib/contextAssets.ts
@@ -415,7 +415,7 @@ export function summarizeContextAssets(assets: ContextAsset[]): ContextAssetSumm
     governanceIssueCounts[health.issueClass] += 1;
     severityCounts[health.severity] += 1;
     if (asset.usage.state === "in_effect") inEffect += 1;
-    if (health.issueClass !== "none") issueCount += 1;
+    if (health.severity === "warning") issueCount += 1;
   }
 
   return {
@@ -441,8 +441,9 @@ export function deriveAssetsSurfaceState(input: {
     ? input.filteredAssets.find((asset) => asset.id === input.selectedAssetId)
     : undefined;
 
+  const selectedHealth = selected ? deriveContextAssetGovernanceHealth(selected) : null;
   const issueVisible = input.filteredAssets.some((asset) => deriveContextAssetGovernanceHealth(asset).severity === "warning");
-  if (selected && deriveContextAssetGovernanceHealth(selected).severity === "warning") return "issue";
+  if (selectedHealth?.severity === "warning") return "issue";
   if (issueVisible) return "issue";
   if (selected) return "selected";
   return "normal";

--- a/src/lib/contextAssets.ts
+++ b/src/lib/contextAssets.ts
@@ -311,7 +311,11 @@ function buildRouteDescriptor(asset: ContextAsset, issueClass: ContextAssetGover
     };
   }
 
-  if (asset.sourceReference?.target === "session" && asset.sourceReference.sessionId && asset.sourceReference.source) {
+  if (
+    (asset.sourceReference?.target === "session" || asset.sourceReference?.target === "source")
+    && asset.sourceReference.sessionId
+    && asset.sourceReference.source
+  ) {
     return {
       owner: "Sessions",
       target: "session",

--- a/src/lib/contextAssets.ts
+++ b/src/lib/contextAssets.ts
@@ -10,6 +10,9 @@ export type ContextAssetScope = (typeof CONTEXT_ASSET_SCOPES)[number];
 export type ContextAssetSource = (typeof CONTEXT_ASSET_SOURCES)[number];
 export type ContextAssetStatus = (typeof CONTEXT_ASSET_STATUSES)[number];
 export type ContextAssetUsageState = "in_effect" | "not_in_effect" | "unknown";
+export type ContextAssetGovernanceSeverity = "healthy" | "informational" | "warning" | "unknown";
+export type ContextAssetGovernanceIssueClass = "none" | "freshness" | "conflict" | "orphaned" | "unknown";
+export type ContextAssetRouteOwner = "Sessions" | "Analysis" | "Backup / Migration" | "Project Overview";
 
 export type ContextAssetSourceReference = {
   label: string;
@@ -60,10 +63,28 @@ export type ContextAssetFilters = {
   status: ContextAssetStatus | "all";
 };
 
+export type ContextAssetRouteDescriptor = {
+  owner: ContextAssetRouteOwner;
+  label: string;
+  reason: string;
+  target: "session" | "analysis" | "backup" | "overview";
+};
+
+export type ContextAssetGovernanceHealth = {
+  severity: ContextAssetGovernanceSeverity;
+  issueClass: ContextAssetGovernanceIssueClass;
+  explanation: string;
+  inEffectExplanation: string;
+  provenanceExplanation: string;
+  recommendedRoute: ContextAssetRouteDescriptor;
+};
+
 export type ContextAssetSummary = {
   total: number;
   inEffect: number;
   issueCount: number;
+  governanceIssueCounts: Record<ContextAssetGovernanceIssueClass, number>;
+  severityCounts: Record<ContextAssetGovernanceSeverity, number>;
   subtypeCounts: Record<ContextAssetSubtype, number>;
   statusCounts: Record<ContextAssetStatus, number>;
 };
@@ -86,7 +107,8 @@ export type AssetsHandoff = {
 
 export type AssetsSurfaceState = "loading" | "empty" | "normal" | "selected" | "issue";
 
-const ISSUE_STATUSES = new Set<ContextAssetStatus>(["stale", "conflicted", "orphaned"]);
+const GOVERNANCE_ISSUE_CLASSES: ContextAssetGovernanceIssueClass[] = ["none", "freshness", "conflict", "orphaned", "unknown"];
+const GOVERNANCE_SEVERITIES: ContextAssetGovernanceSeverity[] = ["healthy", "informational", "warning", "unknown"];
 
 const DEFAULT_USAGE: ContextAssetUsage = {
   state: "unknown",
@@ -279,23 +301,125 @@ export function applyContextAssetFilters(assets: ContextAsset[], filters: Contex
   });
 }
 
+function buildRouteDescriptor(asset: ContextAsset, issueClass: ContextAssetGovernanceIssueClass): ContextAssetRouteDescriptor {
+  if (asset.status === "conflicted" || issueClass === "conflict") {
+    return {
+      owner: "Analysis",
+      target: "analysis",
+      label: "Review grouped interpretation in Analysis",
+      reason: "Analysis owns disagreement triage; Assets only shows object-level context.",
+    };
+  }
+
+  if (asset.sourceReference?.target === "session" && asset.sourceReference.sessionId && asset.sourceReference.source) {
+    return {
+      owner: "Sessions",
+      target: "session",
+      label: "Inspect source evidence in Sessions",
+      reason: "Sessions owns source evidence reading without embedding transcripts inside Assets.",
+    };
+  }
+
+  if (asset.sourceReference?.target === "backup") {
+    return {
+      owner: "Backup / Migration",
+      target: "backup",
+      label: "Prepare workflow context in Backup / Migration",
+      reason: "Backup / Migration owns workflow validation and execution.",
+    };
+  }
+
+  if (asset.status === "unknown" || issueClass === "unknown") {
+    return {
+      owner: "Project Overview",
+      target: "overview",
+      label: "Return to Project Overview",
+      reason: "Project Overview owns summary-level governance context when object evidence is incomplete.",
+    };
+  }
+
+  return {
+    owner: "Analysis",
+    target: "analysis",
+    label: "Review asset context in Analysis",
+    reason: "Analysis owns grouped interpretation when object-level inspection is not enough.",
+  };
+}
+
+export function deriveContextAssetGovernanceHealth(asset: ContextAsset): ContextAssetGovernanceHealth {
+  const provenanceExplanation = asset.provenance || "Provenance unavailable.";
+  const usageSummary = asset.usage.summary || DEFAULT_USAGE.summary;
+  const inEffectExplanation = asset.usage.state === "in_effect"
+    ? `In effect: ${usageSummary}`
+    : asset.usage.state === "not_in_effect"
+      ? `Not currently in effect: ${usageSummary}`
+      : "In-effect data is unavailable; Assets will not infer whether this asset is unused or active in the project.";
+
+  let severity: ContextAssetGovernanceSeverity = "informational";
+  let issueClass: ContextAssetGovernanceIssueClass = "none";
+  let explanation = "Asset is available for inspection, but no stronger governance state is inferred.";
+
+  if (asset.status === "active" && asset.usage.state === "in_effect") {
+    severity = "healthy";
+    explanation = `Active and currently in effect. ${usageSummary}`;
+  } else if (asset.status === "active") {
+    severity = "informational";
+    explanation = "Active inventory is present, but current in-effect usage is not proven by metadata.";
+  } else if (asset.status === "stale") {
+    severity = "warning";
+    issueClass = "freshness";
+    explanation = `Needs freshness review. ${provenanceExplanation}`;
+  } else if (asset.status === "conflicted") {
+    severity = "warning";
+    issueClass = "conflict";
+    explanation = "Governance issue: multiple local copies or interpretations disagree.";
+  } else if (asset.status === "orphaned") {
+    severity = "warning";
+    issueClass = "orphaned";
+    explanation = "Governance issue: evidence exists without a durable canonical owner.";
+  } else if (asset.status === "unknown") {
+    severity = "unknown";
+    issueClass = "unknown";
+    explanation = "Health unknown: metadata is unavailable, so Assets will not classify this asset as active, stale, conflicted, or unused by inference.";
+  } else if (asset.status === "archived") {
+    severity = "informational";
+    explanation = "Archived inventory is retained for inspection, but it is not treated as active project context.";
+  }
+
+  return {
+    severity,
+    issueClass,
+    explanation,
+    inEffectExplanation,
+    provenanceExplanation,
+    recommendedRoute: buildRouteDescriptor(asset, issueClass),
+  };
+}
+
 export function summarizeContextAssets(assets: ContextAsset[]): ContextAssetSummary {
   const subtypeCounts = Object.fromEntries(CONTEXT_ASSET_SUBTYPES.map((key) => [key, 0])) as Record<ContextAssetSubtype, number>;
   const statusCounts = Object.fromEntries(CONTEXT_ASSET_STATUSES.map((key) => [key, 0])) as Record<ContextAssetStatus, number>;
+  const governanceIssueCounts = Object.fromEntries(GOVERNANCE_ISSUE_CLASSES.map((key) => [key, 0])) as Record<ContextAssetGovernanceIssueClass, number>;
+  const severityCounts = Object.fromEntries(GOVERNANCE_SEVERITIES.map((key) => [key, 0])) as Record<ContextAssetGovernanceSeverity, number>;
   let inEffect = 0;
   let issueCount = 0;
 
   for (const asset of assets) {
+    const health = deriveContextAssetGovernanceHealth(asset);
     subtypeCounts[asset.subtype] += 1;
     statusCounts[asset.status] += 1;
+    governanceIssueCounts[health.issueClass] += 1;
+    severityCounts[health.severity] += 1;
     if (asset.usage.state === "in_effect") inEffect += 1;
-    if (ISSUE_STATUSES.has(asset.status)) issueCount += 1;
+    if (health.issueClass !== "none") issueCount += 1;
   }
 
   return {
     total: assets.length,
     inEffect,
     issueCount,
+    governanceIssueCounts,
+    severityCounts,
     subtypeCounts,
     statusCounts
   };
@@ -313,8 +437,8 @@ export function deriveAssetsSurfaceState(input: {
     ? input.filteredAssets.find((asset) => asset.id === input.selectedAssetId)
     : undefined;
 
-  const issueVisible = input.filteredAssets.some((asset) => ISSUE_STATUSES.has(asset.status));
-  if (selected && ISSUE_STATUSES.has(selected.status)) return "issue";
+  const issueVisible = input.filteredAssets.some((asset) => deriveContextAssetGovernanceHealth(asset).severity === "warning");
+  if (selected && deriveContextAssetGovernanceHealth(selected).severity === "warning") return "issue";
   if (issueVisible) return "issue";
   if (selected) return "selected";
   return "normal";
@@ -364,5 +488,5 @@ export function formatContextAssetSourceLabel(source: ContextAssetSource): strin
 }
 
 export function isIssueContextAsset(asset: ContextAsset): boolean {
-  return ISSUE_STATUSES.has(asset.status);
+  return deriveContextAssetGovernanceHealth(asset).severity === "warning";
 }

--- a/src/lib/contextAssets.ts
+++ b/src/lib/contextAssets.ts
@@ -366,6 +366,9 @@ export function deriveContextAssetGovernanceHealth(asset: ContextAsset): Context
   if (asset.status === "active" && asset.usage.state === "in_effect") {
     severity = "healthy";
     explanation = `Active and currently in effect. ${usageSummary}`;
+  } else if (asset.status === "active" && asset.usage.state === "not_in_effect") {
+    severity = "informational";
+    explanation = `Active inventory is present, but the asset is not currently in effect. ${usageSummary}`;
   } else if (asset.status === "active") {
     severity = "informational";
     explanation = "Active inventory is present, but current in-effect usage is not proven by metadata.";
@@ -442,7 +445,10 @@ export function deriveAssetsSurfaceState(input: {
     : undefined;
 
   const selectedHealth = selected ? deriveContextAssetGovernanceHealth(selected) : null;
-  const issueVisible = input.filteredAssets.some((asset) => deriveContextAssetGovernanceHealth(asset).severity === "warning");
+  const issueVisible = input.filteredAssets.some((asset) => {
+    if (selected && asset.id === selected.id) return selectedHealth?.severity === "warning";
+    return deriveContextAssetGovernanceHealth(asset).severity === "warning";
+  });
   if (selectedHealth?.severity === "warning") return "issue";
   if (issueVisible) return "issue";
   if (selected) return "selected";

--- a/tests/assetsFoundation.test.tsx
+++ b/tests/assetsFoundation.test.tsx
@@ -92,7 +92,7 @@ describe("AssetsFoundation", () => {
 
     expect(html).toContain("Foundation data cue");
     expect(html).toContain("not a complete live project scan");
-    expect(html).toContain("Governance issues");
+    expect(html).toContain("Warning issues");
     expect(html).toContain("Freshness");
     expect(html).toContain("Conflict");
     expect(html).toContain("Orphaned");

--- a/tests/assetsFoundation.test.tsx
+++ b/tests/assetsFoundation.test.tsx
@@ -12,6 +12,7 @@ function renderAssetsFoundation(handoff: AssetsHandoff | null) {
       loadingDelayMs={0}
       onOpenAnalysis={vi.fn()}
       onOpenBackup={vi.fn()}
+      onOpenOverview={vi.fn()}
       onOpenSession={vi.fn()}
     />
   );
@@ -112,5 +113,19 @@ describe("AssetsFoundation", () => {
     expect(html).toContain("The original object could not be selected.");
     expect(html).toContain("stale memory");
     expect(html).not.toContain('aria-pressed="true"');
+  });
+
+  it("renders a Project Overview route for selected unknown assets", () => {
+    const html = renderAssetsFoundation({
+      origin: "overview",
+      subtitle: "Review unknown imported fragment.",
+      subtype: "unknown",
+      status: "unknown",
+      assetId: "asset-unknown-imported-1",
+      issueLabel: "unknown metadata",
+    });
+
+    expect(html).toContain("route owner: Project Overview");
+    expect(html).toContain("Route to Project Overview: review governance context");
   });
 });

--- a/tests/assetsFoundation.test.tsx
+++ b/tests/assetsFoundation.test.tsx
@@ -32,6 +32,9 @@ describe("AssetsFoundation", () => {
     expect(html).toContain('aria-pressed="true"');
     expect(html).toContain("Selected asset: Project coding rules");
     expect(html).toContain("In-Effect / Usage");
+    expect(html).toContain("Governance Health");
+    expect(html).toContain("healthy");
+    expect(html).toContain("route owner: Sessions");
   });
 
   it("renders routed-in empty state without fake inventory rows", () => {
@@ -60,8 +63,15 @@ describe("AssetsFoundation", () => {
 
     expect(html).toContain("issue state");
     expect(html).toContain("OpenSpec apply helper skill");
-    expect(html).toContain("Open Analysis");
-    expect(html).toContain("Review in Analysis");
+    expect(html).toContain("Route to Analysis");
+    expect(html).toContain("Route to Analysis: review usage context");
+    expect(html).toContain("issue class: conflict");
+    expect(html).toContain("multiple local copies or interpretations disagree");
+    expect(html).toContain("Route to Backup / Migration: preview scope");
+    expect(html).not.toContain("Repair");
+    expect(html).not.toContain("Sync");
+    expect(html).not.toContain("Deploy");
+    expect(html).not.toContain("Restore");
   });
 
   it("keeps session handoff as origin context rather than stale object selection", () => {
@@ -74,5 +84,33 @@ describe("AssetsFoundation", () => {
 
     expect(html).toContain("routed context");
     expect(html).not.toContain("The original object could not be selected.");
+  });
+
+  it("renders governance issue counts and foundation data cue", () => {
+    const html = renderAssetsFoundation(null);
+
+    expect(html).toContain("Foundation data cue");
+    expect(html).toContain("not a complete live project scan");
+    expect(html).toContain("Governance issues");
+    expect(html).toContain("Freshness");
+    expect(html).toContain("Conflict");
+    expect(html).toContain("Orphaned");
+    expect(html).toContain("Unknown");
+    expect(html).toContain("does not prove every local runtime has been scanned");
+  });
+
+  it("renders stale routed object degradation without fabricating replacement selection", () => {
+    const html = renderAssetsFoundation({
+      origin: "overview",
+      subtitle: "Review stale project memory.",
+      subtype: "memory",
+      status: "stale",
+      assetId: "missing-memory",
+      issueLabel: "stale memory",
+    });
+
+    expect(html).toContain("The original object could not be selected.");
+    expect(html).toContain("stale memory");
+    expect(html).not.toContain('aria-pressed="true"');
   });
 });

--- a/tests/contextAssets.test.ts
+++ b/tests/contextAssets.test.ts
@@ -118,6 +118,28 @@ describe("context asset governance health", () => {
     expect(health.inEffectExplanation).toContain("will not infer");
   });
 
+  it("keeps active not-in-effect assets informational without claiming usage is unproven", () => {
+    const health = deriveContextAssetGovernanceHealth(
+      normalizeContextAsset({
+        id: "active-not-in-effect",
+        title: "Active archived rule",
+        status: "active",
+        usage: {
+          state: "not_in_effect",
+          summary: "A newer project rule takes precedence.",
+        },
+      })
+    );
+
+    expect(health).toMatchObject({
+      severity: "informational",
+      issueClass: "none",
+    });
+    expect(health.explanation).toContain("not currently in effect");
+    expect(health.explanation).not.toContain("not proven");
+  });
+
+
   it("maps stale, conflicted, and orphaned assets to warning issue classes", () => {
     expect(deriveContextAssetGovernanceHealth(normalizeContextAsset({ id: "stale", title: "Stale", status: "stale" }))).toMatchObject({
       severity: "warning",

--- a/tests/contextAssets.test.ts
+++ b/tests/contextAssets.test.ts
@@ -153,6 +153,27 @@ describe("context asset governance health", () => {
     });
     expect(health.explanation).toContain("will not classify");
   });
+
+  it("routes source-backed references with session evidence to Sessions", () => {
+    const health = deriveContextAssetGovernanceHealth(
+      normalizeContextAsset({
+        id: "source-backed",
+        title: "Source backed asset",
+        status: "stale",
+        sourceReference: {
+          label: "Source file evidence",
+          target: "source",
+          sessionId: "session-source-1",
+          source: "codex",
+        },
+      })
+    );
+
+    expect(health.recommendedRoute).toMatchObject({
+      owner: "Sessions",
+      target: "session",
+    });
+  });
 });
 
 describe("assets handoff state derivation", () => {

--- a/tests/contextAssets.test.ts
+++ b/tests/contextAssets.test.ts
@@ -4,6 +4,7 @@ import {
   applyContextAssetFilters,
   buildFiltersFromAssetsHandoff,
   createContextAssetSeeds,
+  deriveContextAssetGovernanceHealth,
   deriveAssetsSurfaceState,
   normalizeContextAsset,
   resolveContextAssetSelection,
@@ -71,6 +72,86 @@ describe("context asset seeds and filters", () => {
     expect(summary.total).toBe(assets.length);
     expect(summary.inEffect).toBeGreaterThan(0);
     expect(summary.issueCount).toBeGreaterThan(0);
+    expect(summary.governanceIssueCounts.freshness).toBe(1);
+    expect(summary.governanceIssueCounts.conflict).toBe(1);
+    expect(summary.governanceIssueCounts.orphaned).toBe(1);
+    expect(summary.governanceIssueCounts.unknown).toBe(1);
+  });
+});
+
+describe("context asset governance health", () => {
+  it("maps active in-effect assets to healthy", () => {
+    const health = deriveContextAssetGovernanceHealth(
+      normalizeContextAsset({
+        id: "active-in-effect",
+        title: "Active rule",
+        status: "active",
+        usage: {
+          state: "in_effect",
+          summary: "Applied by project instructions.",
+        },
+      })
+    );
+
+    expect(health).toMatchObject({
+      severity: "healthy",
+      issueClass: "none",
+    });
+    expect(health.explanation).toContain("currently in effect");
+  });
+
+  it("maps active assets without usage proof to informational", () => {
+    const health = deriveContextAssetGovernanceHealth(
+      normalizeContextAsset({
+        id: "active-unknown",
+        title: "Active memory",
+        status: "active",
+        usage: {
+          state: "unknown",
+          summary: "Usage provider unavailable.",
+        },
+      })
+    );
+
+    expect(health.severity).toBe("informational");
+    expect(health.issueClass).toBe("none");
+    expect(health.inEffectExplanation).toContain("will not infer");
+  });
+
+  it("maps stale, conflicted, and orphaned assets to warning issue classes", () => {
+    expect(deriveContextAssetGovernanceHealth(normalizeContextAsset({ id: "stale", title: "Stale", status: "stale" }))).toMatchObject({
+      severity: "warning",
+      issueClass: "freshness",
+    });
+    expect(deriveContextAssetGovernanceHealth(normalizeContextAsset({ id: "conflict", title: "Conflict", status: "conflicted" }))).toMatchObject({
+      severity: "warning",
+      issueClass: "conflict",
+      recommendedRoute: {
+        owner: "Analysis",
+      },
+    });
+    expect(deriveContextAssetGovernanceHealth(normalizeContextAsset({ id: "orphan", title: "Orphan", status: "orphaned" }))).toMatchObject({
+      severity: "warning",
+      issueClass: "orphaned",
+    });
+  });
+
+  it("keeps unknown health explicit and non-blocking", () => {
+    const health = deriveContextAssetGovernanceHealth(
+      normalizeContextAsset({
+        id: "unknown",
+        title: "Unknown",
+      })
+    );
+
+    expect(health).toMatchObject({
+      severity: "unknown",
+      issueClass: "unknown",
+      recommendedRoute: {
+        owner: "Project Overview",
+      },
+    });
+    expect(health.explanation).toContain("will not classify");
   });
 });
 

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -165,38 +165,69 @@ describe("assets handoff builders", () => {
   });
 
   it("builds an overview handoff with scope and object context", () => {
-    expect(
-      buildAssetsHandoffFromOverview({
-        subtitle: "Review project rules.",
-        subtype: "rule",
-        scope: "project",
-        assetId: "asset-rule-project-codex",
-      })
-    ).toMatchObject({
+    const handoff = buildAssetsHandoffFromOverview({
+      subtitle: "Review project rules.",
+      subtype: "rule",
+      scope: "project",
+      status: "active",
+      assetId: "asset-rule-project-codex",
+      issueLabel: "in-effect rule",
+    });
+
+    expect(handoff).toMatchObject({
       origin: "overview",
       subtitle: "Review project rules.",
       subtype: "rule",
       scope: "project",
+      status: "active",
       assetId: "asset-rule-project-codex",
+      issueLabel: "in-effect rule",
     });
+    expect(Object.keys(handoff).sort()).toEqual([
+      "assetId",
+      "continueLabel",
+      "issueLabel",
+      "origin",
+      "returnLabel",
+      "scope",
+      "status",
+      "subtitle",
+      "subtype",
+    ]);
+    expect(handoff).not.toHaveProperty("summary");
+    expect(handoff).not.toHaveProperty("workflowType");
+    expect(handoff).not.toHaveProperty("operations");
   });
 
   it("builds an analysis handoff that preserves issue framing", () => {
-    expect(
-      buildAssetsHandoffFromAnalysis({
-        subtitle: "Review conflicted skill.",
-        subtype: "skill",
-        status: "conflicted",
-        assetId: "asset-skill-global-generated",
-        issueLabel: "conflicted asset",
-      })
-    ).toMatchObject({
+    const handoff = buildAssetsHandoffFromAnalysis({
+      subtitle: "Review conflicted skill.",
+      subtype: "skill",
+      status: "conflicted",
+      assetId: "asset-skill-global-generated",
+      issueLabel: "conflicted asset",
+    });
+
+    expect(handoff).toMatchObject({
       origin: "analysis",
       subtype: "skill",
       status: "conflicted",
       assetId: "asset-skill-global-generated",
       issueLabel: "conflicted asset",
     });
+    expect(Object.keys(handoff).sort()).toEqual([
+      "assetId",
+      "continueLabel",
+      "issueLabel",
+      "origin",
+      "returnLabel",
+      "status",
+      "subtitle",
+      "subtype",
+    ]);
+    expect(handoff).not.toHaveProperty("findings");
+    expect(handoff).not.toHaveProperty("evidence");
+    expect(handoff).not.toHaveProperty("mutationInstructions");
   });
 });
 


### PR DESCRIPTION
## Summary
- implement `context-assets-governance-hardening`
- add derived reusable-asset governance health semantics, severity, issue class, route owner, and issue summary counts
- update `Assets` with foundation/provider data cue, governance issue counts, selected-detail health/provenance/in-effect explanations, and route-only action labels
- preserve compact Overview/Analysis issue handoffs into `Assets` without carrying full source-page state or mutation/workflow instructions
- update targeted model/component/shell tests, README, CHANGELOG, OpenSpec tasks, QA prompt, and browser QA report

## Validation
- pnpm exec vitest run tests/contextAssets.test.ts tests/assetsFoundation.test.tsx tests/projectShellClient.test.ts tests/analysisFindings.test.ts tests/projectOverview.test.ts tests/projectOverviewSurface.test.tsx tests/analysisFoundation.test.tsx tests/backupMigrationFoundation.test.tsx
- pnpm exec vitest run tests/contextAssets.test.ts tests/assetsFoundation.test.tsx tests/projectShellClient.test.ts
- pnpm exec tsc --noEmit
- pnpm build
- OPENSPEC_TELEMETRY=0 openspec validate context-assets-governance-hardening --strict
- git diff --check

## QA
- Browser QA passed and is recorded in `docs/viewer/assets-governance-hardening-qa.md`
- QA verified provider data cue, warning/unknown issue counts, selected detail health/provenance/in-effect explanations, route-only actions, Overview -> Assets compact routed context, and routed cue clearing.