### PR TITLE
spec: propose project evidence provider v1

### DIFF
--- a/openspec/changes/project-evidence-provider-v1/.openspec.yaml
+++ b/openspec/changes/project-evidence-provider-v1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/project-evidence-provider-v1/design.md
+++ b/openspec/changes/project-evidence-provider-v1/design.md
@@ -43,10 +43,12 @@ skills, commands, and governance concepts.
 
 ### Decision 1: Provider reads explicit repo-local agent-facing files only
 
-The provider SHALL discover known local paths and file classes that are already
-agent-facing: repository instruction files, Copilot/Codex/Windsurf/Antigravity
-skills or workflows, prompts, hooks, and project-level agent rules. It SHALL NOT
-recursively classify arbitrary source files.
+The provider SHALL discover known local paths and file classes from a recognized
+repo-local allowlist that is already agent-facing: repository instruction files,
+Copilot/Codex/Windsurf/Antigravity skills or workflows, prompts, hooks, and
+project-level agent rules. It SHALL NOT treat whole directories like `.codex`,
+`.agents`, `.agent`, `.github`, or `.windsurf` as broad recursive scan roots,
+and it SHALL NOT recursively classify arbitrary source files.
 
 Rationale: this gives real project evidence without over-promising analysis or
 turning Assets into a general repository browser.
@@ -66,6 +68,13 @@ The provider should return a small model containing:
 
 Surfaces consume this model and decide how to render it. The provider does not
 own routing, selection state, or workflow execution.
+
+### Decision 2a: v1 discovery is wired into the server-to-shell data path
+
+v1 discovery runs in the server layer for the current repository root and passes
+normalized provider output into Project Overview, Assets, and Analysis. Provider
+helpers remain pure and fixture-testable, but the v1 slice includes UI wiring for
+provider-backed states rather than stopping at a library-only implementation.
 
 ### Decision 3: Mapping is conservative and explainable
 
