### PR TITLE
docs: add PR preflight gates

### DIFF
--- a/.agents/skills/pr-review-fix/SKILL.md
+++ b/.agents/skills/pr-review-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review-fix
-description: Use when addressing GitHub PR review comments, Copilot review feedback, unresolved review threads, or review-fix follow-up work in this repository.
+description: Use when preparing a PR, marking a PR ready, checking merge readiness, addressing GitHub PR review comments, Copilot review feedback, unresolved review threads, or review-fix follow-up work in this repository.
 license: MIT
 compatibility: Requires git and gh CLI.
 metadata:
@@ -14,19 +14,22 @@ Use this repository-specific workflow together with `docs/dev/pr-review-agent-wo
 
 ## Steps
 
-1. Resolve the PR number and branch.
-2. Fetch PR metadata plus review comments. Prefer thread-aware `gh api graphql` when resolution state matters; use the GitHub connector for flat PR/comment context when sufficient.
-3. Classify each comment before editing: `must-fix`, `should-fix`, `product-decision`, or `ignore`.
-4. Ask the user before changing product names, product scope, placeholder commitments, security/privacy behavior, backup/migration semantics, or any ambiguous `should-fix`.
-5. Implement confirmed `must-fix` and in-scope `should-fix` items only. Batch all actionable comments from the same review round into one fix pass instead of pushing one commit per comment. If the fix is large, runtime-dependent, or benefits from independent verification, delegate it to an authorized subagent and fold the result back into this workflow. If the user has granted standing subagent authorization for the control-thread workflow, treat that as sufficient authorization for bounded review-fix delegation; see `AGENTS.md` for the standing authorization definition and limits.
-6. Run targeted tests, `pnpm build`, and `openspec validate <change-id> --strict` when an OpenSpec change is active.
-7. Commit review fixes separately from workflow/process documentation.
-8. Check unresolved review threads before recommending ready/merge. Resolve only with explicit user authorization, or move non-blocking leftovers to follow-up issues.
-9. Push the PR branch and request Copilot re-review with `gh pr edit <number> --add-reviewer copilot-pull-request-reviewer` when available.
+1. Resolve the PR number and branch, or identify the branch that is about to become a PR.
+2. Before PR ready/merge, run a preflight check: CI/local validation status, OpenSpec validation if active, whether independent pre-review is needed, whether browser QA is needed, and unresolved review thread state.
+3. Fetch PR metadata plus review comments when a PR exists. Prefer thread-aware `gh api graphql` when resolution state matters; use the GitHub connector for flat PR/comment context when sufficient.
+4. Classify each comment before editing: `must-fix`, `should-fix`, `product-decision`, or `ignore`.
+5. Ask the user before changing product names, product scope, placeholder commitments, security/privacy behavior, backup/migration semantics, or any ambiguous `should-fix`.
+6. Implement confirmed `must-fix` and in-scope `should-fix` items only. Batch all actionable comments from the same review round into one fix pass instead of pushing one commit per comment. If the fix is large, runtime-dependent, or benefits from independent verification, delegate it to an authorized subagent and fold the result back into this workflow. If the user has granted standing subagent authorization for the control-thread workflow, treat that as sufficient authorization for bounded review-fix delegation; see `AGENTS.md` for the standing authorization definition and limits.
+7. Run targeted tests, `pnpm build`, and `openspec validate <change-id> --strict` when an OpenSpec change is active.
+8. Commit review fixes separately from workflow/process documentation.
+9. Check unresolved review threads before recommending ready/merge. Resolve only with explicit user authorization, or move non-blocking leftovers to follow-up issues.
+10. Push the PR branch and request Copilot re-review with `gh pr edit <number> --add-reviewer copilot-pull-request-reviewer` when available.
 
 ## Pre-Review Acceleration
 
 - Before marking OpenSpec or medium/large implementation PRs ready, prefer a bounded pre-review with an OpenSpec reviewer subagent, code-review subagent, or local Copilot CLI dry run.
+- Treat draft PR creation as allowed before pre-review/QA, but do not mark the PR ready or recommend merge until required preflight evidence exists or is explicitly waived.
+- For UI/runtime implementation PRs, browser QA is required unless the control thread explicitly waives it with a reason.
 - Use local Copilot CLI for draft review, testability checks, wording ambiguity, and suggested patch drafts; do not let it resolve conversations, merge PRs, or change product scope without control-thread triage.
 - Treat Copilot CLI output as advisory review feedback and classify it with the same `must-fix` / `should-fix` / `product-decision` / `ignore` categories.
 - Skip pre-review for tiny mechanical changes unless the change touches process rules, OpenSpec semantics, security/privacy, backup/migration integrity, or local path handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ Do not duplicate the same fact across these files unless each copy serves a diff
 ## PR Review Workflow
 
 - For PR review triage and agent-assisted fixes, follow `docs/dev/pr-review-agent-workflow.md`.
+- Before opening, marking ready, or recommending merge for a PR, run a PR preflight check even if no Copilot review exists yet:
+  - If the PR is a medium/large implementation slice, OpenSpec implementation, backup/migration change, parser/diagnostics/local-path-sensitive change, or shell/navigation change, perform or delegate an independent pre-review before marking ready.
+  - If the PR changes UI/runtime behavior, record browser QA evidence or explicitly state why browser QA is not required; keep the PR draft until that evidence exists or is explicitly waived.
+  - If the PR is spec-only or docs-only, skip browser QA unless the docs change tooling behavior; still run OpenSpec validation for OpenSpec artifacts.
+  - Fetch unresolved review threads before recommending ready or merge, even when CI is green.
 - Treat Copilot review comments as advisory input, not merge-blocking approval or requested changes.
 - Classify review feedback before editing: `must-fix`, `should-fix`, `product-decision`, or `ignore`.
 - Batch review comments from the same review round; do not push one fix per comment unless the issue is urgent or blocking.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,11 +105,11 @@ Do not duplicate the same fact across these files unless each copy serves a diff
 ## PR Review Workflow
 
 - For PR review triage and agent-assisted fixes, follow `docs/dev/pr-review-agent-workflow.md`.
-- Before opening, marking ready, or recommending merge for a PR, run a PR preflight check even if no Copilot review exists yet:
+- Before opening a PR, marking it ready, or recommending merge, run the applicable PR preflight checks even if no Copilot review exists yet:
   - If the PR is a medium/large implementation slice, OpenSpec implementation, backup/migration change, parser/diagnostics/local-path-sensitive change, or shell/navigation change, perform or delegate an independent pre-review before marking ready.
   - If the PR changes UI/runtime behavior, record browser QA evidence or explicitly state why browser QA is not required; keep the PR draft until that evidence exists or is explicitly waived.
   - If the PR is spec-only or docs-only, skip browser QA unless the docs change tooling behavior; still run OpenSpec validation for OpenSpec artifacts.
-  - Fetch unresolved review threads before recommending ready or merge, even when CI is green.
+  - Once a PR exists, fetch unresolved review threads before recommending ready or merge, even when CI is green.
 - Treat Copilot review comments as advisory input, not merge-blocking approval or requested changes.
 - Classify review feedback before editing: `must-fix`, `should-fix`, `product-decision`, or `ignore`.
 - Batch review comments from the same review round; do not push one fix per comment unless the issue is urgent or blocking.


### PR DESCRIPTION
## Summary
- add explicit PR preflight gates to AGENTS.md so critical ready/merge checks are visible without relying on transitive file references
- broaden pr-review-fix skill activation to PR preparation, ready checks, and merge readiness before Copilot review exists
- clarify that UI/runtime implementation PRs need browser QA evidence or an explicit waiver before ready/merge

## Validation
- docs/process-only change; no runtime validation required

## Notes
- This addresses the workflow gap observed while preparing PR #74.