@@ -127,9 +136,10 @@ findings from file content in this slice.
    false` / `analysisAvailable: false` or labeled seed fallback into the affected
    surfaces while preserving the provider library behind tests.
 
-## Open Questions
+### Decision 6: Expected evidence paths are repo-local allowlist attempts
 
-- Should provider discovery run synchronously from the server layer and pass data
-  into the client shell, or should v1 keep provider helpers pure until a later API
-  integration step? The implementation should choose the smallest path that keeps
-  `pnpm build` and browser QA stable.
+For unreadable diagnostics, an "expected evidence path" means a repo-local path
+that the provider attempts because it matches the recognized allowlist or is
+found while enumerating an allowlisted directory. It does not include user-global
+runtime stores, external paths, cloud sources, session transcript stores, or paths
+outside the repository root.

--- a/openspec/changes/project-evidence-provider-v1/design.md
+++ b/openspec/changes/project-evidence-provider-v1/design.md
@@ -1,0 +1,135 @@
+## Context
+
+The project shell now has mature governance surfaces: Project Overview summarizes
+the project, Assets explains reusable context objects, and Analysis groups
+findings and routes to owning surfaces. The remaining trust gap is evidence
+fidelity. These surfaces can currently fall back to `createContextAssetSeeds()`
+and `createAnalysisFindingSeeds()`, which are useful for shape validation but
+confusing when users ask whether counts and issues describe the current project.
+
+The first live evidence slice should stay narrow. The repository already
+contains explicit agent-facing files (`AGENTS.md`, `.github/copilot-*`,
+`.codex/`, `.agents/skills/`, `.windsurf/`, hooks, prompts, and workflows). These
+files are local, inspectable, and directly aligned with the product's rules,
+skills, commands, and governance concepts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a local-only project evidence provider for explicit repo instruction and
+  agent configuration files.
+- Normalize discovered files into reusable context assets with provenance,
+  source, subtype, scope, status, and usage metadata.
+- Let Project Overview, Assets, and Analysis consume provider-backed evidence
+  before using seed/test fallbacks.
+- Keep missing, unreadable, or unsupported evidence explicit and visible.
+- Preserve the route-first and bounded governance page roles already accepted in
+  OpenSpec.
+
+**Non-Goals:**
+
+- No broad source-code scan or semantic interpretation of arbitrary application
+  files.
+- No session transcript parsing, session-to-asset extraction, or session parser
+  rewrite.
+- No asset editing, repair, sync, deploy, runtime restore, cloud lookup, or
+  privacy-redaction workflow.
+- No claim that every local runtime, user-global config, or hidden agent store
+  has been completely scanned.
+- No replacement for Backup / Migration package generation or import semantics.
+
+## Decisions
+
+### Decision 1: Provider reads explicit repo-local agent-facing files only
+
+The provider SHALL discover known local paths and file classes that are already
+agent-facing: repository instruction files, Copilot/Codex/Windsurf/Antigravity
+skills or workflows, prompts, hooks, and project-level agent rules. It SHALL NOT
+recursively classify arbitrary source files.
+
+Rationale: this gives real project evidence without over-promising analysis or
+turning Assets into a general repository browser.
+
+Alternative considered: scan the entire repository for keywords like "agent",
+"skill", or "memory". Rejected because it creates false positives and makes
+counts hard to trust.
+
+### Decision 2: Provider output is normalized evidence, not UI state
+
+The provider should return a small model containing:
+
+- project identity/root metadata
+- provider status (`available`, `empty`, `partial`, `unavailable`)
+- normalized reusable context assets
+- provider diagnostics for skipped, unreadable, unsupported, or ambiguous files
+
+Surfaces consume this model and decide how to render it. The provider does not
+own routing, selection state, or workflow execution.
+
+### Decision 3: Mapping is conservative and explainable
+
+Known mappings:
+
+- `AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.md`,
+  and `.windsurf/rules/*.md` map to `rule`.
+- `.agents/skills/*/SKILL.md`, `.agent/skills/*/SKILL.md`,
+  `.codex/skills/*/SKILL.md`, `.windsurf/skills/*/SKILL.md`, and
+  `.github/skills/*/SKILL.md` map to `skill`.
+- workflow, prompt, hook, and command-like files map to `command` unless their
+  path clearly indicates a skill or rule.
+- Ambiguous or unsupported files remain `unknown`.
+
+This mapping should be data-driven enough to test without needing a real user's
+home directory.
+
+### Decision 4: Seed data remains available but not silently default
+
+Seed data remains useful for tests and demonstration fallback, but provider
+availability changes the default path:
+
+- provider available with assets: render provider-backed assets and evidence cue
+- provider available but empty: render explicit zero-state, not seed rows
+- provider unavailable: render unavailable cue and optionally labeled seed/test
+  fallback only when the surface is intentionally in fallback/demo mode
+
+### Decision 5: Analysis v1 derives only bounded provider diagnostics/findings
+
+Analysis may show findings for concrete provider diagnostics such as unreadable
+files, ambiguous asset class, duplicate/conflicting files, or stale provider
+metadata if known. It SHALL NOT infer deep semantic conflicts or risky migration
+findings from file content in this slice.
+
+## Risks / Trade-offs
+
+- [Risk] Provider counts can still feel incomplete because user-global runtime
+  stores are out of scope. -> Mitigation: label evidence source as repo-local and
+  keep unavailable/unsupported counts visible.
+- [Risk] Large skill directories could be noisy. -> Mitigation: normalize each
+  discovered skill by directory/file identity and cap UI summaries while keeping
+  Assets as the inventory owner.
+- [Risk] Mapping file paths to subtype may be wrong for custom repo layouts. ->
+  Mitigation: unknown subtype is acceptable and testable; do not force a default.
+- [Risk] Reading local files may expose sensitive absolute paths in UI. ->
+  Mitigation: display project-relative paths by default and keep absolute paths
+  out of copied summaries unless a diagnostic explicitly requires them.
+
+## Migration Plan
+
+1. Add provider model and normalization helpers with fixture-based tests.
+2. Wire provider output into Project Overview, Assets, and Analysis using
+   explicit available/empty/unavailable states.
+3. Keep seed helpers for tests and fallback, but rename/cue usage so seed data is
+   never mistaken for live project evidence.
+4. Update README and QA prompt to describe provider-backed behavior and remaining
+   boundaries.
+5. If provider wiring causes runtime issues, rollback by passing `assetsAvailable:
+   false` / `analysisAvailable: false` or labeled seed fallback into the affected
+   surfaces while preserving the provider library behind tests.
+
+## Open Questions
+
+- Should provider discovery run synchronously from the server layer and pass data
+  into the client shell, or should v1 keep provider helpers pure until a later API
+  integration step? The implementation should choose the smallest path that keeps
+  `pnpm build` and browser QA stable.

--- a/openspec/changes/project-evidence-provider-v1/proposal.md
+++ b/openspec/changes/project-evidence-provider-v1/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Project Overview, Assets, and Analysis now have coherent governance surfaces, but
+their current asset and finding counts are still backed primarily by foundation
+seed data. This change connects those surfaces to explicit local project evidence
+so the app can answer "what project is this about?" and "are these real local
+assets?" without fabricating unavailable context.
+
+## What Changes
+
+- Introduce a bounded local project evidence provider that reads explicit
+  agent-facing repository files and normalizes them into provider evidence.
+- Derive reusable context assets from repo instruction, skill, workflow, prompt,
+  hook, and Copilot/Codex/Windsurf/Antigravity guidance files.
+- Replace seed-first behavior in Project Overview, Assets, and Analysis with
+  provider-backed data when local evidence is available, while preserving
+  explicit unavailable and zero states.
+- Keep provider scope read-only and local-only; no cloud lookup, runtime restore,
+  asset editing, sync, or privacy-redaction workflow is added.
+- Preserve seed data only as a clearly labeled fallback or test fixture, not as
+  the default representation of the current project when provider evidence is
+  available.
+
+## Capabilities
+
+### New Capabilities
+- `project-evidence-provider`: Local provider contract for discovering,
+  normalizing, and reporting explicit project evidence used by governance
+  surfaces.
+
+### Modified Capabilities
+- `context-assets`: Assets SHALL consume provider-backed reusable context assets
+  before falling back to labeled seed/test data.
+- `project-overview-governance`: Project Overview SHALL label and summarize
+  provider-backed local evidence instead of presenting seed counts as project
+  evidence.
+- `analysis-foundation`: Analysis SHALL distinguish provider-derived findings
+  from seed interpretations and keep no-evidence states explicit.
+
+## Impact
+
+- New provider/model helpers under `src/lib/` for project evidence discovery and
+  normalization.
+- `AssetsFoundation`, `ProjectShellClient` / Project Overview, and
+  `AnalysisFoundation` data flow changes to consume provider results.
+- Tests for provider discovery, normalization, unavailable evidence, and
+  seed-fallback labeling.
+- Documentation and QA prompt updates that remove stale "sample data until live
+  inventory" assumptions where provider evidence is available.

--- a/openspec/changes/project-evidence-provider-v1/specs/analysis-foundation/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/analysis-foundation/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Analysis SHALL distinguish provider-derived findings from seed interpretations
+The Analysis surface SHALL consume provider diagnostics as bounded local
+findings while clearly distinguishing them from seed/test interpretations.
+
+#### Scenario: Provider diagnostics become bounded findings
+- **WHEN** the project evidence provider reports unreadable, ambiguous,
+  duplicate, or conflicting evidence diagnostics
+- **THEN** Analysis may render those diagnostics as local findings
+- **AND** each finding preserves evidence references and route targets separately
+
+#### Scenario: Provider-backed no-finding state stays explicit
+- **WHEN** provider evidence is available and no provider diagnostics produce
+  findings
+- **THEN** Analysis shows a no-current-findings state
+- **AND** it does not populate seed findings as if they were current project
+  issues
+
+#### Scenario: Seed interpretations remain labeled fallback
+- **WHEN** provider-backed findings are unavailable and seed/test findings are
+  rendered for demonstration or tests
+- **THEN** Analysis labels them as seed or fallback interpretations
+- **AND** it does not claim complete automated analysis coverage
+
+#### Scenario: Provider findings do not imply deep semantic analysis
+- **WHEN** Analysis renders provider-derived findings
+- **THEN** it limits claims to concrete provider diagnostics
+- **AND** it does not infer migration risk, destructive cleanup risk, or semantic
+  source-code conflicts without explicit evidence

--- a/openspec/changes/project-evidence-provider-v1/specs/analysis-foundation/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/analysis-foundation/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Analysis SHALL distinguish provider-derived findings from seed interpretations
-The Analysis surface SHALL consume provider diagnostics as bounded local
+The system SHALL consume provider diagnostics as bounded local
 findings while clearly distinguishing them from seed/test interpretations.
 
 #### Scenario: Provider diagnostics become bounded findings

--- a/openspec/changes/project-evidence-provider-v1/specs/analysis-foundation/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/analysis-foundation/spec.md
@@ -7,7 +7,8 @@ findings while clearly distinguishing them from seed/test interpretations.
 #### Scenario: Provider diagnostics become bounded findings
 - **WHEN** the project evidence provider reports unreadable, ambiguous,
   duplicate, or conflicting evidence diagnostics
-- **THEN** Analysis may render those diagnostics as local findings
+- **THEN** Analysis renders those diagnostics as bounded local findings when
+  provider-backed analysis is available
 - **AND** each finding preserves evidence references and route targets separately
 
 #### Scenario: Provider-backed no-finding state stays explicit

--- a/openspec/changes/project-evidence-provider-v1/specs/context-assets/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/context-assets/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Assets SHALL consume provider-backed project evidence
-The Assets surface SHALL use project evidence provider output as the primary
+The system SHALL use project evidence provider output as the primary
 source for reusable context assets when provider evidence is available.
 
 #### Scenario: Provider-backed assets replace seed inventory

--- a/openspec/changes/project-evidence-provider-v1/specs/context-assets/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/context-assets/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Assets SHALL consume provider-backed project evidence
+The Assets surface SHALL use project evidence provider output as the primary
+source for reusable context assets when provider evidence is available.
+
+#### Scenario: Provider-backed assets replace seed inventory
+- **WHEN** the project evidence provider returns reusable context assets
+- **THEN** the Assets inventory renders those provider-backed assets
+- **AND** it labels the inventory as derived from local project evidence rather
+  than foundation seed data
+
+#### Scenario: Empty provider result shows zero state
+- **WHEN** the project evidence provider completes with no reusable context
+  assets
+- **THEN** the Assets surface shows a zero-state inventory
+- **AND** it does not populate seed rows as if they were current project assets
+
+#### Scenario: Provider unavailable stays explicit
+- **WHEN** the project evidence provider is unavailable
+- **THEN** the Assets surface shows an unavailable or fallback cue
+- **AND** any seed/test fixture data remains visibly labeled as non-live data
+
+#### Scenario: Provider diagnostics remain inspectable
+- **WHEN** provider diagnostics include skipped, unreadable, unsupported, or
+  ambiguous evidence
+- **THEN** the Assets surface keeps the diagnostic class visible
+- **AND** it avoids leaking sensitive absolute paths in normal UI copy

--- a/openspec/changes/project-evidence-provider-v1/specs/project-evidence-provider/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/project-evidence-provider/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Project evidence provider SHALL discover explicit repo-local agent evidence
+The system SHALL discover explicit agent-facing evidence from the current
+repository without scanning arbitrary source files or external runtime stores.
+
+#### Scenario: Known instruction files are discovered
+- **WHEN** the current repository contains files such as `AGENTS.md`,
+  `.github/copilot-instructions.md`, `.github/instructions/*.md`, or
+  `.windsurf/rules/*.md`
+- **THEN** the provider reports them as local project evidence
+- **AND** each item includes a project-relative path and evidence source label
+
+#### Scenario: Known skill workflow prompt and hook files are discovered
+- **WHEN** the current repository contains files under known agent skill,
+  workflow, prompt, hook, or command directories
+- **THEN** the provider reports those files as local project evidence
+- **AND** it identifies the file class when the path pattern is recognized
+
+#### Scenario: Arbitrary source files are not scanned
+- **WHEN** the repository contains ordinary application source files
+- **THEN** the provider does not classify them as agent evidence by keyword
+  search alone
+- **AND** it does not inflate asset counts with unrelated source files
+
+### Requirement: Project evidence provider SHALL normalize evidence into reusable context assets
+The system SHALL normalize discovered repo-local evidence into reusable context
+asset inputs with explicit subtype, scope, source, provenance, status, and usage
+metadata.
+
+#### Scenario: Rule-like evidence becomes rule assets
+- **WHEN** discovered evidence comes from recognized instruction or rule paths
+- **THEN** the provider emits a reusable context asset with subtype `rule`
+- **AND** the asset provenance references the project-relative file path
+
+#### Scenario: Skill-like evidence becomes skill assets
+- **WHEN** discovered evidence comes from recognized skill paths such as
+  `SKILL.md` files under agent skill directories
+- **THEN** the provider emits a reusable context asset with subtype `skill`
+- **AND** the asset identity remains stable across repeated scans of the same
+  path
+
+#### Scenario: Command-like evidence becomes command assets
+- **WHEN** discovered evidence comes from workflow, prompt, hook, or command-like
+  paths
+- **THEN** the provider emits a reusable context asset with subtype `command`
+- **AND** it does not claim the command has been executed
+
+#### Scenario: Ambiguous evidence remains unknown
+- **WHEN** discovered evidence cannot be mapped to a known reusable asset subtype
+- **THEN** the provider emits subtype `unknown`
+- **AND** the asset remains visible with an explicit explanation instead of being
+  silently dropped or defaulted
+
+### Requirement: Project evidence provider SHALL expose provider status and diagnostics
+The system SHALL expose provider-level status and diagnostics so consuming
+surfaces can distinguish available, empty, partial, and unavailable evidence.
+
+#### Scenario: Provider has evidence
+- **WHEN** at least one recognized local evidence item is discovered
+- **THEN** the provider status is `available`
+- **AND** consuming surfaces can identify the evidence as repo-local rather than
+  seed data
+
+#### Scenario: Provider finds no evidence
+- **WHEN** discovery completes but no recognized local evidence item exists
+- **THEN** the provider status is `empty`
+- **AND** consuming surfaces show explicit zero-state behavior rather than
+  fabricated assets
+
+#### Scenario: Provider has unreadable evidence
+- **WHEN** one or more expected evidence paths cannot be read
+- **THEN** the provider status is `partial` or `unavailable` depending on whether
+  other evidence remains available
+- **AND** diagnostics describe the unreadable evidence without leaking sensitive
+  absolute paths
+
+#### Scenario: Provider is unavailable
+- **WHEN** provider discovery cannot run in the current environment
+- **THEN** the provider status is `unavailable`
+- **AND** consuming surfaces show unavailable cues instead of claiming complete
+  local project coverage

--- a/openspec/changes/project-evidence-provider-v1/specs/project-evidence-provider/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/project-evidence-provider/spec.md
@@ -12,10 +12,12 @@ repository without scanning arbitrary source files or external runtime stores.
 - **AND** each item includes a project-relative path and evidence source label
 
 #### Scenario: Known skill workflow prompt and hook files are discovered
-- **WHEN** the current repository contains files under known agent skill,
-  workflow, prompt, hook, or command directories
+- **WHEN** the current repository contains files matching the provider's
+  recognized agent-facing path allowlist for skills, workflows, prompts, hooks,
+  or commands
 - **THEN** the provider reports those files as local project evidence
 - **AND** it identifies the file class when the path pattern is recognized
+- **AND** it does not traverse outside the current repository root
 
 #### Scenario: Arbitrary source files are not scanned
 - **WHEN** the repository contains ordinary application source files
@@ -69,7 +71,7 @@ surfaces can distinguish available, empty, partial, and unavailable evidence.
   fabricated assets
 
 #### Scenario: Provider has unreadable evidence
-- **WHEN** one or more expected evidence paths cannot be read
+- **WHEN** one or more repo-local allowlist evidence paths cannot be read
 - **THEN** the provider status is `partial` or `unavailable` depending on whether
   other evidence remains available
 - **AND** diagnostics describe the unreadable evidence without leaking sensitive

--- a/openspec/changes/project-evidence-provider-v1/specs/project-overview-governance/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/project-overview-governance/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Project Overview SHALL summarize provider-backed local evidence
+Project Overview SHALL derive asset and analysis summary cues from project
+evidence provider output when local evidence is available.
+
+#### Scenario: Overview labels provider-backed evidence
+- **WHEN** Project Overview receives provider-backed reusable context assets
+- **THEN** it labels the context snapshot as derived from explicit local project
+  evidence
+- **AND** it does not show a sample-data badge for those provider-backed counts
+
+#### Scenario: Overview keeps empty provider state explicit
+- **WHEN** the provider completes with no reusable context assets
+- **THEN** Project Overview shows an explicit no-assets or no-project-context cue
+- **AND** it does not replace the empty provider result with seed counts
+
+#### Scenario: Overview keeps provider unavailable state explicit
+- **WHEN** the provider is unavailable
+- **THEN** Project Overview shows an unknown or unavailable evidence cue
+- **AND** it does not invent counts, findings, or workflow results
+
+#### Scenario: Overview attention items use provider diagnostics conservatively
+- **WHEN** provider diagnostics identify unreadable, ambiguous, duplicate, or
+  conflicting local evidence
+- **THEN** Project Overview may surface compact attention items for those
+  diagnostics
+- **AND** each item routes to Assets or Analysis for inspection rather than
+  claiming automatic remediation

--- a/openspec/changes/project-evidence-provider-v1/specs/project-overview-governance/spec.md
+++ b/openspec/changes/project-evidence-provider-v1/specs/project-overview-governance/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Project Overview SHALL summarize provider-backed local evidence
-Project Overview SHALL derive asset and analysis summary cues from project
+The system SHALL derive asset and analysis summary cues from project
 evidence provider output when local evidence is available.
 
 #### Scenario: Overview labels provider-backed evidence

--- a/openspec/changes/project-evidence-provider-v1/tasks.md
+++ b/openspec/changes/project-evidence-provider-v1/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Provider Model And Discovery
 
 - [ ] 1.1 Define project evidence provider types for provider status, evidence item, diagnostics, and normalized result.
-- [ ] 1.2 Implement repo-local discovery for explicit agent-facing files: `AGENTS.md`, `.github` Copilot instructions/prompts/skills, `.codex`, `.agents` / `.agent`, and `.windsurf` skills/rules/workflows/hooks.
+- [ ] 1.2 Implement repo-local discovery from a recognized path allowlist for explicit agent-facing files: `AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.md`, `.github/prompts/*`, `.github/skills/*/SKILL.md`, `.codex/skills/*/SKILL.md`, `.codex/agents/*`, `.codex/hooks.json`, `.agents/skills/*/SKILL.md`, `.agent/skills/*/SKILL.md`, and `.windsurf` skills/rules/workflows/hooks.
 - [ ] 1.3 Keep discovery bounded to recognized paths and file classes; do not keyword-scan arbitrary application source files.
 - [ ] 1.4 Normalize discovered evidence into `ContextAssetInput` values with stable IDs, project-relative provenance, subtype, scope, source, status, and usage metadata.
 - [ ] 1.5 Emit provider diagnostics for unreadable, skipped, unsupported, duplicate, or ambiguous evidence without exposing sensitive absolute paths in normal UI fields.
@@ -19,14 +19,16 @@
 
 - [ ] 3.1 Add provider unit tests for known instruction, skill, workflow, prompt, and hook path discovery.
 - [ ] 3.2 Add provider unit tests for arbitrary source exclusion and ambiguous evidence normalization.
-- [ ] 3.3 Add provider unit tests for available, empty, partial, and unavailable status behavior.
-- [ ] 3.4 Add Assets tests for provider-backed inventory, empty provider state, unavailable provider state, and diagnostic visibility.
-- [ ] 3.5 Add Project Overview tests proving provider-backed counts are not labeled sample data and empty/unavailable evidence does not fabricate counts.
-- [ ] 3.6 Add Analysis tests proving provider diagnostics are bounded findings and seed findings remain labeled fallback only.
+- [ ] 3.3 Add provider unit tests proving session transcript files and session parser inputs are not parsed or converted into assets.
+- [ ] 3.4 Add provider unit tests proving discovery does not read user-global runtime stores, external paths, cloud sources, or paths outside the repository root.
+- [ ] 3.5 Add provider unit tests for available, empty, partial, and unavailable status behavior.
+- [ ] 3.6 Add Assets tests for provider-backed inventory, empty provider state, unavailable provider state, and diagnostic visibility.
+- [ ] 3.7 Add Project Overview tests proving provider-backed counts are not labeled sample data and empty/unavailable evidence does not fabricate counts.
+- [ ] 3.8 Add Analysis tests proving provider diagnostics are bounded findings and seed findings remain labeled fallback only.
 
 ## 4. Documentation And QA
 
 - [ ] 4.1 Update README to describe repo-local project evidence provider behavior and remaining boundaries.
 - [ ] 4.2 Update relevant QA prompt(s) under `docs/viewer/` to verify provider-backed evidence, zero-state behavior, and seed fallback labeling.
 - [ ] 4.3 Add or update a QA report only after browser/runtime verification is performed for the implemented UI wiring.
-- [ ] 4.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate project-evidence-provider-v1 --strict`.
+- [ ] 4.4 Run `pnpm test`, `pnpm lint`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate project-evidence-provider-v1 --strict`.

--- a/openspec/changes/project-evidence-provider-v1/tasks.md
+++ b/openspec/changes/project-evidence-provider-v1/tasks.md
@@ -1,0 +1,32 @@
+## 1. Provider Model And Discovery
+
+- [ ] 1.1 Define project evidence provider types for provider status, evidence item, diagnostics, and normalized result.
+- [ ] 1.2 Implement repo-local discovery for explicit agent-facing files: `AGENTS.md`, `.github` Copilot instructions/prompts/skills, `.codex`, `.agents` / `.agent`, and `.windsurf` skills/rules/workflows/hooks.
+- [ ] 1.3 Keep discovery bounded to recognized paths and file classes; do not keyword-scan arbitrary application source files.
+- [ ] 1.4 Normalize discovered evidence into `ContextAssetInput` values with stable IDs, project-relative provenance, subtype, scope, source, status, and usage metadata.
+- [ ] 1.5 Emit provider diagnostics for unreadable, skipped, unsupported, duplicate, or ambiguous evidence without exposing sensitive absolute paths in normal UI fields.
+
+## 2. Surface Integration
+
+- [ ] 2.1 Update Assets data flow to consume provider-backed assets when available.
+- [ ] 2.2 Preserve explicit Assets zero-state behavior when the provider is available but empty.
+- [ ] 2.3 Preserve labeled fallback behavior when provider evidence is unavailable and seed/test data is intentionally rendered.
+- [ ] 2.4 Update Project Overview summary inputs so asset counts and evidence labels come from provider-backed local evidence when available.
+- [ ] 2.5 Update Analysis data flow so provider diagnostics can become bounded findings, while no-diagnostic provider results show an explicit no-current-findings state.
+- [ ] 2.6 Keep Backup / Migration workflow execution, project bundle generation, imports, restore semantics, and privacy-redaction scope unchanged.
+
+## 3. Tests
+
+- [ ] 3.1 Add provider unit tests for known instruction, skill, workflow, prompt, and hook path discovery.
+- [ ] 3.2 Add provider unit tests for arbitrary source exclusion and ambiguous evidence normalization.
+- [ ] 3.3 Add provider unit tests for available, empty, partial, and unavailable status behavior.
+- [ ] 3.4 Add Assets tests for provider-backed inventory, empty provider state, unavailable provider state, and diagnostic visibility.
+- [ ] 3.5 Add Project Overview tests proving provider-backed counts are not labeled sample data and empty/unavailable evidence does not fabricate counts.
+- [ ] 3.6 Add Analysis tests proving provider diagnostics are bounded findings and seed findings remain labeled fallback only.
+
+## 4. Documentation And QA
+
+- [ ] 4.1 Update README to describe repo-local project evidence provider behavior and remaining boundaries.
+- [ ] 4.2 Update relevant QA prompt(s) under `docs/viewer/` to verify provider-backed evidence, zero-state behavior, and seed fallback labeling.
+- [ ] 4.3 Add or update a QA report only after browser/runtime verification is performed for the implemented UI wiring.
+- [ ] 4.4 Run `pnpm test`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate project-evidence-provider-v1 --strict`.


### PR DESCRIPTION
## Summary
- propose `project-evidence-provider-v1` OpenSpec change
- define a repo-local provider for explicit agent-facing project evidence
- add delta specs for Assets, Project Overview, and Analysis to consume provider-backed evidence before seed fallback

## Validation
- `OPENSPEC_TELEMETRY=0 openspec validate project-evidence-provider-v1 --strict`

## Notes
- Spec-only PR; no runtime code changes.
- OpenSpec reviewer subagent is reviewing artifacts in parallel.
- Existing untracked `.playwright-cli/` was left untouched.