### PR TITLE
feat: add windsurf legacy recoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 .local
 
 tmp/
+.playwright-cli/
+auth.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ This file records shipped, merged changes for Agent Storage Manager.
 
 ### Added
 
+- `2026-05-26` — Cursor support: first-class session browser with unified Trajectory viewer
+  - Added Cursor as a fourth first-class source (alongside Antigravity, Windsurf, Codex) with bounded local SQLite read, no runtime attach required
+  - Added `src/lib/server/cursor.ts` adapter: `CursorBubble` type, `readCursorBubbles()` for bubble-by-bubble transcript recovery, `buildCursorEvents()` / `buildCursorSummary()`, and `extractSummaryText()` with XML conversation-context stripping
+  - API route now returns `kind: "trajectory", source: "cursor"` (unified model) instead of bare `kind: "markdown"`; search indexing uses `getTrajectoryMetaMapCached` for metadata consistency
+  - `HomeClient.tsx`: added `cursorView` state, Transcript (default) / Trajectory view switcher, cursor trajectory render block with turns/user/assistant badges, filter controls, and jump-to-event cross-view navigation
+  - Added `src/lib/projectEvidenceProvider.ts` for repo-local Cursor asset classification (`.cursor/rules/*.mdc` → `rule`; `.cursorrules` → `rule`; `.cursor/mcp.json` → `command`)
+  - Updated `docs/storage/local-storage-notes.md` with version compatibility risk table, graceful degradation principles, upgrade detection commands, and break-fix upgrade path
+  - Updated `docs/viewer/trajectory-view.md` with Cursor adapter section and API surface; updated `docs/viewer/agent-ui-ux-optimization.md` Shipped list
+  - Closed all four open questions in `openspec/changes/add-cursor-support/design.md`
+
 - `2026-04-19` — Assets governance hardening
   - Added derived governance health semantics for reusable context assets, including healthy, informational, warning, and unknown states
   - Updated `Assets` summary and detail views with governance issue class counts, provenance/in-effect explanations, route ownership, and foundation data cues

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ SSoT/DRY note:
 
 # Agent Storage Manager (v1)
 
-A local Web UI for browsing conversation history generated/persisted by Antigravity, Windsurf, and Codex CLI.
-It fetches Antigravity and Windsurf content via their local Language Server RPC, and reads Codex sessions directly from `.jsonl` files (no running process required).
+A local Web UI for browsing conversation history generated/persisted by Antigravity, Windsurf, Codex CLI, and Cursor.
+It fetches Antigravity and Windsurf content via their local Language Server RPC, reads Codex sessions directly from `.jsonl` files (no running process required), and reads bounded Cursor composer state from local SQLite/app-storage files.
 
 ## Data Sources & Configuration
 
@@ -15,6 +15,7 @@ It fetches Antigravity and Windsurf content via their local Language Server RPC,
   - Antigravity: `~/.gemini/antigravity/conversations`
   - Windsurf: `~/.codeium/windsurf/cascade`
   - Codex: `~/.codex/sessions`
+  - Cursor: `~/Library/Application Support/Cursor/User`
 
 You can add/disable/delete roots in the Web UI Settings page (supports external/backup drives).
 
@@ -60,23 +61,27 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
 
 - Project shell:
   - top-level surfaces for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and `Backup / Migration`
-  - `Project Overview` provides a project-scoped agent context governance foundation with compact context snapshot, in-effect assets, recent sessions, attention items, and route-first quick actions; current asset/finding counts are clearly marked as foundation sample data until live project inventory is connected
+  - `Project Overview` provides a project-scoped agent context governance foundation with compact context snapshot, in-effect assets, recent sessions, attention items, and route-first quick actions; when repo-local provider evidence is available, asset/finding counts are derived from explicit local evidence instead of foundation sample data
   - `Sessions` contains the existing viewer, source diagnostics, URL deep links, search selection, and direct session backup behavior
   - `Assets` provides a bounded reusable context assets foundation for rules, memory, skills, commands, and unknown asset fragments
   - `Analysis` provides a bounded interpretation-and-routing foundation for local context findings
   - `Backup / Migration` provides bounded workflow-first backup and migration-preview surfaces without turning into a generic tools drawer or migration apply UI
 - Assets foundation:
+  - repo-local project evidence provider for explicit agent-facing files: `AGENTS.md`, Copilot instructions/prompts/skills, Codex skills/agents/hooks, cross-agent `.agents` / `.agent` skills, Windsurf skills/rules/workflows/hooks, and Cursor repo-local files such as `.cursor/mcp.json`, `.cursorrules`, and `.cursor/rules/*.mdc`
   - local-first reusable context asset model with subtype, scope, source, status, provenance, optional body summary, in-effect/usage metadata, and derived governance health
+  - provider-backed inventory uses project-relative provenance paths and does not read user-global runtime stores, external paths, cloud sources, session transcript stores, or paths outside the repository root
   - subtype/scope/source/status filtering with asset summary, governance issue class counts, inventory, selected detail, provenance, and in-effect/usage regions
   - route-only governance inspection for Sessions, Analysis, Backup / Migration, or Project Overview without inline edit, repair, sync, deploy, restore, or workflow execution controls
   - routed handoff into `Assets` from Sessions, Project Overview, and Analysis with compact issue context only, without carrying full transcript, overview summary state, findings tables, or trajectory state
 - Analysis foundation:
   - local-first analysis finding model with issue class, severity, status, affected object, evidence references, route targets, and preservation warnings
+  - provider diagnostics for unreadable, ambiguous, duplicate, or unsupported repo-local evidence become bounded findings; a clean provider result shows an explicit no-current-findings state instead of seed issues
   - context health summary, findings inventory, selected finding detail, evidence context, and route-only recommended actions
   - routed handoff into `Analysis` from Assets, Project Overview, and Sessions without claiming complete automated project analysis or inline remediation
 - Scan and list session files (default directories + custom roots from Settings)
   - Antigravity / Windsurf: `.pb` session files (flat directory)
   - Codex CLI: `.jsonl` session files (nested `YYYY/MM/DD/` directory structure)
+  - Cursor: bounded composer sessions from `User/globalStorage/state.vscdb` and related `workspaceStorage/*` state
 - Search and filtering:
   - full-text event search within the current conversation
   - enhanced conversation filtering in the session list / viewer flow
@@ -132,6 +137,8 @@ For detailed view semantics and cross-source alignment notes, see `docs/viewer/t
 - Codex CLI: no running process required. Install the [Codex CLI](https://github.com/openai/codex) and run at least one session — session files will be created automatically at `~/.codex/sessions/`.
   - Sessions are `.jsonl` files nested under `YYYY/MM/DD/` date subdirectories.
   - No token or attach configuration needed; sessions are read directly from disk.
+- Cursor: no runtime attach is required for the current implementation. Open Cursor and use Composer/Agents at least once so local state is written under `~/Library/Application Support/Cursor/User/`.
+  - Current support is intentionally bounded: the app lists Cursor composer sessions and renders reliable local metadata/summary/todo/context state, but does not promise a full bubble-by-bubble transcript for every historical session.
 
 ## Project Status
 

--- a/docs/storage/local-storage-notes.md
+++ b/docs/storage/local-storage-notes.md
@@ -1,6 +1,6 @@
-# Antigravity / Windsurf / Codex 本地存储结构（持续记录）
+# Antigravity / Windsurf / Codex / Cursor 本地存储结构（持续记录）
 
-本文档用于记录 **Antigravity**, **Windsurf** 与 **Codex** 在 macOS 上的本地存储布局、关键文件、以及我们在实现/调试 `agent-storage-manager` 过程中验证过的“可用事实”。它是一个活文档：每次发现新结构或出现不兼容变更时，都应补充到这里（最好附上“如何复现/如何验证”）。
+本文档用于记录 **Antigravity**, **Windsurf**, **Codex** 与 **Cursor** 在 macOS 上的本地存储布局、关键文件、以及我们在实现/调试 `agent-storage-manager` 过程中验证过的“可用事实”。它是一个活文档：每次发现新结构或出现不兼容变更时，都应补充到这里（最好附上“如何复现/如何验证”）。
 
 > 约定：文中路径均以 macOS 为准；`~` 表示用户主目录。  
 > 重要：这些目录里可能包含会话内容、仓库路径、token 等敏感信息；调试/截图/开源文档时注意脱敏。
@@ -71,6 +71,116 @@
 - 对 **Antigravity**，额外利用其 **VS Code global state（`state.vscdb`）** 来稳定提取会话列表所需的 `title/cwd` 元信息（这是我们实际验证过的可靠来源）
 
 ---
+
+## Cursor
+
+### 1) 当前一期实现策略（已验证）
+
+**结论（已验证）：** Cursor 的当前接入不走 localhost / LS attach，而是走 **本地 SQLite / app-storage 状态读取**。
+
+当前一期实现依赖的关键路径：
+
+- `~/.cursor/`
+  - `cli-config.json`
+  - `ide_state.json`
+  - `mcp.json`
+- `~/Library/Application Support/Cursor/User/`
+  - `globalStorage/state.vscdb`
+  - `workspaceStorage/*/state.vscdb`
+  - `workspaceStorage/*/workspace.json`
+
+### 2) 当前已验证的可用事实
+
+- `globalStorage/state.vscdb`
+  - 表：`ItemTable`, `cursorDiskKV`
+  - `cursorDiskKV` 中可见大量与 Cursor Agent / Composer 相关的 key：
+    - `composerData:<uuid>`
+    - `cursor/glass.tabs.v2/.../state.json`
+    - `messageRequestContext:<composerId>:<bubbleId>`
+    - `checkpointId:<composerId>:<bubbleId>`
+    - `composer.*`, `chat.*`, `agent.*`, `cursorAuth/*`
+- `workspaceStorage/*/workspace.json`
+  - 可将 workspace hash 反解到真实仓库路径（`folder: file:///...`）
+- `workspaceStorage/*/state.vscdb`
+  - 可见 `composer.composerData`、`workbench.panel.composerChatViewPane*`、`src.vs.platform.reactivestorage.browser.reactiveStorageServiceImpl.persistentStorage.workspaceUser` 等 key
+
+### 3) 当前产品采用的 bounded contract
+
+`agent-storage-manager` 当前对 Cursor 的支持边界是：
+
+- **支持**
+  - 枚举本地 `composerData:*` 会话
+  - 提取稳定的 `title / status / createdAt / updatedAt / summary / todos / context`
+  - 在可能时，从 `workspaceStorage/*/workspace.json` 或上下文文件选择推断 workspace/cwd
+  - 识别 repo-local Cursor 资产：`.cursor/mcp.json`、`.cursorrules`、`.cursor/rules/*.mdc`
+- **暂不承诺**
+  - 每个历史会话都能恢复完整 bubble-by-bubble transcript
+  - 类似 Windsurf / Antigravity 的 runtime attach 诊断
+
+### 4) 版本兼容性与降级策略
+
+Cursor 存储结构属于**未公开的内部格式**，可随版本升级静默变更，无 semver 保证。以下记录已知风险点和应对原则。
+
+#### 已知变更风险
+
+| 风险点 | 当前依赖 | 升级后可能的变化 |
+| ------ | -------- | --------------- |
+| `cursorDiskKV` 表消失或改名 | `composerData:*`、`bubbleId:*` 键 | Cursor 内部重构后可能迁移到新表或新文件 |
+| `composerData` JSON schema 字段变更 | `latestConversationSummary.summary.summary`、`fullConversationHeadersOnly`、`name`、`createdAt` 等 | 字段随产品功能迭代重命名或移除 |
+| `bubbleId:*` 键不再写入全局 DB | bubble-by-bubble transcript 读取 | Cursor 可能将 bubble 数据迁移到 workspace-local DB 或独立文件 |
+| `workspaceStorage` hash 算法变更 | workspace-to-composer 路径反解 | hash 算法变化会导致现有映射完全失效 |
+| 存储路径变更 | macOS 路径 `~/Library/Application Support/Cursor/` | 虽然 VS Code 系标准路径极少变，但 rebranding 时有先例 |
+
+#### 实现侧的降级原则（已在代码中体现）
+
+- 所有字段访问均为 `?.` 可选链或 `?? fallback`，不假设字段必然存在。
+- `readCursorBubbles()` 在 `fullConversationHeadersOnly` 缺失或为空时，自动回退到 `extractSummaryText()`（单条摘要事件）而非抛出异常。
+- `extractSummaryText()` 在遇到无法解析的 XML 格式时，直接返回裸文本，不中断渲染流程。
+- `getCursorConversation()` 整体用 try/catch 包裹，任何 SQLite 读取失败只记录 warning，不影响会话列表加载。
+
+#### 升级时的检测方法
+
+当 Cursor 升级后如果会话列表出现异常（会话数量骤降、内容全部显示为空摘要），可用以下命令快速定位：
+
+```bash
+# 确认 cursorDiskKV 表是否仍存在
+sqlite3 "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb" \
+  ".tables"
+
+# 确认 composerData 键是否仍存在
+sqlite3 "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb" \
+  "select key from cursorDiskKV where key like 'composerData:%' limit 5;"
+
+# 确认 bubbleId 键是否仍写入
+sqlite3 "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb" \
+  "select key from cursorDiskKV where key like 'bubbleId:%' limit 5;"
+
+# 检查某个 composerData 值的顶层 JSON 字段
+sqlite3 "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb" \
+  "select value from cursorDiskKV where key like 'composerData:%' limit 1;" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(list(d.keys()))"
+```
+
+#### 发现断裂后的升级路径
+
+1. 用上述验证命令定位具体断裂点（表/键/字段哪一层变了）。
+2. 在 `src/lib/server/cursor.ts` 中对应的读取函数加 adapter 分支，保持旧版 fallback 可用。
+3. 更新本文档此节，注明 Cursor 版本号和已验证的新结构。
+4. 若断裂影响 `bounded contract` 中的已承诺能力，同步更新第 3 节并在 `CHANGELOG.md` 记录。
+
+### 5) 本地验证命令
+
+```bash
+# 查看 Cursor 全局状态 DB 是否存在
+ls -l "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+
+# 查看 composerData 是否存在
+sqlite3 "$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb" \
+  "select key, length(value) from cursorDiskKV where key like 'composerData:%' order by length(value) desc limit 20;"
+
+# 查看 workspaceStorage 与真实 workspace 的映射
+find "$HOME/Library/Application Support/Cursor/User/workspaceStorage" -name workspace.json -maxdepth 2 -print
+```
 
 ## Antigravity
 

--- a/docs/storage/local-storage-notes.md
+++ b/docs/storage/local-storage-notes.md
@@ -27,6 +27,8 @@
   - 版本指纹：Commit `73ca2d6aa880de1bc504ad960c1ab79c9248d476`；VS Code OSS `1.108.2`；Electron `39.2.7`；Chromium `142.0.7444.235`；Node.js `22.21.1`；V8 `14.2.231.21-electron.0`；构建时间 `2026-03-09T19:00:54.154Z`；OS `Darwin arm64 24.6.0`
   - 对应实现方案：`pid/port` 从 `Windsurf.log` 读取；live CSRF token 从 LS 子进程环境变量 `WINDSURF_CSRF_TOKEN` 读取；`state.vscdb` 中的 `codeium.windsurf-windsurf_auth-` 不是可用 fallback
   - 回归时先验证：`ps eww -o command= -ww -p <pid>` 是否仍能看到 `WINDSURF_CSRF_TOKEN=`；`Heartbeat` 对 `state.vscdb` UUID 是否仍返回 `401 invalid CSRF token`
+  - recoverability 事实：legacy `~/.codeium/cascade/*.pb` 会话可被本地扫描列出，但若 live LS 返回 `trajectory not found`，则只能标记为 `partial` 或 `unavailable`，不能声称 canonical readable content 仍存在
+  - bounded evidence：本机只发现一个 legacy `cascadeId` 在 `~/.codeium/brain/<cascadeId>/` 下有 sidecar（`plan.md` 与 `plan_metadata.pbtxt`），因此 brain 证据应被视为可选的 bounded evidence，而非 transcript source
 - `Antigravity 1.19.5`
   - 版本指纹：Commit `6adfc1a7e4a1a9af62bc45e8f2d7e6a97b7a9756`；VS Code OSS `1.107.0`；Electron `39.2.3`；Chromium `142.0.7444.175`；构建时间 `2026-02-26T07:23:14.771Z`；OS `Darwin arm64 24.6.0`
   - 对应实现方案：LS 发现仍应优先走 `Antigravity.log` attach，并以 `Heartbeat` 成功作为准入；`daemon/ls_*.json` 可作为 legacy discovery；`title/cwd` 通过 `state.vscdb` 的 `*trajectorySummaries` enrichment
@@ -58,6 +60,32 @@
 - 当时真实来源：token 来自 `argv`、`env`、discovery 文件，还是根本不可读
 - 验证命令：`ps` / `curl` / `rg` / `sqlite3`
 - 结论：旧假设哪里失效、代码层做了什么修复
+
+### Windsurf legacy recoverability（2026-05-26 实测）
+
+- `~/.codeium/cascade` 中的 legacy `.pb` 文件可以通过 Settings root 正常发现并显示在 Sessions 列表中。
+- 这些 legacy session 在当前 live Windsurf LS 上可能全部返回 `trajectory not found`，这表示 **本地发现成功 ≠ LS 仍可读**。
+- `agent-storage-manager` 当前 contract：
+  - `ls_readable`：LS 仍可返回 trajectory / steps
+  - `partial`：LS 返回 `trajectory not found`，但存在 bounded sidecar evidence（例如 `~/.codeium/brain/<cascadeId>/plan.md`）
+  - `unavailable`：LS 返回 `trajectory not found`，且没有额外 bounded evidence
+- `partial` / `unavailable` 只用于 diagnostics、Sessions viewer 与 Backup / Migration handoff；**不表示可以离线重建 canonical transcript**。
+
+建议验证命令：
+
+```bash
+# 检查 legacy Windsurf pb roots
+find "$HOME/.codeium/cascade" -maxdepth 1 -name '*.pb' | head
+
+# 检查某个 legacy session 是否存在 bounded brain sidecar
+ls -la "$HOME/.codeium/brain/<cascadeId>"
+
+# 在已知 pid/port/token 下验证 trajectory 是否仍可读
+curl -sS -X POST "http://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetCascadeTrajectory" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: <live-token>" \
+  -d '{"cascadeId":"<cascadeId>"}'
+```
 
 ---
 

--- a/docs/viewer/agent-ui-ux-optimization.md
+++ b/docs/viewer/agent-ui-ux-optimization.md
@@ -59,6 +59,7 @@
   - 搜索命中词在 title / commandLine / text / output 字段内高亮（`HighlightedText` 零依赖组件）
   - 设计文档：`docs/viewer/search-design.md`；跨会话搜索选型：`docs/adr/ADR-003-cross-session-search.md`
 - Windsurf：默认使用 trajectory-backed（`view=trajectory`）分页加载；legacy chat 仍保留。
+- Cursor：使用统一 Trajectory 事件模型（`kind: "trajectory"`, `source: "cursor"`），从本地 SQLite bubble 读取完整对话。Viewer 提供 `Transcript`（默认）和 `Trajectory` 两种视图，与 Antigravity/Windsurf 保持一致。无 Compact 模式（Cursor 没有 vendor-side narrative 接口）。
 
 ### Next（建议按收益/成本排序）
 

--- a/docs/viewer/agent-ui-ux-optimization.md
+++ b/docs/viewer/agent-ui-ux-optimization.md
@@ -59,7 +59,19 @@
   - 搜索命中词在 title / commandLine / text / output 字段内高亮（`HighlightedText` 零依赖组件）
   - 设计文档：`docs/viewer/search-design.md`；跨会话搜索选型：`docs/adr/ADR-003-cross-session-search.md`
 - Windsurf：默认使用 trajectory-backed（`view=trajectory`）分页加载；legacy chat 仍保留。
+- Windsurf legacy recoverability：当本地发现 legacy session，但运行中的 Windsurf LS 返回 `trajectory not found` 时，Sessions viewer 会保留选中态并展示 recoverability-aware 提示；提示区分 `partial`（存在 bounded evidence）与 `unavailable`（无额外 evidence），并引导用户使用 `Diagnostic JSON` 或 `Backup / Migration` 查看 bounded preservation context。
 - Cursor：使用统一 Trajectory 事件模型（`kind: "trajectory"`, `source: "cursor"`），从本地 SQLite bubble 读取完整对话。Viewer 提供 `Transcript`（默认）和 `Trajectory` 两种视图，与 Antigravity/Windsurf 保持一致。无 Compact 模式（Cursor 没有 vendor-side narrative 接口）。
+
+### Backup / Migration 与 recoverability 的当前语义
+
+- 从 `Sessions` 路由到 `Backup / Migration` 时，单个 session handoff 会携带 compact recoverability context：
+  - `recoverability`
+  - `hasRecoveryEvidence`
+  - `recoverabilityNote`
+- 对 Windsurf：
+  - `unavailable`：validation 明确 block canonical session backup
+  - `partial`：validation 明确 warning，允许继续做 bounded evidence review，但不暗示 transcript reconstruction
+- 这些提示的目标是让用户理解“证据保留”与“canonical transcript backup”是两回事，而不是在 workflow 中隐式承诺 vendor-runtime restoration。
 
 ### Next（建议按收益/成本排序）
 

--- a/docs/viewer/analysis-foundation-qa-prompt.md
+++ b/docs/viewer/analysis-foundation-qa-prompt.md
@@ -9,7 +9,7 @@ Repository: <repo-path>
 Branch under test: feat/analysis-foundation
 
 Goal:
-Verify that the new Analysis foundation behaves as a bounded interpretation-and-routing surface. It should show local context findings, explain why they matter, and route users to owning pages without claiming complete automated analysis, automatic fixes, asset editing, session mutation, or backup execution inside Analysis.
+Verify that the Analysis foundation behaves as a bounded interpretation-and-routing surface. It should show provider diagnostics as local findings when available, explain why they matter, and route users to owning pages without claiming complete automated analysis, automatic fixes, asset editing, session mutation, or backup execution inside Analysis.
 
 Setup:
 1. Use the QA agent's local checkout path for `<repo-path>`.
@@ -30,14 +30,18 @@ Primary smoke checks:
    - Finding Detail
    - Recommended Actions
 6. Confirm copy clearly says this is bounded foundation behavior and does not claim automatic remediation.
+7. Confirm provider-backed Analysis copy distinguishes repo-local provider diagnostics from seed/test fallback interpretations.
 
 Analysis state checks:
-1. In normal top-level Analysis browsing, confirm seeded findings appear.
-2. Select at least one finding and confirm the selected row is visibly active.
-3. Confirm the detail panel shows title, issue class, severity/status/object context, why it matters, evidence context when available, and route-only actions.
-4. Confirm high-severity or preservation-sensitive findings show a warning/issue-heavy cue.
-5. Change filters until no findings match. Confirm an empty state appears and no fake findings are shown.
-6. Confirm changing filters or object focus clears/downgrades routed context cues when applicable.
+1. In normal top-level Analysis browsing with provider-backed evidence, confirm provider diagnostics appear as findings only when warning diagnostics exist.
+2. If the provider has no warning diagnostics, confirm Analysis shows an explicit no-current-provider-findings / empty state instead of seed findings.
+3. If the provider is unavailable or a seed fixture is intentionally used, confirm seed findings are visibly labeled as fallback/non-live interpretations.
+4. Select at least one finding and confirm the selected row is visibly active.
+5. Confirm the detail panel shows title, issue class, severity/status/object context, why it matters, evidence context when available, and route-only actions.
+6. Confirm provider-derived findings limit claims to concrete provider diagnostics such as unreadable, ambiguous, duplicate, or unsupported evidence.
+7. Confirm high-severity or preservation-sensitive findings show a warning/issue-heavy cue only when such findings are present.
+8. Change filters until no findings match. Confirm an empty state appears and no fake findings are shown.
+9. Confirm changing filters or object focus clears/downgrades routed context cues when applicable.
 
 Routed handoff checks:
 1. From `Project Overview`, use a route into Analysis if present, such as `Review Analysis`.
@@ -67,5 +71,6 @@ Report format:
 - Blocking issues: list exact steps, expected result, actual result, screenshots if possible
 - Non-blocking concerns: wording, layout, confusing state transitions
 - Regression notes: anything broken in Sessions, Assets, or Backup / Migration
+- Provider evidence notes: whether findings were provider-backed, empty-provider, or seed-fallback, and whether project-relative paths remained display-safe
 - Suggested follow-up tests
 ```

--- a/docs/viewer/assets-governance-hardening-qa-prompt.md
+++ b/docs/viewer/assets-governance-hardening-qa-prompt.md
@@ -4,7 +4,10 @@ Use this prompt to run a focused QA pass for Assets governance hardening.
 
 ## Scope
 
-- Verify `Assets` shows a foundation/provider data cue and does not imply a complete live project scan.
+- Verify `Assets` shows a provider-backed repo-local evidence cue when allowlisted evidence exists, and does not imply a complete live project scan.
+- Verify provider-backed inventory uses project-relative paths only and does not expose sensitive absolute checkout paths in normal UI copy.
+- Verify an empty provider result shows an explicit zero-state inventory and does not substitute seed rows as current project assets.
+- Verify an unavailable provider result keeps fallback seed/test data visibly labeled as non-live.
 - Verify the summary keeps subtype/scope/source/status filters visible while showing governance issue counts for freshness, conflict, orphaned, and unknown classes.
 - Verify selected detail explains governance health, provenance, in-effect relevance, and the route owner.
 - Verify stale, conflicted, orphaned, and unknown assets use inspection/review language only.
@@ -15,13 +18,14 @@ Use this prompt to run a focused QA pass for Assets governance hardening.
 - `Assets` may route to `Sessions`, `Analysis`, `Backup / Migration`, or `Project Overview`.
 - `Assets` must not render inline edit, repair, sync, deploy, restore, validation, confirmation, execution, or workflow result controls.
 - Unknown health should remain explicit and non-blocking.
-- Seed/provider-backed data must stay labeled as incomplete foundation data.
+- Provider-backed data must stay labeled as repo-local allowlist evidence, not a complete repository/source scan.
+- Seed/test fallback data must stay labeled as non-live fallback data.
 
 ## Suggested Flow
 
 1. Open the app at `/` and confirm `Project Overview` is selected by default.
 2. Open `Assets` from the top-level navigation.
-3. Confirm the foundation data cue is visible near the Assets header.
+3. Confirm the provider-backed repo-local evidence cue is visible near the Assets header when the checkout contains allowlisted agent-facing files.
 4. Confirm filters remain visible and the summary shows governance issue class counts.
 5. Select an active in-effect rule and confirm it shows `healthy`, an in-effect explanation, source/provenance context, and route ownership.
 6. Select or route to a stale memory and confirm it shows freshness review copy and route-only actions.
@@ -31,11 +35,13 @@ Use this prompt to run a focused QA pass for Assets governance hardening.
 10. From `Project Overview`, open an in-effect asset or attention item into `Assets`; confirm only compact issue context appears.
 11. From `Analysis`, open an affected asset route into `Assets`; confirm only compact issue context appears.
 12. Change an Assets filter or select a different asset; confirm the routed cue clears and the new local focus remains active.
+13. If testing a fixture checkout with no allowlisted evidence, confirm `Assets` shows a zero-state rather than seed assets.
+14. If testing an intentionally unavailable provider fixture, confirm fallback rows are labeled provider-unavailable or seed/test fallback.
 
 ## Report Format
 
 - Environment: branch, commit, browser, date
 - Pass/fail summary
-- Evidence notes for health mapping, issue counts, detail route ownership, and bounded action copy
+- Evidence notes for provider-backed paths, health mapping, issue counts, detail route ownership, diagnostics, zero/unavailable states, and bounded action copy
 - Routed continuity notes for Overview -> Assets and Analysis -> Assets
 - Regressions in neighboring `Sessions`, `Analysis`, `Backup / Migration`, or shell navigation

--- a/docs/viewer/project-overview-governance-qa-prompt.md
+++ b/docs/viewer/project-overview-governance-qa-prompt.md
@@ -7,6 +7,8 @@ Use this prompt to run a focused QA pass for the Project Overview governance fou
 - Verify `Project Overview` opens as the default project-scoped agent context governance surface.
 - Verify the module spine renders: Project Header, Context Snapshot, In-Effect Assets, Recent Sessions, Attention Needed, and Quick Actions.
 - Verify explicit page states: loading placeholders, no-project-context zero cues, normal summaries, and issue-state prioritization.
+- Verify provider-backed repo-local evidence is labeled as local evidence, not sample data.
+- Verify empty or unavailable provider evidence shows zero/unknown cues instead of fabricated asset or finding counts.
 - Verify route handoffs from each module:
   - Context Snapshot routes to `Sessions`, `Assets`, `Analysis`, or `Backup / Migration`.
   - In-Effect Assets routes to `Assets` with explicit asset or filter context.
@@ -20,14 +22,17 @@ Use this prompt to run a focused QA pass for the Project Overview governance fou
 - Overview must not imply runtime orchestration, cross-agent sync, migration apply, vendor-runtime restore, cloud sync, privacy redaction, or new workflow types.
 - Quick Actions may route to `session-backup`, `bulk-session-backup`, `import-backup`, `validate-package`, `migration-preview`, and `project-bundle`; workflow bodies remain inside `Backup / Migration`.
 - Missing or unavailable provider data must show unknown, unavailable, or zero-state cues instead of invented counts, sessions, assets, findings, or workflow results.
+- Provider-backed cues should reference explicit local project evidence only; they should not claim user-global runtime stores, session transcript stores, cloud sources, or arbitrary source files were scanned.
 
 ## Suggested Test Flow
 
 1. Open the app at `/` and confirm `Project Overview` is selected by default.
 2. Confirm the header copy frames the page as project-scoped agent context governance.
-3. Click one Context Snapshot cue for each owning page and confirm the destination page receives compact route context.
-4. Click an In-Effect Asset cue and confirm `Assets` selects or filters the target without showing Overview-only detail.
-5. Click a Recent Session cue and confirm `Sessions` receives only session identity/source/root context.
-6. Click the highest-priority Attention Needed item and confirm it opens the owning surface rather than expanding a findings table inline.
-7. Click each Quick Action and confirm accepted workflow types start in safe destination states inside `Backup / Migration`.
-8. Confirm Overview remains compact and does not expose forbidden detail surfaces listed above.
+3. Confirm the evidence label says local project evidence when the checkout contains allowlisted agent-facing files, and that no `sample data` badge appears for provider-backed counts.
+4. Click one Context Snapshot cue for each owning page and confirm the destination page receives compact route context.
+5. Click an In-Effect Asset cue and confirm `Assets` selects or filters the target without showing Overview-only detail.
+6. Click a Recent Session cue and confirm `Sessions` receives only session identity/source/root context.
+7. Click the highest-priority Attention Needed item and confirm it opens the owning surface rather than expanding a findings table inline.
+8. Click each Quick Action and confirm accepted workflow types start in safe destination states inside `Backup / Migration`.
+9. Confirm Overview remains compact and does not expose forbidden detail surfaces listed above.
+10. If using an empty-provider fixture, confirm Overview shows `0 assets` / `0 findings`; if using an unavailable-provider fixture, confirm `Unknown` cues and no invented counts.

--- a/docs/viewer/trajectory-view.md
+++ b/docs/viewer/trajectory-view.md
@@ -18,6 +18,7 @@ Relevant implementation:
 - `src/lib/parse/windsurfSteps.ts`
 - `src/lib/server/antigravity.ts`
 - `src/lib/server/windsurf.ts`
+- `src/lib/server/cursor.ts`
 - `src/app/api/conversations/[source]/[id]/route.ts`
 - `src/components/HomeClient.tsx`
 
@@ -90,6 +91,24 @@ Current mapping highlights:
 - `systemMessage` -> `status`
 - unmatched payload -> `tool` with truncated raw JSON
 
+### Cursor
+
+Input:
+
+- `composerData:<composerId>` JSON from `cursorDiskKV` table in `state.vscdb`
+- `bubbleId:<composerId>:<bubbleId>` entries read in `fullConversationHeadersOnly` order
+
+Output:
+
+- `TrajectoryEvent[]` + `TrajectorySummary` via `buildCursorEvents` + `buildCursorSummary`
+
+Special normalization rules:
+
+1. Bubble types: `type=1` → `kind: "user"`; `type=2` → `kind: "assistant"`
+2. Tool-call infrastructure bubbles (empty assistant, `capabilityType` present, no text) are skipped
+3. Summary fallback: when no `fullConversationHeadersOnly` headers exist or bubble reads fail, `extractSummaryText` provides a single `assistant` summary event
+4. `extractSummaryText` strips Cursor AI conversation-context XML format (`Summary of the conversation so far:...`) and `<summary>` wrappers (including truncated forms)
+
 ## API Surface
 
 - Antigravity conversation API returns trajectory by default:
@@ -97,6 +116,9 @@ Current mapping highlights:
 - Windsurf conversation API has two modes:
   - default: `kind: "chat"`
   - `view=trajectory`: `kind: "trajectory"`, `source: "windsurf"`, `events`, `summary`
+- Cursor conversation API always returns trajectory:
+  - `kind: "trajectory"`, `source: "cursor"`, `events`, `summary`
+  - No paging required; full bubble content read synchronously from local SQLite
 
 Historical note:
 
@@ -105,12 +127,13 @@ Historical note:
 
 ## View-Type Semantics (Compact / Transcript / Trajectory)
 
-The view types are intentionally different projections with different goals. `Compact` is the unified name for source-specific readability modes (Windsurf chat + Antigravity markdown):
+The view types are intentionally different projections with different goals. `Compact` is the unified name for source-specific readability modes (Windsurf chat + Antigravity markdown). Cursor has no Compact mode and defaults directly to `Transcript`.
 
-- `Compact` (default, first tab):
+- `Compact` (default, first tab for Antigravity/Windsurf only):
   - unified UX label with source-specific backing
     - Windsurf: legacy `chat` payload/message list
     - Antigravity: vendor `markdown` from `ConvertTrajectoryToMarkdown`
+    - Cursor: **no Compact mode** — `Transcript` is the default entry point
   - optimized for quick reading with lower structural density
 - `Transcript`:
   - source-agnostic projection from normalized `TrajectoryEvent[]`
@@ -160,6 +183,7 @@ For compact-mode backing data:
 
 - Windsurf compact uses `kind: "chat"` (legacy message projection)
 - Antigravity compact uses `content.markdown` from `ConvertTrajectoryToMarkdown`
+- Cursor has no compact mode; `Transcript` is always backed by `kind: "trajectory"` events
 
 ## Inspector and Error Center (Implemented)
 

--- a/openspec/changes/archive/2026-05-26-add-cursor-support/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-26-add-cursor-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/archive/2026-05-26-add-cursor-support/design.md
+++ b/openspec/changes/archive/2026-05-26-add-cursor-support/design.md
@@ -1,0 +1,144 @@
+## Context
+
+Agent Storage Manager currently models supported session sources as `antigravity`, `windsurf`, and `codex`. That assumption is embedded in shared unions, default root generation, source-status payloads, settings UI options, source labels, project evidence classification, and source-specific loader/parser modules.
+
+Cursor support cuts across two existing product areas:
+
+1. `Sessions`
+   - the app must recognize Cursor as a first-class source for root configuration, session discovery, loading, viewer normalization, and diagnostics
+   - unlike current sources, the concrete Cursor storage/runtime contract has not yet been documented in this repository, so the implementation must preserve an explicit validation/documentation step rather than hard-coding unverified assumptions
+2. `Assets` / `Analysis`
+   - the project evidence provider currently recognizes repo-local Codex, Windsurf, Copilot, and cross-agent assets from an explicit allowlist
+   - Cursor-specific repo-local assets such as `.cursor/` rules/configuration are currently invisible or downgraded to generic unsupported evidence even when they matter for project governance
+
+The design must preserve the repository's local-first model, keep third-party runtime details version-scoped and documented, and avoid promising full Cursor runtime control or inline asset editing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add Cursor as a first-class source in shared product abstractions, configuration, and UI routing.
+- Support bounded Cursor session discovery, selection, loading, normalization, and diagnostics in the `Sessions` surface.
+- Support bounded discovery of repo-local Cursor assets through the existing project evidence provider so they can appear in `Assets` and `Analysis`.
+- Keep unsupported or unverified Cursor details explicit through diagnostics and documentation rather than silently fabricating behavior.
+- Prefer helper-level and model-level test coverage that matches the repository's current Vitest/node testing approach.
+
+**Non-Goals:**
+- Reopen or sync sessions back into the Cursor runtime.
+- Add cloud dependencies, account integration, or remote Cursor APIs.
+- Turn `Assets` into a Cursor rules editor or workflow executor.
+- Reverse-engineer every historical Cursor storage format before shipping a bounded first version.
+
+## Decisions
+
+### 1. Add Cursor as a shared first-class source across the product model
+Cursor will be added to shared source unions and source-derived helpers rather than treated as an ad hoc special case.
+
+Rationale:
+
+- Source-specific branching already exists in `types`, config defaults, settings, root health, labels, routing, and viewer state.
+- A first-class `cursor` source keeps the product model coherent and makes future source-specific features testable.
+
+Alternatives considered:
+
+- Treat Cursor as a variant of Codex or Windsurf.
+  - Rejected because Cursor has different repo-local asset conventions and may have different session storage/runtime semantics.
+- Hide Cursor behind generic external roots only.
+  - Rejected because the request is to add actual product support, not just allow arbitrary folders.
+
+### 2. Implement Cursor sessions behind a dedicated source adapter boundary
+Cursor session support will land behind a dedicated server/parser path, parallel to existing source-specific modules, while reusing the shared conversation list, selection, search, and viewer abstractions.
+
+Rationale:
+
+- The repository already isolates source-specific retrieval logic under `src/lib/server/` and `src/lib/parse/`.
+- Cursor storage/attach facts are not yet validated here; isolating them behind a dedicated adapter limits blast radius while preserving explicit diagnostics.
+
+Alternatives considered:
+
+- Fold Cursor logic into an existing generic scanner.
+  - Rejected because source-specific metadata, root layout, and diagnostics would become harder to reason about.
+- Block the proposal until every Cursor storage detail is fully verified.
+  - Rejected because the change should establish the intended contract now while leaving version-scoped validation as an implementation task.
+
+### 3. Keep Cursor source status bounded and evidence-based
+The product will expose Cursor source availability using the same bounded philosophy as existing sources: show discovered/available state when validated facts exist, and otherwise present explicit unavailable or unsupported diagnostics instead of guessing.
+
+Rationale:
+
+- Existing Antigravity and Windsurf support already depends on attach/runtime facts that change by product version.
+- Cursor may require file-backed, runtime-backed, or hybrid status semantics depending on validated implementation facts.
+
+Alternatives considered:
+
+- Always report Cursor as file-backed only.
+  - Rejected until validated facts prove that runtime attach is unnecessary for the intended session fidelity.
+- Hide Cursor status until perfect parity exists.
+  - Rejected because users still need explicit visibility into whether the source is supported, misconfigured, or not yet attachable.
+
+### 4. Extend the project evidence allowlist with explicit Cursor-owned repo-local paths
+Cursor repo-local assets will be discovered through an explicit allowlist in the project evidence provider, mapping recognized Cursor files into the existing bounded asset kinds (`rule`, `command`, `unknown`) and source labels.
+
+Initial expected scope:
+
+- `.cursor/` project assets that the repository can classify from explicit allowlisted subpaths and file names
+- legacy project-level Cursor rule files when present
+
+Rationale:
+
+- The current provider is intentionally allowlist-based and bounded.
+- Cursor support in `Assets` and `Analysis` should behave like other repo-local agent-facing evidence: recognized where explicit, unsupported where outside the allowlist, and never inferred from arbitrary files.
+
+Alternatives considered:
+
+- Recursively ingest all `.cursor/` files.
+  - Rejected because it would violate the provider's bounded-governance model.
+- Delay Cursor asset support until a full editor/integration exists.
+  - Rejected because the request explicitly includes asset/rule recognition, and read-only governance support fits the current product.
+
+### 5. Prefer helper and state-derivation tests over DOM-heavy coverage
+Validation for this change will focus on parser, scanner, provider, normalization, and view-model tests, with UI assertions limited to state derivation and small rendering helpers unless the test environment changes.
+
+Rationale:
+
+- The repository currently uses Vitest with a node environment.
+- Source support changes are most reliably covered through pure helpers, server modules, and deterministic data-shape tests.
+
+Alternatives considered:
+
+- Introduce broad DOM-rendering coverage as part of this change.
+  - Rejected as unnecessary scope growth for a source-support slice.
+
+## Risks / Trade-offs
+
+- **Cursor storage/runtime facts may change or be incomplete** → Mitigation: make validation/documentation a first implementation step, keep diagnostics explicit, and isolate source-specific assumptions behind a dedicated adapter.
+- **Source-model changes touch many files** → Mitigation: centralize Cursor additions in shared unions/labels first, then update source-specific consumers with targeted tests.
+- **Repo-local Cursor assets may have multiple evolving conventions** → Mitigation: ship an explicit allowlist, classify unsupported paths as bounded diagnostics, and document version-scoped facts.
+- **Users may assume full Cursor runtime interoperability** → Mitigation: keep specs and docs explicit that support is for local reading/governance, not reopening sessions or editing third-party runtime state.
+
+## Migration Plan
+
+1. Validate and document the current Cursor local storage/runtime facts needed for bounded support.
+2. Add Cursor to shared source/config/label/filter abstractions and default root handling.
+3. Implement Cursor session scanning, load/normalize flows, and source diagnostics behind a dedicated adapter.
+4. Extend the project evidence allowlist and context asset source labels for Cursor repo-local assets.
+5. Update README and storage documentation to describe supported Cursor behavior and constraints.
+6. Run targeted tests for scanning, parsing, provider classification, and affected view-model helpers.
+
+Rollback strategy:
+
+- If Cursor session retrieval proves too unstable, the session adapter can be gated back to explicit unsupported diagnostics while preserving non-destructive config and project-evidence support.
+- Repo-local Cursor asset recognition can be narrowed by shrinking the allowlist without affecting other sources.
+
+## Open Questions (Resolved)
+
+- **What validated Cursor session storage path(s), metadata store(s), and title/cwd sources should be treated as the initial macOS implementation target?**
+  Resolved: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` (`cursorDiskKV` table, keys prefixed `composerData:` and `bubbleId:`). Workspace-to-composer mapping read from per-workspace `state.vscdb` files under `workspaceStorage/`. Documented in `docs/storage/local-storage-notes.md`.
+
+- **Does Cursor require a running local runtime for full-fidelity session retrieval, or is a file-backed reader sufficient for the accepted viewer modes?**
+  Resolved: File-backed SQLite reader is sufficient. No runtime attach is required. Full bubble-by-bubble transcripts are recovered from `bubbleId:<composerId>:<bubbleId>` keys. See `src/lib/server/cursor.ts`.
+
+- **Which Cursor repo-local files should map to `rule` versus `command` versus `unknown` in the bounded provider model?**
+  Resolved: `.cursor/rules/*.mdc` → `rule`; `.cursorrules` → `rule`; `.cursor/mcp.json` → `command`; `.cursor/settings/` files → `unknown`. Implemented in `src/lib/projectEvidenceProvider.ts`.
+
+- **Should Cursor-specific storage notes live in the existing storage document or in a dedicated Cursor storage note referenced from README?**
+  Resolved: Added a `## Cursor` section to the existing `docs/storage/local-storage-notes.md` (consistent with the Antigravity, Windsurf, and Codex sections already there). Referenced from `README.md`.

--- a/openspec/changes/archive/2026-05-26-add-cursor-support/proposal.md
+++ b/openspec/changes/archive/2026-05-26-add-cursor-support/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Agent Storage Manager currently treats supported agent products as Antigravity, Windsurf, and Codex only. Users who work in Cursor cannot browse Cursor sessions in the Sessions surface and cannot inspect Cursor-specific project governance assets alongside the rest of a repository-local agent setup.
+
+## What Changes
+
+- Add first-class Cursor support as a new source in the local product model.
+- Support listing, selecting, loading, and diagnosing Cursor sessions using Cursor-specific storage/runtime rules instead of forcing users to treat Cursor data as unsupported.
+- Support Cursor project evidence discovery so `.cursor/` and other repo-local Cursor-facing assets can appear in `Assets` and `Analysis` alongside existing agent-facing files.
+- Extend product configuration, routing, and source-status surfaces so Cursor appears as a peer to Antigravity, Windsurf, and Codex where applicable.
+- Keep the change local-first and bounded: no cloud dependency, no inline editing of Cursor assets, and no promise to reopen sessions inside Cursor itself.
+
+## Capabilities
+
+### New Capabilities
+- `cursor-support`: Support Cursor session browsing/inspection plus Cursor repo-local asset discovery and governance routing.
+
+### Modified Capabilities
+- `project-shell`: Expand shell-visible supported source behavior so Cursor appears in source presence, session switching, and related routing surfaces.
+
+## Impact
+
+- Affected code:
+  - `src/lib/types.ts`
+  - `src/lib/server/config.ts`
+  - session scanning/loading and source-status code under `src/lib/server/`
+  - parsing/normalization code under `src/lib/parse/`
+  - project evidence discovery under `src/lib/projectEvidenceProvider.ts`
+  - session and asset UI surfaces in `src/components/`
+  - tests covering source scanning, parsing, provider evidence, and UI state derivation
+- Affected docs:
+  - `README.md`
+  - storage notes under `docs/storage/`
+  - new and modified OpenSpec artifacts under `openspec/`
+- Expected constraints:
+  - Cursor support must fit the existing local-first architecture.
+  - Any Cursor attach or metadata assumptions must be documented as version-scoped facts, similar to existing Windsurf and Antigravity notes.

--- a/openspec/changes/archive/2026-05-26-add-cursor-support/specs/cursor-support/spec.md
+++ b/openspec/changes/archive/2026-05-26-add-cursor-support/specs/cursor-support/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Cursor SHALL be a first-class supported source
+The system SHALL treat Cursor as a first-class source in configuration, source selection, and shared session-routing behavior instead of treating Cursor data as an unnamed external folder.
+
+#### Scenario: Cursor can be configured as a source root
+- **WHEN** the user manages source roots in Settings
+- **THEN** the user can add, enable, disable, and remove a root whose source is `cursor`
+- **AND** the product preserves that root in the same local configuration model used for other supported sources
+
+#### Scenario: Cursor participates in source selection
+- **WHEN** the app shows supported session sources
+- **THEN** Cursor appears as a selectable source peer to Antigravity, Windsurf, and Codex
+- **AND** selecting Cursor scopes session listing, selection, and deep-link restoration to Cursor sessions
+
+### Requirement: Cursor sessions SHALL support bounded local discovery and loading
+The system SHALL support bounded local discovery, selection, and loading of Cursor sessions using validated Cursor-specific storage or runtime rules documented for the supported version scope.
+
+#### Scenario: Cursor sessions are listed from configured roots
+- **WHEN** at least one enabled Cursor root contains valid Cursor session material for the supported implementation scope
+- **THEN** the Sessions surface lists matching Cursor sessions from those roots
+- **AND** each listed session retains its Cursor source identity and root ownership
+
+#### Scenario: Selected Cursor session loads into the existing viewer model
+- **WHEN** the user selects a listed Cursor session
+- **THEN** the system loads the session through the Cursor adapter and normalizes it into the product's existing readable viewer model
+- **AND** the user can inspect the session using whichever viewer modes the Cursor adapter explicitly supports
+- **AND** unsupported viewer affordances remain explicit rather than silently fabricated
+
+#### Scenario: Unsupported or invalid Cursor session material is diagnosed explicitly
+- **WHEN** a configured Cursor root is present but does not contain supported or readable Cursor session material
+- **THEN** the product reports explicit Cursor-specific unavailable, unreadable, or unsupported diagnostics
+- **AND** it does not misclassify the root as another source type or fabricate session content
+
+### Requirement: Cursor source status SHALL remain evidence-based
+The system SHALL expose Cursor source availability and diagnostics using validated local evidence and SHALL avoid implying runtime attachment or healthy availability when those facts are unknown.
+
+#### Scenario: Validated Cursor availability is shown
+- **WHEN** the system has enough validated local evidence to determine current Cursor source availability for the supported implementation scope
+- **THEN** the source-status UI shows Cursor availability using source-specific status details
+- **AND** any attach, discovery, or file-backed limitations remain visible to the user
+
+#### Scenario: Unknown Cursor availability stays explicit
+- **WHEN** the system cannot validate the expected Cursor local evidence for the supported implementation scope
+- **THEN** the source-status UI reports Cursor as unavailable, unsupported, or unknown with actionable diagnostics
+- **AND** it does not claim successful attachment or session-read coverage by inference alone
+
+### Requirement: Cursor repo-local assets SHALL be discoverable through the bounded provider model
+The system SHALL recognize allowlisted Cursor repo-local files as project evidence so Cursor-facing rules or commands can appear in `Assets` and `Analysis` without turning the provider into an unbounded repository scanner.
+
+#### Scenario: Recognized Cursor project evidence becomes asset inventory
+- **WHEN** the repository contains allowlisted Cursor repo-local project files recognized by the provider
+- **THEN** the provider emits project-scoped assets whose source is `cursor`
+- **AND** each recognized item preserves bounded subtype, provenance, and source-reference data
+
+#### Scenario: Unsupported Cursor files stay bounded diagnostics
+- **WHEN** the repository contains Cursor-related files outside the provider allowlist or outside recognized mappings
+- **THEN** the provider records them as unsupported or ambiguous diagnostics when applicable
+- **AND** it does not silently ingest arbitrary repository files as Cursor assets
+
+#### Scenario: Cursor-backed asset findings route without inline mutation
+- **WHEN** a recognized Cursor asset has provider diagnostics or governance issues
+- **THEN** the resulting Assets and Analysis routes stay read-only and bounded
+- **AND** the product does not offer inline editing, sync, or runtime restore of Cursor-owned files from those surfaces

--- a/openspec/changes/archive/2026-05-26-add-cursor-support/specs/project-shell/spec.md
+++ b/openspec/changes/archive/2026-05-26-add-cursor-support/specs/project-shell/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Source status and diagnostics preservation
+The system SHALL preserve source status and diagnostics access during the shell
+foundation.
+
+#### Scenario: Source presence remains visible
+- **WHEN** source status has loaded
+- **THEN** the app exposes Antigravity, Windsurf, Codex, and Cursor source presence or
+  attachment state from either the shell or the `Sessions` source area
+
+#### Scenario: Diagnostics remain accessible
+- **WHEN** source diagnostics are available
+- **THEN** the user can still access diagnostic details and copyable evidence
+  without leaving the current local app workflow

--- a/openspec/changes/archive/2026-05-26-add-cursor-support/tasks.md
+++ b/openspec/changes/archive/2026-05-26-add-cursor-support/tasks.md
@@ -1,0 +1,24 @@
+## 1. Validate Cursor source facts
+
+- [x] 1.1 Confirm the supported Cursor local storage/runtime facts for the initial macOS implementation target and record them in project docs.
+- [x] 1.2 Decide the initial Cursor session retrieval contract (file-backed, runtime-backed, or hybrid) and document bounded fallback/diagnostic behavior.
+- [x] 1.3 Define the initial allowlist of Cursor repo-local files that map into project evidence asset kinds.
+
+## 2. Extend shared source abstractions
+
+- [x] 2.1 Add `cursor` to shared source/config/status/label/filter types and helpers.
+- [x] 2.2 Update Settings and other source-selection surfaces so Cursor roots can be added and managed.
+- [x] 2.3 Update shared routing, deep-link, and source-status consumers so Cursor is treated as a first-class source.
+
+## 3. Implement bounded Cursor session support
+
+- [x] 3.1 Add a dedicated Cursor server adapter for root scanning, session lookup, and source-status diagnostics.
+- [x] 3.2 Add Cursor parsing/normalization logic that converts supported Cursor session material into the existing viewer model.
+- [x] 3.3 Wire Cursor sessions into list/detail/search/export flows with explicit unsupported diagnostics where parity is not available.
+
+## 4. Implement Cursor asset support and validation
+
+- [x] 4.1 Extend the project evidence provider and context asset source labels with allowlisted Cursor repo-local assets.
+- [x] 4.2 Update Assets and Analysis state-derivation paths so Cursor-backed assets and findings route correctly.
+- [x] 4.3 Add or update targeted Vitest coverage for Cursor scanning, parsing, provider classification, and shared source state derivation.
+- [x] 4.4 Update README and storage/support docs to describe the supported Cursor behavior, constraints, and validation commands.

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/design.md
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/design.md
@@ -1,0 +1,73 @@
+# Windsurf Legacy Recoverability Design
+
+## Context
+
+Agent Storage Manager currently discovers Windsurf sessions from configured roots by scanning local `.pb` files, but readable session content still comes from the live Windsurf language server through LS RPC. This split is acceptable for current Windsurf sessions, but it becomes confusing for legacy session roots such as `~/.codeium/cascade`: the list can show historical sessions while the viewer later fails because the running LS no longer has the referenced trajectory.
+
+Recent investigation confirmed two important facts. First, five legacy Windsurf `.pb` sessions from 2025 can be discovered locally, but all return `trajectory not found` from the live LS. Second, one of those legacy sessions has a readable sidecar under `~/.codeium/brain`, which means recoverability must be modeled separately from LS readability. Investigation also confirmed that Windsurf 2.3.9 exposes the live LS CSRF token through `WINDSURF_CSRF_TOKEN` in process environment, even when older command-line token expectations no longer apply.
+
+The design therefore needs to improve user-facing semantics without changing the architectural decision that LS RPC remains the source of truth for readable Windsurf content.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a bounded recoverability model for Windsurf sessions that distinguishes LS-readable sessions from partially recoverable or unavailable legacy sessions.
+- Surface recoverability state in the Sessions experience with actionable diagnostics instead of opaque transport failures.
+- Preserve evidence that can be inspected or preserved when a Windsurf session is locally discoverable but not readable from the live LS.
+- Normalize Windsurf attach/token diagnostics so newer builds that expose CSRF via process environment are reported accurately.
+- Keep the change local-first and consistent with existing `Backup / Migration` and shell routing boundaries.
+
+**Non-Goals:**
+
+- Reverse-engineer Windsurf `.pb` files into a full transcript source.
+- Restore legacy sessions back into Windsurf or claim vendor-runtime restoration.
+- Introduce cloud recovery, remote sync, or server-side recovery workflows.
+- Redefine canonical session backup format or make raw source preservation the default.
+
+## Decisions
+
+### Decision: Introduce an explicit recoverability classification for Windsurf sessions
+
+The system will classify Windsurf sessions into bounded recoverability states such as LS-readable, partially recoverable, or unavailable. This avoids conflating transport health with data availability.
+
+Alternative considered: treating all LS failures as generic viewer errors. Rejected because `trajectory not found` for a locally discovered session carries different meaning from token failure, port failure, or malformed response.
+
+### Decision: Keep LS RPC as the authority for readable session content
+
+The design preserves ADR-001: readable Windsurf content still comes from LS RPC. Recoverability evidence augments the product's understanding of a session, but it does not replace LS-readable canonical content.
+
+Alternative considered: elevating local `.pb` or `brain` sidecars to a full content source. Rejected because the current evidence is partial, version-specific, and not stable enough for the canonical contract.
+
+### Decision: Route partial recovery through diagnostics and bounded workflow context
+
+When a Windsurf session is not LS-readable, the product will expose structured recoverability evidence through diagnostics and route-only workflow context rather than claiming that a normal session open, backup, or restore is still possible.
+
+Alternative considered: silently hiding unreadable legacy sessions from the list. Rejected because users may intentionally add legacy roots and need the product to acknowledge what was found, even if only partial evidence is available.
+
+### Decision: Treat token source as version-aware process evidence, not only historical args
+
+Windsurf attach logic and diagnostics will treat the live LS token as coming from running process evidence, including environment-provided tokens such as `WINDSURF_CSRF_TOKEN`, rather than assuming only command-line flags or manual override.
+
+Alternative considered: keeping the old `ps_args` mental model and relying on Settings override when it fails. Rejected because it misclassifies newer Windsurf behavior and produces misleading remediation guidance.
+
+## Risks / Trade-offs
+
+- [Recoverability semantics may be misunderstood as restoration support] → Mitigation: specs and UI copy must explicitly distinguish evidence preservation from vendor-runtime reopening or transcript restore.
+- [Partial sidecar evidence may vary by version or session] → Mitigation: classify sidecar-backed recovery as bounded and optional; never require it for canonical session behavior.
+- [Token-source refinement may require small type and diagnostic changes across multiple modules] → Mitigation: keep the change additive, reuse existing status surfaces, and document version-scoped behavior in storage notes.
+- [Users may still expect backup to succeed for unreadable sessions] → Mitigation: route unreadable legacy sessions through validation-first warnings in `Backup / Migration` and do not imply that canonical backup can be produced without readable source content.
+
+## Migration Plan
+
+1. Update Windsurf diagnostics and storage notes to document legacy `trajectory not found` behavior and process-environment token sourcing.
+2. Add recoverability classification and evidence collection to Windsurf-specific diagnostics and session metadata enrichment.
+3. Update Sessions/Viewer rendering to show recoverability-aware status messaging for unreadable Windsurf sessions.
+4. Update `Backup / Migration` routing and validation behavior so unreadable legacy Windsurf sessions can preserve evidence context without implying transcript or vendor-runtime restoration.
+5. Roll forward additively; rollback consists of removing the recoverability-specific UI and falling back to existing generic diagnostics.
+
+## Open Questions
+
+- Should the initial recoverability surface appear only in diagnostics and Viewer, or also as a compact badge in the session list on first rollout?
+- Should partial-recovery evidence be materialized into the canonical session record as metadata, or remain Windsurf-specific diagnostic context until broader reuse is proven?
+- Should token-source vocabulary distinguish `ps_args` from `ps_env`, or is a broader `process` category sufficient for the first compatibility pass?

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/proposal.md
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/proposal.md
@@ -1,0 +1,32 @@
+# Windsurf Legacy Recoverability
+
+## Why
+
+Windsurf legacy sessions discovered from local `~/.codeium/cascade/*.pb` roots can appear in the Sessions list even when the running Windsurf language server no longer has the corresponding trajectory. Today this creates a confusing user experience: the product can discover a legacy session, but the viewer fails at read time unless the user manually inspects diagnostics and interprets low-level LS behavior.
+
+We also confirmed that newer Windsurf builds expose the live LS CSRF token through process environment rather than only through historical command-line flags. The product needs a clearer contract for recoverability evidence and a version-aware attach/token strategy so diagnostics and session access remain trustworthy.
+
+## What Changes
+
+- Introduce a bounded Windsurf session recoverability capability that distinguishes between LS-readable sessions, partially recoverable legacy sessions with sidecar evidence, and unavailable sessions that only have opaque local source artifacts.
+- Define how the Sessions surface and Viewer present recoverability state, diagnostics, and next-step guidance when a session is discoverable locally but not readable from the live Windsurf LS.
+- Define how Backup / Migration consumes recoverability context for Windsurf sessions so routed workflows can preserve evidence without implying vendor-runtime restoration.
+- Define version-aware Windsurf attach/token expectations for environments where the live LS CSRF token is sourced from process environment rather than only from command-line args or Settings override.
+- Preserve the existing local-first model and the ADR decision that LS RPC remains the source of truth for readable Windsurf session content.
+
+## Capabilities
+
+### New Capabilities
+
+- `windsurf-session-recoverability`: Recoverability states, evidence collection, and user-facing diagnostics for Windsurf sessions that are locally discovered but not fully readable from the live language server.
+
+### Modified Capabilities
+
+- `project-shell`: The Sessions surface needs explicit recoverability messaging and diagnostics behavior for Windsurf sessions that cannot be opened normally.
+- `backup-migration`: Backup / Migration needs bounded workflow behavior for routed Windsurf legacy sessions whose readable content is unavailable but whose recovery evidence can still be inspected or preserved.
+
+## Impact
+
+- Affected code likely includes `src/lib/server/windsurf.ts`, diagnostic export paths, Sessions/Viewer rendering in `src/components/HomeClient.tsx`, and Backup / Migration routing/state in the shell foundation.
+- Affected documentation includes `docs/storage/local-storage-notes.md` and any viewer UX guidance that documents legacy Windsurf session behavior.
+- No new cloud dependency is introduced; the change remains local-first and continues to treat LS RPC as authoritative for readable Windsurf content.

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/specs/backup-migration/spec.md
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/specs/backup-migration/spec.md
@@ -1,0 +1,53 @@
+# Backup Migration Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Backup / Migration SHALL validate unreadable Windsurf legacy sessions explicitly
+
+The system SHALL treat Windsurf sessions that are locally discovered but unreadable from the live language server as explicit validation subjects instead of silently treating them as normal session-backup candidates.
+
+#### Scenario: Unreadable Windsurf legacy session blocks canonical backup generation
+
+- **WHEN** a routed or selected Windsurf session is classified as unavailable because the running Windsurf LS returns `trajectory not found`
+- **THEN** the workflow validation marks canonical session backup as blocked for that session
+- **AND** the validation explains that local `.pb` discovery alone is not enough to produce a readable canonical session record
+
+#### Scenario: Partial evidence remains inspectable without implying restore
+
+- **WHEN** a routed or selected Windsurf session is classified as partially recoverable because bounded sidecar evidence exists
+- **THEN** the workflow may surface that evidence in validation or result context
+- **AND** it does not claim that the workflow can restore the session into Windsurf or recreate a canonical transcript automatically
+
+## MODIFIED Requirements
+
+### Requirement: Routed handoff SHALL preserve workflow and object context
+
+The system SHALL consume routed handoff context from `Project Overview`, `Sessions`, `Assets`, and `Analysis` to open the correct workflow and prefill selections.
+
+#### Scenario: Sessions routes to session backup workflow
+
+- **WHEN** `Sessions` hands off workflow context for session backup with a selected session
+- **THEN** `Backup / Migration` opens the session backup workflow with the session prefilled
+
+#### Scenario: Analysis routes to preservation workflow
+
+- **WHEN** `Analysis` hands off workflow context with a finding that recommends preservation
+- **THEN** `Backup / Migration` opens the appropriate workflow and shows the issue context
+
+#### Scenario: Project Overview routes to backup-oriented workflow
+
+- **WHEN** `Project Overview` hands off workflow context for backup, import, or validation
+- **THEN** `Backup / Migration` opens the requested workflow with any available context summary
+
+#### Scenario: Assets preserves handoff context when workflow cannot be inferred
+
+- **WHEN** `Assets` hands off workflow context with preservation intent
+- **THEN** `Backup / Migration` opens the relevant workflow when the handoff resolves one
+- **AND** otherwise degrades to the workflow selector idle state instead of opening a broken workflow
+- **AND** the page still shows the asset context and origin cue from `Assets`
+
+#### Scenario: Sessions handoff preserves recoverability context for unreadable Windsurf session
+
+- **WHEN** `Sessions` routes a Windsurf session whose recoverability state is partial or unavailable into `Backup / Migration`
+- **THEN** the workflow preserves compact context such as recoverability class, bounded evidence summary, and the fact that canonical readable content is unavailable
+- **AND** the workflow does not invent transcript availability, vendor-runtime restoration, or implicit backup success from that handoff alone

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/specs/project-shell/spec.md
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/specs/project-shell/spec.md
@@ -1,0 +1,62 @@
+# Project Shell Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: Current session viewer containment
+
+The system SHALL preserve the existing session viewer behavior inside the
+`Sessions` surface during the shell foundation, including recoverability-aware
+handling for Windsurf sessions whose local discovery does not guarantee readable
+content from the live language server.
+
+#### Scenario: Sessions surface contains existing viewer capability
+
+- **WHEN** the user navigates to `Sessions`
+- **THEN** the user can browse sources, select sessions, and view session
+  content using the existing compact, transcript, or trajectory views supported
+  by the selected source
+
+#### Scenario: Session inspector remains available
+
+- **WHEN** the user selects an inspectable session row or opens error
+  inspection from the `Sessions` surface
+- **THEN** the existing inspector behavior remains available
+
+#### Scenario: Windsurf viewer shows recoverability state for unreadable legacy session
+
+- **WHEN** the user selects a Windsurf session that is locally discovered but the
+  live language server returns `trajectory not found`
+- **THEN** the `Sessions` surface keeps the session selected instead of silently
+  clearing it
+- **AND** the viewer presents explicit recoverability messaging explaining that
+  the local `.pb` was found but the running Windsurf LS no longer has that
+  trajectory
+- **AND** the viewer may offer diagnostic or workflow routes for bounded
+  recovery evidence without claiming that normal viewer content is available
+
+### Requirement: Source status and diagnostics preservation
+
+The system SHALL preserve source status and diagnostics access during the shell
+foundation, including version-aware Windsurf attach/token diagnostics and
+recoverability evidence for locally discovered but unreadable Windsurf sessions.
+
+#### Scenario: Source presence remains visible
+
+- **WHEN** source status has loaded
+- **THEN** the app exposes Antigravity, Windsurf, Codex, and Cursor source presence or
+  attachment state from either the shell or the `Sessions` source area
+
+#### Scenario: Diagnostics remain accessible
+
+- **WHEN** source diagnostics are available
+- **THEN** the user can still access diagnostic details and copyable evidence
+  without leaving the current local app workflow
+
+#### Scenario: Windsurf diagnostics distinguish token source from trajectory absence
+
+- **WHEN** the product evaluates Windsurf source status or a Windsurf session
+  read fails
+- **THEN** diagnostics distinguish attach or token issues from successful
+  attachment where the selected trajectory is absent from the running LS
+- **AND** diagnostics may report that the live token came from running process
+  evidence rather than assuming historical command-line args only

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/specs/windsurf-session-recoverability/spec.md
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/specs/windsurf-session-recoverability/spec.md
@@ -1,0 +1,59 @@
+# Windsurf Session Recoverability Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Windsurf sessions SHALL expose bounded recoverability state
+
+The system SHALL classify Windsurf sessions by recoverability so locally discovered sessions can be distinguished from sessions whose readable content is unavailable from the live Windsurf language server.
+
+#### Scenario: LS-readable session remains readable
+
+- **WHEN** a Windsurf session is discoverable locally and the live Windsurf language server can return its trajectory content
+- **THEN** the system classifies the session as LS-readable
+- **AND** the user can open the session through the existing viewer modes without recoverability warnings
+
+#### Scenario: Legacy session has partial recovery evidence
+
+- **WHEN** a Windsurf session is discoverable locally but the live Windsurf language server returns `trajectory not found`
+- **AND** the product finds bounded sidecar evidence such as a readable brain artifact for that same session identity
+- **THEN** the system classifies the session as partially recoverable
+- **AND** the recoverability state does not claim that a full transcript or canonical event stream is available
+
+#### Scenario: Legacy session has no additional evidence
+
+- **WHEN** a Windsurf session is discoverable locally but the live Windsurf language server returns `trajectory not found`
+- **AND** no bounded recovery sidecar or readable evidence is found for that session identity
+- **THEN** the system classifies the session as unavailable
+- **AND** the recoverability state explains that local discovery alone does not imply readable content
+
+### Requirement: Windsurf diagnostics SHALL separate attachment failures from data absence
+
+The system SHALL distinguish Windsurf attach or token failures from successful attachment where the target trajectory no longer exists in the live language server.
+
+#### Scenario: Token failure remains an attach diagnostic
+
+- **WHEN** Windsurf status or read attempts fail because the live LS token is missing, invalid, or unreadable
+- **THEN** the product reports an attach or token diagnostic
+- **AND** it does not label the session itself as partially recoverable or unavailable based only on the token failure
+
+#### Scenario: Trajectory absence is reported as data absence
+
+- **WHEN** Windsurf attachment succeeds but `GetCascadeTrajectory`, `GetCascadeTrajectorySteps`, or an equivalent readable-content call returns `trajectory not found`
+- **THEN** the product reports that the session is no longer present in the running Windsurf LS database
+- **AND** the message does not describe the failure as a generic transport error
+
+### Requirement: Windsurf recoverability evidence SHALL remain bounded and local-first
+
+The system SHALL preserve recoverability evidence as bounded local evidence and SHALL not imply vendor-runtime restoration or offline transcript reconstruction.
+
+#### Scenario: Brain sidecar evidence is bounded
+
+- **WHEN** the product finds a readable Windsurf sidecar artifact such as `plan.md` or sidecar metadata for an unavailable session
+- **THEN** diagnostics may expose the artifact path, title, current goal, or other bounded evidence extracted from that artifact
+- **AND** the product does not claim that the sidecar replaces canonical session content
+
+#### Scenario: Opaque local source does not become canonical content
+
+- **WHEN** the only remaining Windsurf source artifact is an opaque local `.pb` file
+- **THEN** the product may preserve metadata such as file presence, size, or timestamps as evidence
+- **AND** it does not claim to reconstruct or normalize transcript content from that file by default

--- a/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/tasks.md
+++ b/openspec/changes/archive/2026-05-26-windsurf-legacy-recoverability/tasks.md
@@ -1,0 +1,25 @@
+# Windsurf Legacy Recoverability Tasks
+
+## 1. Recoverability model and diagnostics
+
+- [x] 1.1 Add a bounded Windsurf recoverability model for LS-readable, partial, and unavailable session states.
+- [x] 1.2 Extend Windsurf diagnostic export to include recoverability evidence such as local `.pb` presence, LS `trajectory not found`, and bounded brain sidecar metadata.
+- [x] 1.3 Update Windsurf error mapping so trajectory absence is reported as data unavailability rather than a generic transport failure.
+
+## 2. Windsurf attach/token compatibility
+
+- [x] 2.1 Refine Windsurf token-source detection to recognize live process-environment sourcing in addition to historical command-line args and Settings override.
+- [x] 2.2 Update Windsurf source status messaging and diagnostics guidance to reflect version-aware token sourcing and separate token failures from trajectory absence.
+- [x] 2.3 Add or update targeted tests for Windsurf token-source classification and trajectory-not-found diagnostics.
+
+## 3. Sessions and workflow UX
+
+- [x] 3.1 Update the Sessions viewer to show recoverability-aware messaging and bounded next steps for unreadable Windsurf legacy sessions.
+- [x] 3.2 Route compact recoverability context from Sessions into Backup / Migration without implying transcript availability or vendor-runtime restoration.
+- [x] 3.3 Validate Backup / Migration behavior for unreadable and partially recoverable Windsurf sessions, including blocking canonical backup when readable content is unavailable.
+
+## 4. Documentation and validation
+
+- [x] 4.1 Update `docs/storage/local-storage-notes.md` with version-scoped Windsurf token findings and legacy `trajectory not found` recovery evidence.
+- [x] 4.2 Update any relevant viewer or backup workflow documentation to explain recoverability semantics and bounded recovery claims.
+- [x] 4.3 Run targeted validation for the touched Windsurf diagnostics, session viewer, and backup workflow paths.

--- a/openspec/changes/project-evidence-provider-v1/tasks.md
+++ b/openspec/changes/project-evidence-provider-v1/tasks.md
@@ -1,34 +1,34 @@
 ## 1. Provider Model And Discovery
 
-- [ ] 1.1 Define project evidence provider types for provider status, evidence item, diagnostics, and normalized result.
-- [ ] 1.2 Implement repo-local discovery from a recognized path allowlist for explicit agent-facing files: `AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.md`, `.github/prompts/*`, `.github/skills/*/SKILL.md`, `.codex/skills/*/SKILL.md`, `.codex/agents/*`, `.codex/hooks.json`, `.agents/skills/*/SKILL.md`, `.agent/skills/*/SKILL.md`, and `.windsurf` skills/rules/workflows/hooks.
-- [ ] 1.3 Keep discovery bounded to recognized paths and file classes; do not keyword-scan arbitrary application source files.
-- [ ] 1.4 Normalize discovered evidence into `ContextAssetInput` values with stable IDs, project-relative provenance, subtype, scope, source, status, and usage metadata.
-- [ ] 1.5 Emit provider diagnostics for unreadable, skipped, unsupported, duplicate, or ambiguous evidence without exposing sensitive absolute paths in normal UI fields.
+- [x] 1.1 Define project evidence provider types for provider status, evidence item, diagnostics, and normalized result.
+- [x] 1.2 Implement repo-local discovery from a recognized path allowlist for explicit agent-facing files: `AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.md`, `.github/prompts/*`, `.github/skills/*/SKILL.md`, `.codex/skills/*/SKILL.md`, `.codex/agents/*`, `.codex/hooks.json`, `.agents/skills/*/SKILL.md`, `.agent/skills/*/SKILL.md`, and `.windsurf` skills/rules/workflows/hooks.
+- [x] 1.3 Keep discovery bounded to recognized paths and file classes; do not keyword-scan arbitrary application source files.
+- [x] 1.4 Normalize discovered evidence into `ContextAssetInput` values with stable IDs, project-relative provenance, subtype, scope, source, status, and usage metadata.
+- [x] 1.5 Emit provider diagnostics for unreadable, skipped, unsupported, duplicate, or ambiguous evidence without exposing sensitive absolute paths in normal UI fields.
 
 ## 2. Surface Integration
 
-- [ ] 2.1 Update Assets data flow to consume provider-backed assets when available.
-- [ ] 2.2 Preserve explicit Assets zero-state behavior when the provider is available but empty.
-- [ ] 2.3 Preserve labeled fallback behavior when provider evidence is unavailable and seed/test data is intentionally rendered.
-- [ ] 2.4 Update Project Overview summary inputs so asset counts and evidence labels come from provider-backed local evidence when available.
-- [ ] 2.5 Update Analysis data flow so provider diagnostics can become bounded findings, while no-diagnostic provider results show an explicit no-current-findings state.
-- [ ] 2.6 Keep Backup / Migration workflow execution, project bundle generation, imports, restore semantics, and privacy-redaction scope unchanged.
+- [x] 2.1 Update Assets data flow to consume provider-backed assets when available.
+- [x] 2.2 Preserve explicit Assets zero-state behavior when the provider is available but empty.
+- [x] 2.3 Preserve labeled fallback behavior when provider evidence is unavailable and seed/test data is intentionally rendered.
+- [x] 2.4 Update Project Overview summary inputs so asset counts and evidence labels come from provider-backed local evidence when available.
+- [x] 2.5 Update Analysis data flow so provider diagnostics can become bounded findings, while no-diagnostic provider results show an explicit no-current-findings state.
+- [x] 2.6 Keep Backup / Migration workflow execution, project bundle generation, imports, restore semantics, and privacy-redaction scope unchanged.
 
 ## 3. Tests
 
-- [ ] 3.1 Add provider unit tests for known instruction, skill, workflow, prompt, and hook path discovery.
-- [ ] 3.2 Add provider unit tests for arbitrary source exclusion and ambiguous evidence normalization.
-- [ ] 3.3 Add provider unit tests proving session transcript files and session parser inputs are not parsed or converted into assets.
-- [ ] 3.4 Add provider unit tests proving discovery does not read user-global runtime stores, external paths, cloud sources, or paths outside the repository root.
-- [ ] 3.5 Add provider unit tests for available, empty, partial, and unavailable status behavior.
-- [ ] 3.6 Add Assets tests for provider-backed inventory, empty provider state, unavailable provider state, and diagnostic visibility.
-- [ ] 3.7 Add Project Overview tests proving provider-backed counts are not labeled sample data and empty/unavailable evidence does not fabricate counts.
-- [ ] 3.8 Add Analysis tests proving provider diagnostics are bounded findings and seed findings remain labeled fallback only.
+- [x] 3.1 Add provider unit tests for known instruction, skill, workflow, prompt, and hook path discovery.
+- [x] 3.2 Add provider unit tests for arbitrary source exclusion and ambiguous evidence normalization.
+- [x] 3.3 Add provider unit tests proving session transcript files and session parser inputs are not parsed or converted into assets.
+- [x] 3.4 Add provider unit tests proving discovery does not read user-global runtime stores, external paths, cloud sources, or paths outside the repository root.
+- [x] 3.5 Add provider unit tests for available, empty, partial, and unavailable status behavior.
+- [x] 3.6 Add Assets tests for provider-backed inventory, empty provider state, unavailable provider state, and diagnostic visibility.
+- [x] 3.7 Add Project Overview tests proving provider-backed counts are not labeled sample data and empty/unavailable evidence does not fabricate counts.
+- [x] 3.8 Add Analysis tests proving provider diagnostics are bounded findings and seed findings remain labeled fallback only.
 
 ## 4. Documentation And QA
 
-- [ ] 4.1 Update README to describe repo-local project evidence provider behavior and remaining boundaries.
-- [ ] 4.2 Update relevant QA prompt(s) under `docs/viewer/` to verify provider-backed evidence, zero-state behavior, and seed fallback labeling.
+- [x] 4.1 Update README to describe repo-local project evidence provider behavior and remaining boundaries.
+- [x] 4.2 Update relevant QA prompt(s) under `docs/viewer/` to verify provider-backed evidence, zero-state behavior, and seed fallback labeling.
 - [ ] 4.3 Add or update a QA report only after browser/runtime verification is performed for the implemented UI wiring.
-- [ ] 4.4 Run `pnpm test`, `pnpm lint`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate project-evidence-provider-v1 --strict`.
+- [x] 4.4 Run `pnpm test`, `pnpm lint`, `pnpm build`, and `OPENSPEC_TELEMETRY=0 openspec validate project-evidence-provider-v1 --strict`.

--- a/openspec/specs/backup-migration/spec.md
+++ b/openspec/specs/backup-migration/spec.md
@@ -36,6 +36,19 @@ The system SHALL support single session backup through the Backup / Migration wo
 - **WHEN** the session backup workflow reaches the configuration step
 - **THEN** source backup is presented as an opt-in advanced option, not the default
 
+### Requirement: Backup / Migration SHALL validate unreadable Windsurf legacy sessions explicitly
+The system SHALL treat Windsurf sessions that are locally discovered but unreadable from the live language server as explicit validation subjects instead of silently treating them as normal session-backup candidates.
+
+#### Scenario: Unreadable Windsurf legacy session blocks canonical backup generation
+- **WHEN** a routed or selected Windsurf session is classified as unavailable because the running Windsurf LS returns `trajectory not found`
+- **THEN** the workflow validation marks canonical session backup as blocked for that session
+- **AND** the validation explains that local `.pb` discovery alone is not enough to produce a readable canonical session record
+
+#### Scenario: Partial evidence remains inspectable without implying restore
+- **WHEN** a routed or selected Windsurf session is classified as partially recoverable because bounded sidecar evidence exists
+- **THEN** the workflow may surface that evidence in validation or result context
+- **AND** it does not claim that the workflow can restore the session into Windsurf or recreate a canonical transcript automatically
+
 ### Requirement: Import backup workflow SHALL validate before accepting
 The system SHALL support importing session-backup packages through a validation-first workflow.
 
@@ -89,6 +102,11 @@ The system SHALL consume routed handoff context from `Project Overview`, `Sessio
 - **THEN** `Backup / Migration` opens the relevant workflow when the handoff resolves one
 - **AND** otherwise degrades to the workflow selector idle state instead of opening a broken workflow
 - **AND** the page still shows the asset context and origin cue from `Assets`
+
+#### Scenario: Sessions handoff preserves recoverability context for unreadable Windsurf session
+- **WHEN** `Sessions` routes a Windsurf session whose recoverability state is partial or unavailable into `Backup / Migration`
+- **THEN** the workflow preserves compact context such as recoverability class, bounded evidence summary, and the fact that canonical readable content is unavailable
+- **AND** the workflow does not invent transcript availability, vendor-runtime restoration, or implicit backup success from that handoff alone
 
 ### Requirement: Validation and warnings SHALL be explicit about preservation risk
 The system SHALL include explicit warnings at validation gates for preservation risk, destructive potential, and trust boundaries.

--- a/openspec/specs/cursor-support/spec.md
+++ b/openspec/specs/cursor-support/spec.md
@@ -1,0 +1,69 @@
+## Purpose
+
+Define the accepted behavior for Cursor as a first-class source in Agent Storage Manager,
+covering session discovery and loading, source status diagnostics, and repo-local asset recognition.
+
+## Requirements
+
+### Requirement: Cursor SHALL be a first-class supported source
+The system SHALL treat Cursor as a first-class source in configuration, source selection, and shared session-routing behavior instead of treating Cursor data as an unnamed external folder.
+
+#### Scenario: Cursor can be configured as a source root
+- **WHEN** the user manages source roots in Settings
+- **THEN** the user can add, enable, disable, and remove a root whose source is `cursor`
+- **AND** the product preserves that root in the same local configuration model used for other supported sources
+
+#### Scenario: Cursor participates in source selection
+- **WHEN** the app shows supported session sources
+- **THEN** Cursor appears as a selectable source peer to Antigravity, Windsurf, and Codex
+- **AND** selecting Cursor scopes session listing, selection, and deep-link restoration to Cursor sessions
+
+### Requirement: Cursor sessions SHALL support bounded local discovery and loading
+The system SHALL support bounded local discovery, selection, and loading of Cursor sessions using validated Cursor-specific storage or runtime rules documented for the supported version scope.
+
+#### Scenario: Cursor sessions are listed from configured roots
+- **WHEN** at least one enabled Cursor root contains valid Cursor session material for the supported implementation scope
+- **THEN** the Sessions surface lists matching Cursor sessions from those roots
+- **AND** each listed session retains its Cursor source identity and root ownership
+
+#### Scenario: Selected Cursor session loads into the existing viewer model
+- **WHEN** the user selects a listed Cursor session
+- **THEN** the system loads the session through the Cursor adapter and normalizes it into the product's existing readable viewer model
+- **AND** the user can inspect the session using whichever viewer modes the Cursor adapter explicitly supports
+- **AND** unsupported viewer affordances remain explicit rather than silently fabricated
+
+#### Scenario: Unsupported or invalid Cursor session material is diagnosed explicitly
+- **WHEN** a configured Cursor root is present but does not contain supported or readable Cursor session material
+- **THEN** the product reports explicit Cursor-specific unavailable, unreadable, or unsupported diagnostics
+- **AND** it does not misclassify the root as another source type or fabricate session content
+
+### Requirement: Cursor source status SHALL remain evidence-based
+The system SHALL expose Cursor source availability and diagnostics using validated local evidence and SHALL avoid implying runtime attachment or healthy availability when those facts are unknown.
+
+#### Scenario: Validated Cursor availability is shown
+- **WHEN** the system has enough validated local evidence to determine current Cursor source availability for the supported implementation scope
+- **THEN** the source-status UI shows Cursor availability using source-specific status details
+- **AND** any attach, discovery, or file-backed limitations remain visible to the user
+
+#### Scenario: Unknown Cursor availability stays explicit
+- **WHEN** the system cannot validate the expected Cursor local evidence for the supported implementation scope
+- **THEN** the source-status UI reports Cursor as unavailable, unsupported, or unknown with actionable diagnostics
+- **AND** it does not claim successful attachment or session-read coverage by inference alone
+
+### Requirement: Cursor repo-local assets SHALL be discoverable through the bounded provider model
+The system SHALL recognize allowlisted Cursor repo-local files as project evidence so Cursor-facing rules or commands can appear in `Assets` and `Analysis` without turning the provider into an unbounded repository scanner.
+
+#### Scenario: Recognized Cursor project evidence becomes asset inventory
+- **WHEN** the repository contains allowlisted Cursor repo-local project files recognized by the provider
+- **THEN** the provider emits project-scoped assets whose source is `cursor`
+- **AND** each recognized item preserves bounded subtype, provenance, and source-reference data
+
+#### Scenario: Unsupported Cursor files stay bounded diagnostics
+- **WHEN** the repository contains Cursor-related files outside the provider allowlist or outside recognized mappings
+- **THEN** the provider records them as unsupported or ambiguous diagnostics when applicable
+- **AND** it does not silently ingest arbitrary repository files as Cursor assets
+
+#### Scenario: Cursor-backed asset findings route without inline mutation
+- **WHEN** a recognized Cursor asset has provider diagnostics or governance issues
+- **THEN** the resulting Assets and Analysis routes stay read-only and bounded
+- **AND** the product does not offer inline editing, sync, or runtime restore of Cursor-owned files from those surfaces

--- a/openspec/specs/project-shell/spec.md
+++ b/openspec/specs/project-shell/spec.md
@@ -22,7 +22,9 @@ project-scoped agent context rather than around the session viewer.
 
 ### Requirement: Current session viewer containment
 The system SHALL preserve the existing session viewer behavior inside the
-`Sessions` surface during the shell foundation.
+`Sessions` surface during the shell foundation, including recoverability-aware
+handling for Windsurf sessions whose local discovery does not guarantee readable
+content from the live language server.
 
 #### Scenario: Sessions surface contains existing viewer capability
 - **WHEN** the user navigates to `Sessions`
@@ -35,9 +37,21 @@ The system SHALL preserve the existing session viewer behavior inside the
   inspection from the `Sessions` surface
 - **THEN** the existing inspector behavior remains available
 
+#### Scenario: Windsurf viewer shows recoverability state for unreadable legacy session
+- **WHEN** the user selects a Windsurf session that is locally discovered but the
+  live language server returns `trajectory not found`
+- **THEN** the `Sessions` surface keeps the session selected instead of silently
+  clearing it
+- **AND** the viewer presents explicit recoverability messaging explaining that
+  the local `.pb` was found but the running Windsurf LS no longer has that
+  trajectory
+- **AND** the viewer may offer diagnostic or workflow routes for bounded
+  recovery evidence without claiming that normal viewer content is available
+
 ### Requirement: Source status and diagnostics preservation
 The system SHALL preserve source status and diagnostics access during the shell
-foundation.
+foundation, including version-aware Windsurf attach/token diagnostics and
+recoverability evidence for locally discovered but unreadable Windsurf sessions.
 
 #### Scenario: Source presence remains visible
 - **WHEN** source status has loaded
@@ -48,6 +62,14 @@ foundation.
 - **WHEN** source diagnostics are available
 - **THEN** the user can still access diagnostic details and copyable evidence
   without leaving the current local app workflow
+
+#### Scenario: Windsurf diagnostics distinguish token source from trajectory absence
+- **WHEN** the product evaluates Windsurf source status or a Windsurf session
+  read fails
+- **THEN** diagnostics distinguish attach or token issues from successful
+  attachment where the selected trajectory is absent from the running LS
+- **AND** diagnostics may report that the live token came from running process
+  evidence rather than assuming historical command-line args only
 
 ### Requirement: Search selection preservation
 The system SHALL preserve the existing global search session-selection behavior.

--- a/openspec/specs/project-shell/spec.md
+++ b/openspec/specs/project-shell/spec.md
@@ -41,7 +41,7 @@ foundation.
 
 #### Scenario: Source presence remains visible
 - **WHEN** source status has loaded
-- **THEN** the app exposes Antigravity, Windsurf, and Codex source presence or
+- **THEN** the app exposes Antigravity, Windsurf, Codex, and Cursor source presence or
   attachment state from either the shell or the `Sessions` source area
 
 #### Scenario: Diagnostics remain accessible

--- a/openspec/specs/windsurf-session-recoverability/spec.md
+++ b/openspec/specs/windsurf-session-recoverability/spec.md
@@ -1,0 +1,51 @@
+## Purpose
+
+Define the accepted bounded recoverability contract for Windsurf sessions that are locally discovered but may no longer be readable from the live Windsurf language server.
+
+## Requirements
+
+### Requirement: Windsurf sessions SHALL expose bounded recoverability state
+The system SHALL classify Windsurf sessions by recoverability so locally discovered sessions can be distinguished from sessions whose readable content is unavailable from the live Windsurf language server.
+
+#### Scenario: LS-readable session remains readable
+- **WHEN** a Windsurf session is discoverable locally and the live Windsurf language server can return its trajectory content
+- **THEN** the system classifies the session as LS-readable
+- **AND** the user can open the session through the existing viewer modes without recoverability warnings
+
+#### Scenario: Legacy session has partial recovery evidence
+- **WHEN** a Windsurf session is discoverable locally but the live Windsurf language server returns `trajectory not found`
+- **AND** the product finds bounded sidecar evidence such as a readable brain artifact for that same session identity
+- **THEN** the system classifies the session as partially recoverable
+- **AND** the recoverability state does not claim that a full transcript or canonical event stream is available
+
+#### Scenario: Legacy session has no additional evidence
+- **WHEN** a Windsurf session is discoverable locally but the live Windsurf language server returns `trajectory not found`
+- **AND** no bounded recovery sidecar or readable evidence is found for that session identity
+- **THEN** the system classifies the session as unavailable
+- **AND** the recoverability state explains that local discovery alone does not imply readable content
+
+### Requirement: Windsurf diagnostics SHALL separate attachment failures from data absence
+The system SHALL distinguish Windsurf attach or token failures from successful attachment where the target trajectory no longer exists in the live language server.
+
+#### Scenario: Token failure remains an attach diagnostic
+- **WHEN** Windsurf status or read attempts fail because the live LS token is missing, invalid, or unreadable
+- **THEN** the product reports an attach or token diagnostic
+- **AND** it does not label the session itself as partially recoverable or unavailable based only on the token failure
+
+#### Scenario: Trajectory absence is reported as data absence
+- **WHEN** Windsurf attachment succeeds but `GetCascadeTrajectory`, `GetCascadeTrajectorySteps`, or an equivalent readable-content call returns `trajectory not found`
+- **THEN** the product reports that the session is no longer present in the running Windsurf LS database
+- **AND** the message does not describe the failure as a generic transport error
+
+### Requirement: Windsurf recoverability evidence SHALL remain bounded and local-first
+The system SHALL preserve recoverability evidence as bounded local evidence and SHALL not imply vendor-runtime restoration or offline transcript reconstruction.
+
+#### Scenario: Brain sidecar evidence is bounded
+- **WHEN** the product finds a readable Windsurf sidecar artifact such as `plan.md` or sidecar metadata for an unavailable session
+- **THEN** diagnostics may expose the artifact path, title, current goal, or other bounded evidence extracted from that artifact
+- **AND** the product does not claim that the sidecar replaces canonical session content
+
+#### Scenario: Opaque local source does not become canonical content
+- **WHEN** the only remaining Windsurf source artifact is an opaque local `.pb` file
+- **THEN** the product may preserve metadata such as file presence, size, or timestamps as evidence
+- **AND** it does not claim to reconstruct or normalize transcript content from that file by default

--- a/src/app/api/conversations/[source]/[id]/diagnostic/route.ts
+++ b/src/app/api/conversations/[source]/[id]/diagnostic/route.ts
@@ -9,7 +9,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 function isSource(value: string): value is Source {
-  return value === "antigravity" || value === "windsurf" || value === "codex";
+  return value === "antigravity" || value === "windsurf" || value === "codex" || value === "cursor";
 }
 
 function safeFilename(value: string): string {

--- a/src/app/api/conversations/[source]/[id]/route.ts
+++ b/src/app/api/conversations/[source]/[id]/route.ts
@@ -5,6 +5,7 @@ import { readConfig } from "@/lib/server/config";
 import { getAntigravityConversation } from "@/lib/server/antigravity";
 import { getWindsurfChat, getWindsurfTrajectory } from "@/lib/server/windsurf";
 import { getCodexConversation, validateRootId } from "@/lib/server/codex";
+import { getCursorConversation } from "@/lib/server/cursor";
 import { getTrajectoryMetaMapCached } from "@/lib/server/metaCache";
 import { indexSession, isSessionIndexed } from "@/lib/server/searchIndex";
 
@@ -12,7 +13,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 function isSource(value: string): value is Source {
-  return value === "antigravity" || value === "windsurf" || value === "codex";
+  return value === "antigravity" || value === "windsurf" || value === "codex" || value === "cursor";
 }
 
 /** Extract cwd from the first event that has one. */
@@ -58,6 +59,35 @@ export async function GET(req: Request, ctx: { params: { source: string; id: str
         })().catch((err) => {
           // Catch any unexpected errors from the async IIFE
           console.error(`[search] Unexpected error in antigravity session indexing for ${id}:`, err);
+        });
+      });
+      return NextResponse.json(out);
+    }
+
+    if (source === "cursor") {
+      const { config } = await readConfig();
+      const cursor = await getCursorConversation(id, config);
+      const out: ConversationContent = {
+        kind: "trajectory",
+        source: "cursor",
+        events: cursor.events,
+        summary: cursor.summary,
+      };
+      const eventsSnap = cursor.events;
+      setImmediate(() => {
+        (async () => {
+          try {
+            const { config: cfg } = await readConfig();
+            const metaMap = await getTrajectoryMetaMapCached({ source: "cursor", config: cfg });
+            const meta = metaMap[id] ?? {};
+            const title = meta.title ?? id;
+            const cwd = meta.cwd ?? eventsSnap.find((event) => event.cwd)?.cwd ?? cursor.workspacePath ?? "";
+            await indexSession(id, "cursor", title, cwd, eventsSnap, { rootId: rootId ?? "" });
+          } catch (err) {
+            console.warn(`[search] Failed to index cursor session ${id}:`, err instanceof Error ? err.message : err);
+          }
+        })().catch((err) => {
+          console.error(`[search] Unexpected error in cursor session indexing for ${id}:`, err);
         });
       });
       return NextResponse.json(out);

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,8 +1,13 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
 import { NextResponse } from "next/server";
 
 import type { ConversationListItem, ConversationMeta, Source } from "@/lib/types";
+import { expandHome } from "@/lib/server/paths";
 import { readConfig } from "@/lib/server/config";
 import { detectDuplicates, listConversationFiles } from "@/lib/server/conversations";
+import { inferWindsurfRecoverability } from "@/lib/parse/windsurfRecoverability";
 import { getTrajectoryMetaMapCached } from "@/lib/server/metaCache";
 
 export const runtime = "nodejs";
@@ -86,10 +91,28 @@ export async function GET(req: Request) {
     metaMap = {};
   }
 
-  const withMeta: ConversationListItem[] = items.map((it) => {
+  const withMeta: ConversationListItem[] = await Promise.all(items.map(async (it) => {
     const meta = metaMap[it.id] ?? {};
     const dupRoots = duplicates[it.id];
     const duplicateRootIds = dupRoots ? dupRoots.filter((rid) => rid !== it.rootId) : undefined;
+    const normalizedDir = it.path.replace(/\\/g, "/").replace(/\/[^/]+$/, "");
+    const isLegacyWindsurfRoot = sourceParam === "windsurf" && /\/\.codeium\/cascade$/i.test(normalizedDir);
+    const brainDir = expandHome(`~/.codeium/brain/${it.id}`);
+    const hasRecoveryEvidence = sourceParam === "windsurf"
+      ? Boolean(await fs.stat(path.join(brainDir, "plan.md")).catch(() => null) || await fs.stat(path.join(brainDir, "plan_metadata.pbtxt")).catch(() => null))
+      : false;
+    const recoverability = sourceParam === "windsurf"
+      ? inferWindsurfRecoverability({
+          trajectoryReadable: typeof meta.timestampMs === "number",
+          trajectoryMissing: isLegacyWindsurfRoot && typeof meta.timestampMs !== "number",
+          hasSidecarEvidence: hasRecoveryEvidence,
+        })
+      : undefined;
+    const recoverabilityNote = recoverability === "unavailable"
+      ? "Local Windsurf session file found, but the running LS may no longer have this trajectory."
+      : recoverability === "partial"
+        ? "Legacy Windsurf session has bounded brain-sidecar evidence even though the running LS may no longer read it."
+        : undefined;
     
     // For Windsurf sessions, use trajectory timestamp instead of file modification time
     // This ensures sessions are ordered by actual session date, not file modification date
@@ -101,9 +124,12 @@ export async function GET(req: Request) {
       ...it,
       ...meta,
       mtimeMs: effectiveMtimeMs,
+      ...(recoverability ? { recoverability } : {}),
+      ...(hasRecoveryEvidence ? { hasRecoveryEvidence } : {}),
+      ...(recoverabilityNote ? { recoverabilityNote } : {}),
       ...(duplicateRootIds && duplicateRootIds.length > 0 ? { duplicateRootIds } : {})
     };
-  });
+  }));
 
   // Re-sort by the effective mtimeMs to ensure proper ordering
   withMeta.sort((a, b) => b.mtimeMs - a.mtimeMs);

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import type { ConversationListItem, Source } from "@/lib/types";
+import type { ConversationListItem, ConversationMeta, Source } from "@/lib/types";
 import { readConfig } from "@/lib/server/config";
 import { detectDuplicates, listConversationFiles } from "@/lib/server/conversations";
 import { getTrajectoryMetaMapCached } from "@/lib/server/metaCache";
@@ -20,14 +20,14 @@ const duplicatesCache = new Map<
 const MAX_DUPLICATES_CACHE_ENTRIES = 100;
 
 function isSource(value: string | null): value is Source {
-  return value === "antigravity" || value === "windsurf" || value === "codex";
+  return value === "antigravity" || value === "windsurf" || value === "codex" || value === "cursor";
 }
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const sourceParam = url.searchParams.get("source");
   if (!isSource(sourceParam)) {
-    return NextResponse.json({ error: "Missing/invalid source. Use ?source=antigravity|windsurf|codex" }, { status: 400 });
+    return NextResponse.json({ error: "Missing/invalid source. Use ?source=antigravity|windsurf|codex|cursor" }, { status: 400 });
   }
 
   const limit = Math.min(Math.max(Number(url.searchParams.get("limit") ?? "200"), 1), 1000);
@@ -79,7 +79,7 @@ export async function GET(req: Request) {
       ? allItems.slice(offset, offset + limit)
       : await listConversationFiles({ roots: config.roots, source: sourceParam, limit, offset });
 
-  let metaMap: Record<string, { title?: string; cwd?: string }> = {};
+  let metaMap: Record<string, ConversationMeta> = {};
   try {
     metaMap = await getTrajectoryMetaMapCached({ source: sourceParam, config });
   } catch {
@@ -90,12 +90,23 @@ export async function GET(req: Request) {
     const meta = metaMap[it.id] ?? {};
     const dupRoots = duplicates[it.id];
     const duplicateRootIds = dupRoots ? dupRoots.filter((rid) => rid !== it.rootId) : undefined;
+    
+    // For Windsurf sessions, use trajectory timestamp instead of file modification time
+    // This ensures sessions are ordered by actual session date, not file modification date
+    const effectiveMtimeMs = (sourceParam === "windsurf" && typeof meta.timestampMs === "number") 
+      ? meta.timestampMs 
+      : it.mtimeMs;
+    
     return {
       ...it,
       ...meta,
+      mtimeMs: effectiveMtimeMs,
       ...(duplicateRootIds && duplicateRootIds.length > 0 ? { duplicateRootIds } : {})
     };
   });
+
+  // Re-sort by the effective mtimeMs to ensure proper ordering
+  withMeta.sort((a, b) => b.mtimeMs - a.mtimeMs);
 
   return NextResponse.json({ items: withMeta, limit, offset });
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 function isSource(value: string | null): value is Source {
-  return value === "antigravity" || value === "windsurf" || value === "codex";
+  return value === "antigravity" || value === "windsurf" || value === "codex" || value === "cursor";
 }
 
 export async function GET(req: Request) {

--- a/src/app/api/session-backups/route.ts
+++ b/src/app/api/session-backups/route.ts
@@ -8,6 +8,7 @@ import { toSessionRecord } from "@/lib/sessionRecordMapper";
 import { readConfig } from "@/lib/server/config";
 import { getAntigravityConversation } from "@/lib/server/antigravity";
 import { getCodexConversation, getCodexRawContent, validateRootId } from "@/lib/server/codex";
+import { getCursorConversation } from "@/lib/server/cursor";
 import { getTrajectoryMetaMapCached } from "@/lib/server/metaCache";
 import { writeSessionBackupPackage } from "@/lib/server/sessionBackupService";
 import { getWindsurfTrajectory } from "@/lib/server/windsurf";
@@ -24,7 +25,7 @@ type CreateSessionBackupBody = {
 };
 
 function isSource(value: unknown): value is Source {
-  return value === "antigravity" || value === "windsurf" || value === "codex";
+  return value === "antigravity" || value === "windsurf" || value === "codex" || value === "cursor";
 }
 
 async function loadWindsurfTrajectoryContent(config: Awaited<ReturnType<typeof readConfig>>["config"], sessionId: string): Promise<TrajectoryContent> {
@@ -142,6 +143,26 @@ export async function POST(req: Request) {
         summary: conversation.summary
       };
       sourceLocator = raw.filePath;
+    } else if (body.source === "cursor") {
+      if (body.includeSourceCopy) {
+        return NextResponse.json(
+          {
+            error: `includeSourceCopy is not implemented for source: ${body.source}`,
+            code: "SOURCE_COPY_UNSUPPORTED",
+            title: "Source copy unavailable",
+            hint: "Cursor currently supports metadata-backed preservation only in v1."
+          },
+          { status: 501 }
+        );
+      }
+      const cursor = await getCursorConversation(body.sessionId, config);
+      content = {
+        kind: "trajectory",
+        source: "cursor",
+        events: cursor.events,
+        summary: cursor.summary
+      };
+      sourceLocator = cursor.locator;
     } else {
       if (body.includeSourceCopy) {
         return NextResponse.json(
@@ -162,7 +183,7 @@ export async function POST(req: Request) {
       sessionId: body.sessionId,
       source: body.source,
       sourceRef: {
-        kind: body.source === "codex" ? "file" : "runtime_rpc",
+        kind: body.source === "codex" ? "file" : body.source === "cursor" ? "sqlite" : "runtime_rpc",
         locator: sourceLocator
       },
       content,

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -5,6 +5,7 @@ import { readConfig } from "@/lib/server/config";
 import { getAntigravityStatus } from "@/lib/server/antigravity";
 import { getWindsurfStatus } from "@/lib/server/windsurf";
 import { getCodexStatus } from "@/lib/server/codex";
+import { getCursorStatus } from "@/lib/server/cursor";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -36,6 +37,14 @@ export async function GET() {
     codex = { sessionsFound: false, error: message };
   }
 
-  const status: SourcesStatus = { antigravity, windsurf, codex };
+  let cursor: SourcesStatus["cursor"];
+  try {
+    cursor = await getCursorStatus(config);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    cursor = { sessionsFound: false, error: message, recommendedAction: message };
+  }
+
+  const status: SourcesStatus = { antigravity, windsurf, codex, cursor };
   return NextResponse.json(status);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
 import ProjectShellClient from "@/components/ProjectShellClient";
+import { getProjectEvidenceProviderResult } from "@/lib/server/projectEvidenceProvider";
+
+export const dynamic = "force-dynamic";
 
 export default function Page() {
-  return <ProjectShellClient />;
+  const projectEvidence = getProjectEvidenceProviderResult();
+  return <ProjectShellClient projectEvidence={projectEvidence} />;
 }

--- a/src/components/AnalysisFoundation.tsx
+++ b/src/components/AnalysisFoundation.tsx
@@ -34,10 +34,12 @@ import {
   type AnalysisSeverity,
 } from "@/lib/analysisFindings";
 import type { AssetsHandoff } from "@/lib/contextAssets";
+import { createProjectEvidenceDiagnosticsFindings, type ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
 import type { Source } from "@/lib/types";
 
 export type AnalysisFoundationProps = {
   handoff: AnalysisHandoff | null;
+  projectEvidence?: ProjectEvidenceProviderResult | null;
   onOpenAssets(handoff: AssetsHandoff): void;
   onOpenBackup(context: { findingId: string; title: string; preservationWarning?: string; routeLabel?: string; backupWorkflowType?: AnalysisRoute["backupWorkflowType"] }): void;
   onOpenOverview(): void;
@@ -46,6 +48,37 @@ export type AnalysisFoundationProps = {
 };
 
 const LOADING_DELAY_MS = 120;
+
+function resolveAnalysisInventory(projectEvidence: ProjectEvidenceProviderResult | null | undefined): {
+  findings: AnalysisFinding[];
+  label: string;
+  body: string;
+} {
+  if (!projectEvidence) {
+    return {
+      findings: createAnalysisFindingSeeds(),
+      label: "seed fallback",
+      body: "Findings are local seed interpretations for routing validation, not complete automated analysis.",
+    };
+  }
+
+  if (projectEvidence.status === "unavailable") {
+    return {
+      findings: createAnalysisFindingSeeds(),
+      label: "provider unavailable fallback",
+      body: "Repo-local provider diagnostics are unavailable, so these findings are labeled seed fallback interpretations.",
+    };
+  }
+
+  const findings = createProjectEvidenceDiagnosticsFindings(projectEvidence);
+  return {
+    findings,
+    label: findings.length > 0 ? "provider diagnostics" : "no current provider findings",
+    body: findings.length > 0
+      ? "Findings are bounded provider diagnostics from explicit repo-local evidence. They do not imply deep semantic repository analysis."
+      : "The repo-local project evidence provider reported no warning diagnostics, so Analysis will not fabricate seed findings for the current project.",
+  };
+}
 
 export function resolveAnalysisNavigationHandoff(handoff: AnalysisHandoff | null): AnalysisHandoff | null {
   return handoff?.sessionId && handoff.source ? handoff : null;
@@ -194,13 +227,15 @@ function RouteButton(props: {
 
 export function AnalysisFoundation({
   handoff,
+  projectEvidence,
   onOpenAssets,
   onOpenBackup,
   onOpenOverview,
   onOpenSession,
   loadingDelayMs = LOADING_DELAY_MS,
 }: AnalysisFoundationProps) {
-  const findings = useMemo(() => createAnalysisFindingSeeds(), []);
+  const inventory = useMemo(() => resolveAnalysisInventory(projectEvidence), [projectEvidence]);
+  const findings = inventory.findings;
   const initialFilters = buildFiltersFromAnalysisHandoff(handoff, createDefaultAnalysisFilters());
   const initialFilteredFindings = applyAnalysisFilters(findings, initialFilters);
   const initialSelectedFinding = resolveAnalysisFindingSelection(initialFilteredFindings, handoff);
@@ -301,6 +336,9 @@ export function AnalysisFoundation({
             <p className="max-w-3xl text-sm leading-6 text-muted">
               Interpret local context issues, preserve evidence boundaries, and route each finding to the owning surface. This foundation does not claim automatic fixes, asset editing, session mutation, or backup execution.
             </p>
+            <div className="rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-2 text-xs leading-5 text-muted">
+              <span className="font-medium text-foreground">{inventory.label}:</span> {inventory.body}
+            </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <FilterSelect
@@ -373,7 +411,7 @@ export function AnalysisFoundation({
             <div className="mb-3 flex items-center justify-between gap-3">
               <div>
                 <div className="text-xs uppercase tracking-[0.18em] text-muted">Findings Inventory</div>
-                <div className="text-sm text-muted">Findings are local seed interpretations for routing validation, not complete automated analysis.</div>
+                <div className="text-sm text-muted">{inventory.body}</div>
               </div>
               {selectedFinding ? <Badge variant="default">selected finding active</Badge> : null}
             </div>

--- a/src/components/AssetsFoundation.tsx
+++ b/src/components/AssetsFoundation.tsx
@@ -32,10 +32,12 @@ import {
   type ContextAssetStatus,
   type ContextAssetSubtype,
 } from "@/lib/contextAssets";
+import type { ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
 import type { Source } from "@/lib/types";
 
 export type AssetsFoundationProps = {
   handoff: AssetsHandoff | null;
+  projectEvidence?: ProjectEvidenceProviderResult | null;
   onOpenSession(selection: { sessionId: string; source: Source; rootId?: string }): void;
   onOpenAnalysis(context: { issueLabel: string; assetId?: string; subtype?: ContextAssetSubtype; status?: ContextAssetStatus }): void;
   onOpenBackup(context: { assetId?: string; subtype?: ContextAssetSubtype; workflowType?: "migration-preview" | "project-bundle" }): void;
@@ -44,6 +46,57 @@ export type AssetsFoundationProps = {
 };
 
 const LOADING_DELAY_MS = 120;
+
+function resolveAssetsInventory(projectEvidence: ProjectEvidenceProviderResult | null | undefined): {
+  assets: ContextAsset[];
+  cue: {
+    label: string;
+    body: string;
+  };
+  diagnostics: ProjectEvidenceProviderResult["diagnostics"];
+} {
+  if (!projectEvidence) {
+    return {
+      assets: createContextAssetSeeds(),
+      cue: {
+        label: "Foundation data cue",
+        body: "This Assets inventory is backed by local seed/provider-shaped data, not a complete live project scan. Unknown, unavailable, and unsupported evidence remains visible.",
+      },
+      diagnostics: [],
+    };
+  }
+
+  if (projectEvidence.status === "unavailable") {
+    return {
+      assets: createContextAssetSeeds(),
+      cue: {
+        label: "Provider unavailable fallback",
+        body: "Repo-local project evidence is unavailable, so this inventory is showing labeled foundation fallback data rather than current project assets.",
+      },
+      diagnostics: projectEvidence.diagnostics,
+    };
+  }
+
+  if (projectEvidence.status === "empty") {
+    return {
+      assets: [],
+      cue: {
+        label: "Repo-local evidence zero state",
+        body: "The project evidence provider completed and found no allowlisted repo-local agent evidence. Seed rows are intentionally not shown as current project assets.",
+      },
+      diagnostics: projectEvidence.diagnostics,
+    };
+  }
+
+  return {
+    assets: projectEvidence.assets,
+    cue: {
+      label: projectEvidence.status === "partial" ? "Repo-local evidence partial" : "Repo-local evidence",
+      body: "This Assets inventory is derived from explicit repo-local agent-facing files on the provider allowlist. It is not a broad source scan or session transcript extraction.",
+    },
+    diagnostics: projectEvidence.diagnostics,
+  };
+}
 
 function CueStrip(props: {
   handoff: AssetsHandoff | null;
@@ -111,8 +164,9 @@ function renderSeverityBadge(severity: ContextAssetGovernanceSeverity) {
   return <Badge variant="default">informational</Badge>;
 }
 
-export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpenBackup, onOpenOverview, loadingDelayMs = LOADING_DELAY_MS }: AssetsFoundationProps) {
-  const assets = useMemo(() => createContextAssetSeeds(), []);
+export function AssetsFoundation({ handoff, projectEvidence, onOpenSession, onOpenAnalysis, onOpenBackup, onOpenOverview, loadingDelayMs = LOADING_DELAY_MS }: AssetsFoundationProps) {
+  const inventory = useMemo(() => resolveAssetsInventory(projectEvidence), [projectEvidence]);
+  const assets = inventory.assets;
   const initialFilters = buildFiltersFromAssetsHandoff(handoff, createDefaultContextAssetFilters());
   const initialFilteredAssets = applyContextAssetFilters(assets, initialFilters);
   const initialSelectedAsset = resolveContextAssetSelection(initialFilteredAssets, handoff);
@@ -217,7 +271,7 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
               Inspect rules, memory, skills, and commands by subtype, scope, source, status, provenance, and in-effect relevance without turning this page into a generic editor or migration workflow.
             </p>
             <div className="rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-2 text-xs leading-5 text-muted">
-              Foundation data cue: this Assets inventory is backed by local seed/provider-shaped data, not a complete live project scan. Unknown, unavailable, and unsupported evidence remains visible.
+              <span className="font-medium text-foreground">{inventory.cue.label}:</span> {inventory.cue.body}
             </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -297,6 +351,18 @@ export function AssetsFoundation({ handoff, onOpenSession, onOpenAnalysis, onOpe
             <p className="mt-3 text-xs leading-5 text-muted">
               No known issue count means no stale, conflicted, orphaned, or unknown asset in the filtered seed/provider inventory; it does not prove every local runtime has been scanned.
             </p>
+            {inventory.diagnostics.length > 0 ? (
+              <div className="mt-4 rounded-xl border border-border/60 bg-background/10 px-3 py-3 text-xs leading-5 text-muted">
+                <div className="mb-2 font-medium text-foreground">Provider diagnostics</div>
+                <div className="flex flex-wrap gap-2">
+                  {inventory.diagnostics.map((item) => (
+                    <Badge key={item.id} variant={item.severity === "warning" ? "warn" : "default"}>
+                      {item.kind}: {item.path}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null}
             {surfaceState === "issue" ? (
               <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-3 text-sm text-muted">
                 <div>

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -1360,6 +1360,7 @@ export function BackupMigrationFoundation({
                     <option value="antigravity">Antigravity</option>
                     <option value="windsurf">Windsurf</option>
                     <option value="codex">Codex</option>
+                    <option value="cursor">Cursor</option>
                   </select>
                 </label>
                 <label className="grid gap-1 text-sm">
@@ -1400,6 +1401,7 @@ export function BackupMigrationFoundation({
                     <option value="antigravity">Antigravity</option>
                     <option value="windsurf">Windsurf</option>
                     <option value="codex">Codex</option>
+                    <option value="cursor">Cursor</option>
                     <option value="imported">Imported</option>
                     <option value="generated">Generated</option>
                   </select>
@@ -1464,6 +1466,7 @@ export function BackupMigrationFoundation({
                       <option value="antigravity">Antigravity</option>
                       <option value="windsurf">Windsurf</option>
                       <option value="codex">Codex</option>
+                      <option value="cursor">Cursor</option>
                     </select>
                   </label>
                   <label className="grid gap-1 text-sm">
@@ -1568,6 +1571,7 @@ export function BackupMigrationFoundation({
                         <option value="antigravity">Antigravity</option>
                         <option value="windsurf">Windsurf</option>
                         <option value="codex">Codex</option>
+                        <option value="cursor">Cursor</option>
                       </select>
                     </label>
                     <label className="grid gap-1 text-sm">

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -82,14 +82,55 @@ export type BackupMigrationFoundationProps = {
 
 // ── Validation seed helpers ─────────────────────────────────────────────────
 
-function buildSessionBackupValidation(sessionId: string | null): BackupValidationItem[] {
-  if (!sessionId) {
+function buildSessionBackupValidation(input: {
+  sessionId: string | null;
+  source: Source | null;
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  hasRecoveryEvidence?: boolean;
+  recoverabilityNote?: string;
+}): BackupValidationItem[] {
+  if (!input.sessionId) {
     return [{ id: "v-no-session", label: "No session selected", severity: "block", detail: "Select a session before proceeding." }];
   }
+
+  if (input.source === "windsurf" && input.recoverability === "unavailable") {
+    return [
+      {
+        id: "v-windsurf-unavailable",
+        label: "Canonical Windsurf content unavailable",
+        severity: "block",
+        detail: input.recoverabilityNote ?? "The running Windsurf LS no longer has this trajectory, so canonical session backup cannot be generated from readable content.",
+      },
+      {
+        id: "v-windsurf-local-evidence",
+        label: "Local source evidence",
+        severity: "warning",
+        detail: input.hasRecoveryEvidence
+          ? "Bounded recovery evidence exists and can be inspected, but it does not replace canonical readable session content."
+          : "A local Windsurf session file may still exist, but local discovery alone does not make the session canonically backup-ready.",
+      },
+    ];
+  }
+
+  const recoverabilityWarning =
+    input.source === "windsurf" && input.recoverability === "partial"
+      ? [
+          {
+            id: "v-windsurf-partial",
+            label: "Partial recovery evidence",
+            severity: "warning" as const,
+            detail:
+              input.recoverabilityNote ??
+              "Bounded recovery evidence exists for this Windsurf session, but it does not imply vendor-runtime restoration or transcript reconstruction.",
+          },
+        ]
+      : [];
+
   return [
     { id: "v-schema", label: "Schema version", severity: "ok", detail: "session-record/v1 is supported." },
     { id: "v-integrity", label: "Session integrity", severity: "ok", detail: "Session data passes integrity checks." },
     { id: "v-provenance", label: "Provenance", severity: "ok", detail: "Source reference is present and traceable." },
+    ...recoverabilityWarning,
   ];
 }
 
@@ -595,6 +636,9 @@ export function BackupMigrationFoundation({
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(handoff?.sessionId ?? null);
   const [selectedSource, setSelectedSource] = useState<Source | null>((handoff?.source as Source) ?? null);
   const [selectedRootId, setSelectedRootId] = useState<string | null>(handoff?.rootId ?? null);
+  const [selectedRecoverability, setSelectedRecoverability] = useState<BackupMigrationHandoff["recoverability"]>(handoff?.recoverability);
+  const [selectedHasRecoveryEvidence, setSelectedHasRecoveryEvidence] = useState<boolean>(handoff?.hasRecoveryEvidence === true);
+  const [selectedRecoverabilityNote, setSelectedRecoverabilityNote] = useState<string | null>(handoff?.recoverabilityNote ?? null);
   const [includeSourceCopy, setIncludeSourceCopy] = useState(false);
 
   // Bulk session backup state
@@ -668,6 +712,9 @@ export function BackupMigrationFoundation({
     setSelectedSessionId(null);
     setSelectedSource(null);
     setSelectedRootId(null);
+    setSelectedRecoverability(undefined);
+    setSelectedHasRecoveryEvidence(false);
+    setSelectedRecoverabilityNote(null);
     setIncludeSourceCopy(false);
     setBulkSelections([]);
     setBulkDraftSessionId("");
@@ -745,7 +792,13 @@ export function BackupMigrationFoundation({
   const runValidation = useCallback(async () => {
     if (!activeWorkflow) return;
     if (activeWorkflow === "session-backup") {
-      const result = deriveValidationResult(buildSessionBackupValidation(selectedSessionId));
+      const result = deriveValidationResult(buildSessionBackupValidation({
+        sessionId: selectedSessionId,
+        source: selectedSource,
+        recoverability: selectedRecoverability,
+        hasRecoveryEvidence: selectedHasRecoveryEvidence,
+        recoverabilityNote: selectedRecoverabilityNote ?? undefined,
+      }));
       setValidationResult(result);
       setWorkflowState("validation");
       return;
@@ -836,7 +889,11 @@ export function BackupMigrationFoundation({
     previewSourceContext,
     previewTargetContext,
     projectBundleSelection,
+    selectedHasRecoveryEvidence,
+    selectedRecoverability,
+    selectedRecoverabilityNote,
     selectedSessionId,
+    selectedSource,
   ]);
 
   const addBulkSelection = useCallback(() => {
@@ -1666,6 +1723,21 @@ export function BackupMigrationFoundation({
                   <div className="font-medium">Session: {selectedSessionId}</div>
                   <div className="text-xs text-muted">Source: {selectedSource}{selectedRootId ? ` / Root: ${selectedRootId}` : ""}</div>
                 </div>
+                {selectedSource === "windsurf" && selectedRecoverability && selectedRecoverability !== "ls_readable" ? (
+                  <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-3 py-3 text-sm text-amber-900 dark:text-amber-200">
+                    <div className="font-medium">
+                      {selectedRecoverability === "unavailable"
+                        ? "Canonical Windsurf content is unavailable"
+                        : "This Windsurf session carries bounded recovery evidence"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 opacity-90">
+                      {selectedRecoverabilityNote ??
+                        (selectedRecoverability === "unavailable"
+                          ? "The running Windsurf LS no longer has this trajectory, so this workflow should be used for evidence review rather than canonical transcript backup."
+                          : "Recovery evidence can be reviewed and preserved, but it does not imply transcript reconstruction or vendor-runtime restoration.")}
+                    </div>
+                  </div>
+                ) : null}
                 <label className="flex items-center gap-2 text-sm">
                   <input
                     type="checkbox"

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -72,6 +72,9 @@ export type HomeClientSessionHandoff = {
   sessionId: string;
   source: Source;
   rootId?: string;
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  hasRecoveryEvidence?: boolean;
+  recoverabilityNote?: string;
 };
 
 export type HomeClientProps = {
@@ -1547,6 +1550,25 @@ export default function HomeClient({
     return items.find((it) => it.id === parsed.id && it.rootId === parsed.rootId) ?? null;
   }, [items, selectedKey]);
 
+  const windsurfRecoverabilityMessage = useMemo(() => {
+    if (!selectedItem || source !== "windsurf") return null;
+    if (selectedItem.recoverability === "unavailable") {
+      return {
+        tone: "danger" as const,
+        title: "Legacy Windsurf session is not readable from the running LS.",
+        message: selectedItem.recoverabilityNote ?? "The local session file was discovered, but the running Windsurf LS no longer has this trajectory.",
+      };
+    }
+    if (selectedItem.recoverability === "partial") {
+      return {
+        tone: "warning" as const,
+        title: "Legacy Windsurf session has bounded recovery evidence.",
+        message: selectedItem.recoverabilityNote ?? "Some recoverability evidence may exist even though the full session is not guaranteed to be readable from the running Windsurf LS.",
+      };
+    }
+    return null;
+  }, [selectedItem, source]);
+
   const sourceCopySupported = useMemo(() => supportsSessionSourceCopy(source), [source]);
 
   const filteredItems = useMemo(() => {
@@ -2745,6 +2767,9 @@ export default function HomeClient({
                         sessionId: selectedId,
                         source,
                         ...(selectedItem?.rootId ? { rootId: selectedItem.rootId } : {}),
+                        ...(selectedItem?.recoverability ? { recoverability: selectedItem.recoverability } : {}),
+                        ...(selectedItem?.hasRecoveryEvidence != null ? { hasRecoveryEvidence: selectedItem.hasRecoveryEvidence } : {}),
+                        ...(selectedItem?.recoverabilityNote ? { recoverabilityNote: selectedItem.recoverabilityNote } : {}),
                       })
                     }
                     title="Route to Backup / Migration with bounded session backup context"
@@ -2773,6 +2798,23 @@ export default function HomeClient({
                     Diagnostic JSON
                   </a>
                 </Button>
+              </div>
+            </div>
+          ) : null}
+
+          {selectedId && source === "windsurf" && windsurfRecoverabilityMessage ? (
+            <div
+              className={cn(
+                "mb-3 rounded-2xl border px-3 py-2 text-sm",
+                windsurfRecoverabilityMessage.tone === "danger"
+                  ? "border-danger/55 bg-danger/10 text-danger"
+                  : "border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-300"
+              )}
+            >
+              <div className="font-medium">{windsurfRecoverabilityMessage.title}</div>
+              <div className="mt-1 leading-6">{windsurfRecoverabilityMessage.message}</div>
+              <div className="mt-1 text-xs opacity-90">
+                Use Diagnostic JSON for detailed evidence, or open Backup / Migration to review bounded preservation context.
               </div>
             </div>
           ) : null}

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -1462,6 +1462,7 @@ export default function HomeClient({
   const [backupFeedback, setBackupFeedback] = useState<SessionBackupFeedback | null>(null);
   const [antigravityView, setAntigravityView] = useState<"transcript" | "trajectory" | "markdown">("markdown");
   const [windsurfView, setWindsurfView] = useState<"chat" | "transcript" | "trajectory">("chat");
+  const [cursorView, setCursorView] = useState<"transcript" | "trajectory">("transcript");
   const [windsurfIncludeCleared, setWindsurfIncludeCleared] = useState(false);
   const [trajectoryFilters, setTrajectoryFilters] = useState<TrajectoryFilters>({
     thought: true,
@@ -1969,6 +1970,7 @@ export default function HomeClient({
       setEventSearch("");
       setAntigravityView("markdown");
       setWindsurfView("chat");
+      setCursorView("transcript");
       setCollapsedExecutionGroups({});
       if (shouldDeferSearchSelectionLoad({ currentSource: source, nextSource: sessionSource, itemCount: items.length })) {
         pendingSearchSelectionRef.current = { sessionId, source: sessionSource, rootId };
@@ -2008,6 +2010,7 @@ export default function HomeClient({
 
     if (content.source === "antigravity" && antigravityView !== "trajectory") setAntigravityView("trajectory");
     if (content.source === "windsurf" && windsurfView !== "trajectory") setWindsurfView("trajectory");
+    if (content.source === "cursor" && cursorView !== "trajectory") setCursorView("trajectory");
 
     const groupId = event.executionId ?? "ungrouped";
     setCollapsedExecutionGroups((prev) => {
@@ -2050,7 +2053,7 @@ export default function HomeClient({
     setInspectorOpen(true);
     setScrollToRowId(rowId);
     setPendingTrajectoryJumpEventId(null);
-  }, [pendingTrajectoryJumpEventId, content, eventsById, trajectoryRows, antigravityView, windsurfView]);
+  }, [pendingTrajectoryJumpEventId, content, eventsById, trajectoryRows, antigravityView, windsurfView, cursorView]);
 
   useEffect(() => {
     setBackupFeedback(null);
@@ -2224,6 +2227,7 @@ export default function HomeClient({
     setEventSearch("");
     setAntigravityView("markdown");
     setWindsurfView("chat");
+    setCursorView("transcript");
     setCollapsedExecutionGroups({});
   }, [source]);
 
@@ -2464,6 +2468,12 @@ export default function HomeClient({
     return <StatusPill label="Codex: not found" tone="bad" title={status.codex.error} />;
   })();
 
+  const cursorPill = (() => {
+    if (!status) return <StatusPill label="Cursor: ..." tone="warn" />;
+    if (status.cursor.sessionsFound) return <StatusPill label={`Cursor: ${status.cursor.sessionCount ?? "?"} sessions`} tone="ok" title={status.cursor.storagePath} />;
+    return <StatusPill label="Cursor: not found" tone="bad" title={status.cursor.error ?? status.cursor.recommendedAction} />;
+  })();
+
   const toggleExecutionGroup = useCallback((groupId: string) => {
     setCollapsedExecutionGroups((prev) => ({ ...prev, [groupId]: !prev[groupId] }));
   }, []);
@@ -2506,6 +2516,7 @@ export default function HomeClient({
           {antigravityPill}
           {windsurfPill}
           {codexPill}
+          {cursorPill}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {chrome === "full" ? <GlobalSearch onSelect={handleGlobalSearchSelect} /> : null}
@@ -2542,6 +2553,13 @@ export default function HomeClient({
             onClick={() => setSource("codex")}
           >
             Codex
+          </Button>
+          <Button
+            variant={source === "cursor" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setSource("cursor")}
+          >
+            Cursor
           </Button>
           <div className="flex-1" />
           <div className="w-full sm:w-[360px] sm:max-w-[360px]">
@@ -2585,6 +2603,7 @@ export default function HomeClient({
                     setEventSearch("");
                     setAntigravityView("markdown");
                     setWindsurfView("chat");
+                    setCursorView("transcript");
                     setCollapsedExecutionGroups({});
                     loadConversation(source, it.id, 0, source === "windsurf" ? "chat" : undefined, {
                       rootId: it.rootId
@@ -2784,6 +2803,38 @@ export default function HomeClient({
           ) : null}
 
           {!selectedId ? <div className="text-sm text-muted">Select a conversation on the left.</div> : null}
+
+          {selectedId && source === "cursor" ? (
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant={cursorView === "transcript" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => {
+                    setInspectorOpen(false);
+                    setSelectedRowId(null);
+                    setScrollToRowId(null);
+                    setCursorView("transcript");
+                  }}
+                >
+                  Transcript
+                </Button>
+                <Button
+                  variant={cursorView === "trajectory" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => {
+                    setInspectorOpen(false);
+                    setSelectedRowId(null);
+                    setScrollToRowId(null);
+                    setCursorView("trajectory");
+                  }}
+                >
+                  Trajectory
+                </Button>
+              </div>
+              <div className="text-xs text-muted">Cursor session (read from local SQLite)</div>
+            </div>
+          ) : null}
 
           {selectedId && source === "windsurf" ? (
             <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
@@ -3066,6 +3117,72 @@ export default function HomeClient({
                   Load more
                 </Button>
               </div>
+            </div>
+          ) : null}
+
+          {selectedId && content?.kind === "trajectory" && content.source === "cursor" ? (
+            <div>
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge>turns {content.summary.userCount + content.summary.assistantCount}</Badge>
+                  <Badge>user {content.summary.userCount}</Badge>
+                  <Badge>assistant {content.summary.assistantCount}</Badge>
+                  {content.summary.errorCount > 0 ? (
+                    <Button variant="destructive" size="sm" onClick={() => openErrorCenter()}>
+                      errors {content.summary.errorCount}
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+              {cursorView === "trajectory" ? (
+                <div>
+                  <TrajectoryFilterControls
+                    filters={trajectoryFilters}
+                    onFiltersChange={setTrajectoryFilters}
+                    groupCount={executionGroups.length}
+                    eventSearch={eventSearch}
+                    onEventSearchChange={setEventSearch}
+                    searchMatchCount={eventSearchMatchEvents.length}
+                    activeMatchIndex={activeSearchMatchIndex}
+                    onNavigateMatch={navigateSearchMatchByOffset}
+                  />
+                  {withInspector(
+                    <VirtualizedTrajectoryRows
+                      rows={trajectoryRows}
+                      onToggleGroup={toggleExecutionGroup}
+                      onSelectRow={onSelectRow}
+                      selectedRowId={selectedRowId}
+                      highlightedRowId={highlightedRowId}
+                      scrollToRowId={scrollToRowId}
+                      onScrolledToRowId={() => setScrollToRowId(null)}
+                      autoOpenDetailsRowId={autoOpenDetailsRowId}
+                      autoOpenDetailsToken={autoOpenDetailsToken}
+                      onAutoOpenedDetails={(rowId, token) => {
+                        if (rowId === autoOpenDetailsRowId && token === autoOpenDetailsToken) setAutoOpenDetailsRowId(null);
+                      }}
+                      searchQuery={eventSearch}
+                    />
+                  )}
+                </div>
+              ) : (
+                <div>
+                  <div className="mb-2 text-xs text-muted">
+                    Transcript shows user/assistant turns. Switch to Trajectory for full event detail.
+                  </div>
+                  {withInspector(
+                    <VirtualizedTrajectoryRows
+                      rows={transcriptRows}
+                      onToggleGroup={toggleExecutionGroup}
+                      onSelectRow={onSelectRow}
+                      selectedRowId={selectedRowId}
+                      highlightedRowId={highlightedRowId}
+                      scrollToRowId={scrollToRowId}
+                      onScrolledToRowId={() => setScrollToRowId(null)}
+                      onJumpToTrajectoryEventId={requestJumpToTrajectoryEventId}
+                    />
+                  )}
+                </div>
+              )}
             </div>
           ) : null}
 

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -327,6 +327,9 @@ export function buildBackupHandoffFromSessions(context: {
   sessionId?: string;
   source?: Source;
   rootId?: string;
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  hasRecoveryEvidence?: boolean;
+  recoverabilityNote?: string;
   sessions?: BackupSessionSelection[];
 }): BackupMigrationHandoff {
   if ((context.sessions?.length ?? 0) > 0) {
@@ -343,12 +346,18 @@ export function buildBackupHandoffFromSessions(context: {
   return {
     origin: "sessions",
     subtitle: `Back up session ${context.sessionId} from Sessions.`,
-    continueLabel: "Use the session backup workflow to preserve this session record.",
+    continueLabel:
+      context.recoverability && context.recoverability !== "ls_readable"
+        ? "Review recoverability evidence before attempting preservation for this Windsurf session."
+        : "Use the session backup workflow to preserve this session record.",
     returnLabel: "Return to the originating session for evidence review.",
     workflowType: "session-backup",
     sessionId: context.sessionId,
     source: context.source,
     rootId: context.rootId,
+    ...(context.recoverability ? { recoverability: context.recoverability } : {}),
+    ...(context.hasRecoveryEvidence != null ? { hasRecoveryEvidence: context.hasRecoveryEvidence } : {}),
+    ...(context.recoverabilityNote ? { recoverabilityNote: context.recoverabilityNote } : {}),
   };
 }
 

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import type { AnalysisFindingStatus, AnalysisHandoff, AnalysisIssueClass, AnalysisObjectType, AnalysisSeverity } from "@/lib/analysisFindings";
 import type { AssetsHandoff, ContextAssetScope, ContextAssetStatus, ContextAssetSubtype } from "@/lib/contextAssets";
+import { createProjectEvidenceDiagnosticsFindings, type ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
 import {
   deriveProjectOverviewSummary,
   type ProjectOverviewAssetSummary,
@@ -420,7 +421,8 @@ function clearSessionViewerUrlState(): void {
 function formatSourceLabel(source: Source): string {
   if (source === "antigravity") return "Antigravity";
   if (source === "windsurf") return "Windsurf";
-  return "Codex";
+  if (source === "codex") return "Codex";
+  return "Cursor";
 }
 
 function formatCompactLabel(value: string): string {
@@ -757,7 +759,37 @@ function PlaceholderSurface(props: {
   );
 }
 
-export default function ProjectShellClient() {
+export type ProjectShellClientProps = {
+  projectEvidence?: ProjectEvidenceProviderResult | null;
+};
+
+export function deriveProjectEvidenceOverviewSummary(projectEvidence: ProjectEvidenceProviderResult | null | undefined): ProjectOverviewSummary | undefined {
+  if (!projectEvidence) return undefined;
+
+  if (projectEvidence.status === "unavailable") {
+    return deriveProjectOverviewSummary({
+      assets: null,
+      findings: null,
+      sessions: [],
+      projectTitle: "Project Overview",
+      scopeLabel: "Repo-local provider unavailable",
+    });
+  }
+
+  return deriveProjectOverviewSummary({
+    assets: projectEvidence.assets,
+    findings: createProjectEvidenceDiagnosticsFindings(projectEvidence),
+    sessions: [],
+    projectTitle: "Project Overview",
+    scopeLabel: projectEvidence.status === "empty"
+      ? "Repo-local evidence provider found no assets"
+      : projectEvidence.status === "partial"
+        ? "Partial repo-local project evidence"
+        : "Repo-local project evidence",
+  });
+}
+
+export default function ProjectShellClient({ projectEvidence }: ProjectShellClientProps) {
   const [activePage, setActivePage] = useState<ProjectShellPage>("overview");
   const [externalSelection, setExternalSelection] = useState<HomeClientExternalSelection | null>(null);
   const [assetsHandoff, setAssetsHandoff] = useState<AssetsHandoff | null>(null);
@@ -946,6 +978,7 @@ export default function ProjectShellClient() {
   }, [handleNavigate, handleOpenAnalysis, handleOpenAssets, handleOpenBackup]);
 
   const activeNav = NAV_ITEMS.find((item) => item.id === activePage) ?? NAV_ITEMS[0]!;
+  const overviewSummary = deriveProjectEvidenceOverviewSummary(projectEvidence);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -1004,6 +1037,7 @@ export default function ProjectShellClient() {
 
           {activePage === "overview" ? (
             <ProjectOverviewSurface
+              summary={overviewSummary}
               onRoute={handleOpenOverviewRoute}
             />
           ) : null}
@@ -1020,6 +1054,7 @@ export default function ProjectShellClient() {
             <AssetsFoundation
               key={buildAssetsFoundationInstanceKey(assetsHandoff)}
               handoff={assetsHandoff}
+              projectEvidence={projectEvidence}
               onOpenSession={handleOpenSessionFromContext}
               onOpenAnalysis={handleOpenAnalysisFromAssets}
               onOpenBackup={handleOpenBackupFromAssets}
@@ -1030,6 +1065,7 @@ export default function ProjectShellClient() {
             <AnalysisFoundation
               key={buildAnalysisFoundationInstanceKey(analysisHandoff)}
               handoff={analysisHandoff}
+              projectEvidence={projectEvidence}
               onOpenAssets={handleOpenAssets}
               onOpenBackup={handleOpenBackupFromAnalysis}
               onOpenOverview={() => handleNavigate("overview")}

--- a/src/components/SettingsClient.tsx
+++ b/src/components/SettingsClient.tsx
@@ -27,7 +27,7 @@ const healthColors: Record<string, string> = {
 function HealthBadge({ health, source }: { health: RootHealth | undefined; source: Source }) {
   if (!health) return null;
   const color = healthColors[health.status] ?? "";
-  const fileUnit = source === "codex" ? "jsonl" : "pb";
+  const fileUnit = source === "codex" ? "jsonl" : source === "cursor" ? "sessions" : "pb";
   const label =
     health.status === "healthy"
       ? `${health.fileCount} ${fileUnit} · ${health.scanMs}ms`
@@ -103,7 +103,8 @@ export default function SettingsClient() {
     return {
       antigravity: roots.filter((r) => r.source === "antigravity"),
       windsurf: roots.filter((r) => r.source === "windsurf"),
-      codex: roots.filter((r) => r.source === "codex")
+      codex: roots.filter((r) => r.source === "codex"),
+      cursor: roots.filter((r) => r.source === "cursor")
     };
   }, [config]);
 
@@ -240,6 +241,7 @@ export default function SettingsClient() {
             <option value="antigravity">antigravity</option>
             <option value="windsurf">windsurf</option>
             <option value="codex">codex</option>
+            <option value="cursor">cursor</option>
           </Select>
           <Input
             className="font-mono"
@@ -349,6 +351,33 @@ export default function SettingsClient() {
               />
             ))}
             {rootsBySource.codex.length === 0 ? <div className="text-sm text-muted">No roots.</div> : null}
+          </div>
+        </div>
+
+        <div className="min-w-0">
+          <div className="mb-2 text-sm font-semibold">Cursor roots</div>
+          <div className="flex flex-col gap-2">
+            {rootsBySource.cursor.map((r) => (
+              <RootRow
+                key={r.id}
+                root={r}
+                health={rootHealthMap[r.id]}
+                onToggle={() => {
+                  if (!config) return;
+                  const next = cloneConfig(config);
+                  const idx = next.roots.findIndex((x) => x.id === r.id);
+                  if (idx >= 0) next.roots[idx].enabled = !next.roots[idx].enabled;
+                  save(next).catch(() => {});
+                }}
+                onRemove={() => {
+                  if (!config) return;
+                  const next = cloneConfig(config);
+                  next.roots = next.roots.filter((x) => x.id !== r.id);
+                  save(next).catch(() => {});
+                }}
+              />
+            ))}
+            {rootsBySource.cursor.length === 0 ? <div className="text-sm text-muted">No roots.</div> : null}
           </div>
         </div>
       </div>

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -24,7 +24,7 @@ export const BACKUP_WORKFLOW_STATES = [
 ] as const;
 export type BackupWorkflowState = (typeof BACKUP_WORKFLOW_STATES)[number];
 
-export const MIGRATION_PREVIEW_SOURCE_PRODUCTS = ["antigravity", "windsurf", "codex", "imported", "generated"] as const;
+export const MIGRATION_PREVIEW_SOURCE_PRODUCTS = ["antigravity", "windsurf", "codex", "cursor", "imported", "generated"] as const;
 export type MigrationPreviewSourceProduct = (typeof MIGRATION_PREVIEW_SOURCE_PRODUCTS)[number];
 
 export const MIGRATION_PREVIEW_SOURCE_KINDS = ["session-evidence", "context-asset", "analysis-context", "project-overview"] as const;
@@ -523,6 +523,7 @@ export function formatMigrationPreviewSourceProductLabel(product: MigrationPrevi
   if (product === "antigravity") return "Antigravity";
   if (product === "windsurf") return "Windsurf";
   if (product === "codex") return "Codex";
+  if (product === "cursor") return "Cursor";
   return product.charAt(0).toUpperCase() + product.slice(1);
 }
 

--- a/src/lib/backupMigration.ts
+++ b/src/lib/backupMigration.ts
@@ -235,6 +235,9 @@ export type BackupSessionSelection = {
   sessionId: string;
   source?: Source;
   rootId?: string;
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  hasRecoveryEvidence?: boolean;
+  recoverabilityNote?: string;
   includeSourceCopy?: boolean;
   unresolvedReason?: string;
 };
@@ -330,6 +333,9 @@ export type BackupMigrationHandoff = {
   sessions?: BackupSessionSelection[];
   source?: Source;
   rootId?: string;
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  hasRecoveryEvidence?: boolean;
+  recoverabilityNote?: string;
   assetId?: string;
   assetSubtype?: string;
   findingId?: string;

--- a/src/lib/contextAssets.ts
+++ b/src/lib/contextAssets.ts
@@ -2,7 +2,7 @@ import type { Source } from "@/lib/types";
 
 export const CONTEXT_ASSET_SUBTYPES = ["rule", "memory", "skill", "command", "unknown"] as const;
 export const CONTEXT_ASSET_SCOPES = ["global", "user", "project", "unknown"] as const;
-export const CONTEXT_ASSET_SOURCES = ["antigravity", "windsurf", "codex", "imported", "generated", "unknown"] as const;
+export const CONTEXT_ASSET_SOURCES = ["antigravity", "windsurf", "codex", "cursor", "imported", "generated", "unknown"] as const;
 export const CONTEXT_ASSET_STATUSES = ["active", "stale", "conflicted", "orphaned", "archived", "unknown"] as const;
 
 export type ContextAssetSubtype = (typeof CONTEXT_ASSET_SUBTYPES)[number];
@@ -494,6 +494,7 @@ export function formatContextAssetSourceLabel(source: ContextAssetSource): strin
   if (source === "antigravity") return "Antigravity";
   if (source === "windsurf") return "Windsurf";
   if (source === "codex") return "Codex";
+  if (source === "cursor") return "Cursor";
   if (source === "unknown") return "Unknown";
   return source.charAt(0).toUpperCase() + source.slice(1);
 }

--- a/src/lib/parse/commandLine.ts
+++ b/src/lib/parse/commandLine.ts
@@ -1,15 +1,32 @@
 export function extractCsrfTokenFromCommand(commandLine: string): string | null {
-  const patterns = [
+  return extractCsrfTokenMatchFromCommand(commandLine).token;
+}
+
+export type ProcessCsrfTokenMatch = {
+  token: string | null;
+  source: "ps_args" | "ps_env" | "none";
+};
+
+export function extractCsrfTokenMatchFromCommand(commandLine: string): ProcessCsrfTokenMatch {
+  const argPatterns = [
     /--csrf[_-]token\s+([0-9a-fA-F-]{36})/i,
     /--csrf[_-]token=([0-9a-fA-F-]{36})/i,
     /--csrfToken\s+([0-9a-fA-F-]{36})/i,
-    /--csrfToken=([0-9a-fA-F-]{36})/i,
+    /--csrfToken=([0-9a-fA-F-]{36})/i
+  ];
+  for (const re of argPatterns) {
+    const match = commandLine.match(re);
+    if (match?.[1]) return { token: match[1], source: "ps_args" };
+  }
+
+  const envPatterns = [
     /(?:^|\s)CODEIUM_CSRF_TOKEN=([0-9a-fA-F-]{36})(?:\s|$)/i,
     /(?:^|\s)WINDSURF_CSRF_TOKEN=([0-9a-fA-F-]{36})(?:\s|$)/i
   ];
-  for (const re of patterns) {
+  for (const re of envPatterns) {
     const match = commandLine.match(re);
-    if (match?.[1]) return match[1];
+    if (match?.[1]) return { token: match[1], source: "ps_env" };
   }
-  return null;
+
+  return { token: null, source: "none" };
 }

--- a/src/lib/parse/sourceDiagnostics.ts
+++ b/src/lib/parse/sourceDiagnostics.ts
@@ -4,6 +4,7 @@ export function formatSourceDiagnostics(status: SourcesStatus): string {
   const ag = status.antigravity;
   const ws = status.windsurf;
   const cx = status.codex;
+  const cur = status.cursor ?? { sessionsFound: false };
   return [
     "Antigravity",
     `- discovered: ${ag.discovered}`,
@@ -30,6 +31,13 @@ export function formatSourceDiagnostics(status: SourcesStatus): string {
     "Codex",
     `- sessionsFound: ${cx.sessionsFound}`,
     `- sessionsDir: ${cx.sessionsDir ?? "n/a"}`,
-    `- error: ${cx.error ?? "none"}`
+    `- error: ${cx.error ?? "none"}`,
+    "",
+    "Cursor",
+    `- sessionsFound: ${cur.sessionsFound}`,
+    `- storagePath: ${cur.storagePath ?? "n/a"}`,
+    `- sessionCount: ${cur.sessionCount ?? "n/a"}`,
+    `- error: ${cur.error ?? "none"}`,
+    `- recommendedAction: ${cur.recommendedAction ?? "none"}`
   ].join("\n");
 }

--- a/src/lib/parse/tokenSource.ts
+++ b/src/lib/parse/tokenSource.ts
@@ -1,15 +1,17 @@
-export type CsrfTokenSource = "ps_args" | "override" | "discovery_file" | "none";
+export type CsrfTokenSource = "ps_args" | "ps_env" | "override" | "discovery_file" | "none";
 
 export function classifyCsrfTokenSource(params: {
   tokenFromPs?: string | null;
+  tokenFromPsSource?: "ps_args" | "ps_env" | "none";
   overrideToken?: string | null;
   discoveryToken?: string | null;
 }): { token: string | null; source: CsrfTokenSource } {
   const tokenFromPs = params.tokenFromPs?.trim() || "";
+  const tokenFromPsSource = params.tokenFromPsSource ?? "ps_args";
   const overrideToken = params.overrideToken?.trim() || "";
   const discoveryToken = params.discoveryToken?.trim() || "";
 
-  if (tokenFromPs) return { token: tokenFromPs, source: "ps_args" };
+  if (tokenFromPs) return { token: tokenFromPs, source: tokenFromPsSource };
   if (overrideToken) return { token: overrideToken, source: "override" };
   if (discoveryToken) return { token: discoveryToken, source: "discovery_file" };
   return { token: null, source: "none" };

--- a/src/lib/parse/windsurfRecoverability.ts
+++ b/src/lib/parse/windsurfRecoverability.ts
@@ -1,0 +1,13 @@
+export type WindsurfRecoverability = "ls_readable" | "partial" | "unavailable";
+
+export function inferWindsurfRecoverability(params: {
+  trajectoryReadable: boolean;
+  trajectoryMissing: boolean;
+  hasSidecarEvidence: boolean;
+}): WindsurfRecoverability | undefined {
+  const { trajectoryReadable, trajectoryMissing, hasSidecarEvidence } = params;
+
+  if (trajectoryReadable) return "ls_readable";
+  if (!trajectoryMissing) return undefined;
+  return hasSidecarEvidence ? "partial" : "unavailable";
+}

--- a/src/lib/parse/windsurfStatus.ts
+++ b/src/lib/parse/windsurfStatus.ts
@@ -18,7 +18,7 @@ export function getWindsurfRecommendedAction(params: {
   const { attached, tokenRequired } = params;
 
   if (attached) return "Connection healthy.";
-  if (tokenRequired === true) return "Set Windsurf CSRF token override in Settings if process args are unreadable.";
+  if (tokenRequired === true) return "Set Windsurf CSRF token override in Settings if the live LS token cannot be read from the running process.";
   if (tokenRequired === false) return "Keep Windsurf open and start/restart a Cascade session, then refresh.";
   return "CSRF token may be invalid or expired. First try refreshing the override token in Settings; if that fails, restart a Cascade session.";
 }

--- a/src/lib/projectEvidenceProvider.ts
+++ b/src/lib/projectEvidenceProvider.ts
@@ -1,0 +1,402 @@
+import {
+  normalizeContextAsset,
+  type ContextAsset,
+  type ContextAssetInput,
+  type ContextAssetSource,
+  type ContextAssetSubtype,
+} from "@/lib/contextAssets";
+import { normalizeAnalysisFinding, type AnalysisFinding, type AnalysisIssueClass } from "@/lib/analysisFindings";
+
+export type ProjectEvidenceProviderStatus = "available" | "empty" | "partial" | "unavailable";
+export type ProjectEvidenceKind = "rule" | "skill" | "command" | "unknown";
+export type ProjectEvidenceDiagnosticKind = "unreadable" | "skipped" | "unsupported" | "duplicate" | "ambiguous";
+export type ProjectEvidenceSource = "repo-local";
+
+export type ProjectEvidenceItem = {
+  id: string;
+  path: string;
+  title: string;
+  kind: ProjectEvidenceKind;
+  source: ContextAssetSource;
+  evidenceSource: ProjectEvidenceSource;
+  status: "read" | "ambiguous";
+  bodySummary?: string;
+};
+
+export type ProjectEvidenceDiagnostic = {
+  id: string;
+  kind: ProjectEvidenceDiagnosticKind;
+  severity: "info" | "warning";
+  path: string;
+  message: string;
+};
+
+export type ProjectEvidenceProviderResult = {
+  provider: "project-evidence-provider-v1";
+  status: ProjectEvidenceProviderStatus;
+  rootLabel: string;
+  evidenceSource: ProjectEvidenceSource;
+  items: ProjectEvidenceItem[];
+  assets: ContextAsset[];
+  diagnostics: ProjectEvidenceDiagnostic[];
+};
+
+export type ProjectEvidenceFileSystem = {
+  exists(relativePath: string): boolean;
+  isFile(relativePath: string): boolean;
+  isDirectory(relativePath: string): boolean;
+  listDirectory(relativePath: string): string[];
+  readFile(relativePath: string): string;
+};
+
+type EvidencePattern = {
+  base: string;
+  recursive: false;
+  kind: ProjectEvidenceKind;
+  source: ContextAssetSource;
+  fileName?: string;
+  extension?: string;
+};
+
+const FIXED_EVIDENCE = [
+  { path: "AGENTS.md", kind: "rule", source: "codex" },
+  { path: ".github/copilot-instructions.md", kind: "rule", source: "unknown" },
+  { path: ".codex/hooks.json", kind: "command", source: "codex" },
+  { path: ".windsurf/hooks.json", kind: "command", source: "windsurf" },
+  { path: ".cursor/mcp.json", kind: "command", source: "cursor" },
+  { path: ".cursorrules", kind: "rule", source: "cursor" },
+] satisfies Array<{ path: string; kind: ProjectEvidenceKind; source: ContextAssetSource }>;
+
+const DIRECTORY_EVIDENCE = [
+  { base: ".github/instructions", recursive: false, kind: "rule", source: "unknown", extension: ".md" },
+  { base: ".github/prompts", recursive: false, kind: "command", source: "unknown" },
+  { base: ".github/hooks", recursive: false, kind: "command", source: "unknown" },
+  { base: ".github/skills", recursive: false, kind: "skill", source: "unknown", fileName: "SKILL.md" },
+  { base: ".codex/skills", recursive: false, kind: "skill", source: "codex", fileName: "SKILL.md" },
+  { base: ".codex/agents", recursive: false, kind: "command", source: "codex" },
+  { base: ".agents/skills", recursive: false, kind: "skill", source: "unknown", fileName: "SKILL.md" },
+  { base: ".agent/skills", recursive: false, kind: "skill", source: "unknown", fileName: "SKILL.md" },
+  { base: ".windsurf/skills", recursive: false, kind: "skill", source: "windsurf", fileName: "SKILL.md" },
+  { base: ".windsurf/rules", recursive: false, kind: "rule", source: "windsurf", extension: ".md" },
+  { base: ".windsurf/workflows", recursive: false, kind: "command", source: "windsurf" },
+  { base: ".windsurf/hooks", recursive: false, kind: "command", source: "windsurf" },
+  { base: ".cursor/rules", recursive: false, kind: "rule", source: "cursor", extension: ".mdc" },
+] satisfies EvidencePattern[];
+
+const UNSUPPORTED_AGENT_PATH_PREFIXES = [
+  ".github/workflows/",
+  ".codex/hooks/",
+  ".agent/workflows/",
+] as const;
+
+function normalizeRelativePath(input: string): string | null {
+  const normalized = input.replaceAll("\\", "/").replace(/^\/+/, "").replace(/\/+/g, "/");
+  if (!normalized || normalized === "." || normalized.startsWith("../") || normalized.includes("/../")) return null;
+  return normalized;
+}
+
+function joinRelativePath(...parts: string[]): string {
+  return parts
+    .filter(Boolean)
+    .join("/")
+    .replace(/\/+/g, "/");
+}
+
+function stableEvidenceId(relativePath: string): string {
+  return `asset-project-evidence-${relativePath.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+}
+
+function titleFromPath(relativePath: string): string {
+  const fileName = relativePath.split("/").at(-1) ?? relativePath;
+  const leaf = fileName === "SKILL.md"
+    ? relativePath.split("/").at(-2) ?? fileName
+    : fileName.replace(/\.(md|json|toml|ya?ml)$/i, "");
+  return leaf
+    .split(/[-_.\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ") || relativePath;
+}
+
+function summarizeEvidenceContent(content: string): string {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("<!--"));
+  const heading = lines.find((line) => line.startsWith("#"));
+  const summary = (heading ?? lines[0] ?? "Content is present but no text summary is available.")
+    .replace(/^#+\s*/, "")
+    .slice(0, 180);
+  return `${summary}${summary.length === 180 ? "..." : ""}`;
+}
+
+function diagnostic(input: Omit<ProjectEvidenceDiagnostic, "id">): ProjectEvidenceDiagnostic {
+  return {
+    ...input,
+    id: `project-evidence-diagnostic-${input.kind}-${input.path.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`,
+  };
+}
+
+function canReadEvidencePath(fs: ProjectEvidenceFileSystem, relativePath: string): boolean {
+  try {
+    return fs.exists(relativePath) && fs.isFile(relativePath);
+  } catch {
+    return true;
+  }
+}
+
+function collectDirectoryEvidence(fs: ProjectEvidenceFileSystem, pattern: EvidencePattern): string[] {
+  if (!fs.exists(pattern.base) || !fs.isDirectory(pattern.base)) return [];
+  const names = fs.listDirectory(pattern.base).filter((name) => normalizeRelativePath(name) === name).sort();
+  const paths: string[] = [];
+
+  for (const name of names) {
+    const firstLevelPath = joinRelativePath(pattern.base, name);
+    if (pattern.fileName) {
+      if (!fs.isDirectory(firstLevelPath)) continue;
+      const skillPath = joinRelativePath(firstLevelPath, pattern.fileName);
+      if (canReadEvidencePath(fs, skillPath)) paths.push(skillPath);
+      continue;
+    }
+    if (!fs.isFile(firstLevelPath)) continue;
+    if (pattern.extension && !firstLevelPath.endsWith(pattern.extension)) continue;
+    paths.push(firstLevelPath);
+  }
+
+  return paths;
+}
+
+function patternForPath(relativePath: string): { kind: ProjectEvidenceKind; source: ContextAssetSource } | null {
+  const fixed = FIXED_EVIDENCE.find((item) => item.path === relativePath);
+  if (fixed) return { kind: fixed.kind, source: fixed.source };
+
+  for (const pattern of DIRECTORY_EVIDENCE) {
+    if (!relativePath.startsWith(`${pattern.base}/`)) continue;
+    if (pattern.fileName && !relativePath.endsWith(`/${pattern.fileName}`)) continue;
+    if (pattern.extension && !relativePath.endsWith(pattern.extension)) continue;
+    const remainder = relativePath.slice(pattern.base.length + 1);
+    const expectedDepth = pattern.fileName ? 2 : 1;
+    if (remainder.split("/").length !== expectedDepth) continue;
+    return { kind: pattern.kind, source: pattern.source };
+  }
+
+  return null;
+}
+
+function sourceLabel(source: ContextAssetSource): string {
+  if (source === "codex") return "Codex";
+  if (source === "cursor") return "Cursor";
+  if (source === "windsurf") return "Windsurf";
+  if (source === "antigravity") return "Antigravity";
+  return "repo-local";
+}
+
+function subtypeFromKind(kind: ProjectEvidenceKind): ContextAssetSubtype {
+  if (kind === "rule" || kind === "skill" || kind === "command") return kind;
+  return "unknown";
+}
+
+export function normalizeProjectEvidenceItem(input: {
+  path: string;
+  kind?: ProjectEvidenceKind | null;
+  source?: ContextAssetSource | null;
+  content?: string | null;
+}): ProjectEvidenceItem {
+  const path = normalizeRelativePath(input.path) ?? "unknown";
+  const kind = input.kind ?? "unknown";
+  return {
+    id: stableEvidenceId(path),
+    path,
+    title: titleFromPath(path),
+    kind,
+    source: input.source ?? "unknown",
+    evidenceSource: "repo-local",
+    status: kind === "unknown" ? "ambiguous" : "read",
+    ...(input.content ? { bodySummary: summarizeEvidenceContent(input.content) } : {}),
+  };
+}
+
+export function projectEvidenceItemToContextAssetInput(item: ProjectEvidenceItem): ContextAssetInput {
+  const subtype = subtypeFromKind(item.kind);
+  return {
+    id: item.id,
+    title: item.title,
+    subtype,
+    scope: "project",
+    source: item.source,
+    status: item.status === "ambiguous" ? "unknown" : "active",
+    provenance: `${item.path} (${item.evidenceSource})`,
+    bodySummary: item.bodySummary ?? `Recognized ${subtype} evidence at ${item.path}.`,
+    sourceReference: {
+      label: item.path,
+      target: "source",
+      path: item.path,
+    },
+    usage: {
+      state: item.status === "ambiguous" ? "unknown" : "in_effect",
+      summary: item.status === "ambiguous"
+        ? "Provider found the file in an allowlisted location but could not classify the reusable asset subtype."
+        : `Recognized as ${sourceLabel(item.source)} ${subtype} evidence from an allowlisted repo-local path.`,
+      analysisLabel: item.status === "ambiguous" ? "Ambiguous provider evidence" : undefined,
+    },
+  };
+}
+
+export function createProjectEvidenceDiagnosticsFindings(result: ProjectEvidenceProviderResult): AnalysisFinding[] {
+  return result.diagnostics
+    .filter((item) => item.severity === "warning")
+    .map((item) => {
+      const relatedAsset = result.assets.find((asset) => asset.provenance.includes(item.path));
+      const issueClass: AnalysisIssueClass = item.kind === "duplicate" ? "conflict" : item.kind === "unreadable" ? "provenance" : "unknown";
+      return normalizeAnalysisFinding({
+        id: `finding-${item.id}`,
+        title: `Provider ${item.kind} evidence: ${item.path}`,
+        issueClass,
+        severity: item.kind === "duplicate" ? "high" : "medium",
+        status: "open",
+        affectedObjectType: relatedAsset ? "asset" : "project",
+        affectedObjectLabel: relatedAsset?.title ?? item.path,
+        whyItMatters: `${item.message} This is a bounded project evidence provider diagnostic, not a semantic repository analysis.`,
+        evidence: [
+          {
+            label: item.path,
+            target: relatedAsset ? "asset" : "source",
+            assetId: relatedAsset?.id,
+          },
+        ],
+        routes: relatedAsset
+          ? [
+            {
+              target: "assets",
+              label: "Open provider evidence",
+              reason: "Assets owns provider-backed evidence inventory and diagnostic inspection.",
+              assetId: relatedAsset.id,
+              assetSubtype: relatedAsset.subtype,
+              assetStatus: relatedAsset.status,
+            },
+          ]
+          : [
+            {
+              target: "assets",
+              label: "Review provider inventory",
+              reason: "Assets owns provider diagnostic visibility even when no asset could be normalized.",
+            },
+          ],
+      });
+    });
+}
+
+export function discoverProjectEvidence(input: {
+  fileSystem: ProjectEvidenceFileSystem;
+  rootLabel?: string;
+}): ProjectEvidenceProviderResult {
+  const diagnostics: ProjectEvidenceDiagnostic[] = [];
+  const paths = new Set<string>();
+
+  try {
+    for (const item of FIXED_EVIDENCE) {
+      if (input.fileSystem.exists(item.path)) paths.add(item.path);
+    }
+
+    for (const pattern of DIRECTORY_EVIDENCE) {
+      for (const path of collectDirectoryEvidence(input.fileSystem, pattern)) {
+        paths.add(path);
+      }
+    }
+
+    for (const unsupportedPrefix of UNSUPPORTED_AGENT_PATH_PREFIXES) {
+      const base = unsupportedPrefix.replace(/\/$/, "");
+      if (!input.fileSystem.exists(base) || !input.fileSystem.isDirectory(base)) continue;
+      for (const name of input.fileSystem.listDirectory(base)) {
+        const relativePath = normalizeRelativePath(joinRelativePath(base, name));
+        if (!relativePath) continue;
+        diagnostics.push(diagnostic({
+          kind: "unsupported",
+          severity: "info",
+          path: relativePath,
+          message: "Provider skipped this repo-local agent-facing file because it is outside the v1 allowlist.",
+        }));
+      }
+    }
+  } catch (error) {
+    return {
+      provider: "project-evidence-provider-v1",
+      status: "unavailable",
+      rootLabel: input.rootLabel ?? "repository root",
+      evidenceSource: "repo-local",
+      items: [],
+      assets: [],
+      diagnostics: [
+        diagnostic({
+          kind: "unreadable",
+          severity: "warning",
+          path: "repository root",
+          message: error instanceof Error ? error.message : "Project evidence discovery could not run.",
+        }),
+      ],
+    };
+  }
+
+  const items: ProjectEvidenceItem[] = [];
+  const seenIds = new Set<string>();
+
+  for (const relativePath of Array.from(paths).sort()) {
+    const mapping = patternForPath(relativePath);
+    if (!mapping) {
+      diagnostics.push(diagnostic({
+        kind: "ambiguous",
+        severity: "warning",
+        path: relativePath,
+        message: "Provider found evidence in an allowlisted area but could not map it to a reusable asset subtype.",
+      }));
+    }
+
+    try {
+      const content = input.fileSystem.readFile(relativePath);
+      const item = normalizeProjectEvidenceItem({
+        path: relativePath,
+        kind: mapping?.kind ?? "unknown",
+        source: mapping?.source ?? "unknown",
+        content,
+      });
+      if (seenIds.has(item.id)) {
+        diagnostics.push(diagnostic({
+          kind: "duplicate",
+          severity: "warning",
+          path: relativePath,
+          message: "Provider generated a duplicate stable evidence identity for this path.",
+        }));
+        continue;
+      }
+      seenIds.add(item.id);
+      items.push(item);
+    } catch {
+      diagnostics.push(diagnostic({
+        kind: "unreadable",
+        severity: "warning",
+        path: relativePath,
+        message: "Provider could not read this repo-local allowlisted evidence file.",
+      }));
+    }
+  }
+
+  const assets = items.map((item) => normalizeContextAsset(projectEvidenceItemToContextAssetInput(item)));
+  const hasUnreadable = diagnostics.some((item) => item.kind === "unreadable" && item.severity === "warning");
+  const status: ProjectEvidenceProviderStatus = hasUnreadable && assets.length === 0
+    ? "unavailable"
+    : hasUnreadable
+      ? "partial"
+      : assets.length > 0
+        ? "available"
+        : "empty";
+
+  return {
+    provider: "project-evidence-provider-v1",
+    status,
+    rootLabel: input.rootLabel ?? "repository root",
+    evidenceSource: "repo-local",
+    items,
+    assets,
+    diagnostics,
+  };
+}

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -36,6 +36,12 @@ function defaultRoots(): RootConfig[] {
       source: "codex",
       path: "~/.codex/sessions",
       enabled: true
+    },
+    {
+      id: "cursor-default",
+      source: "cursor",
+      path: "~/Library/Application Support/Cursor/User",
+      enabled: true
     }
   ];
 }
@@ -53,7 +59,7 @@ export function defaultConfig(): AppConfig {
 }
 
 function isSource(value: unknown): value is Source {
-  return value === "antigravity" || value === "windsurf" || value === "codex";
+  return value === "antigravity" || value === "windsurf" || value === "codex" || value === "cursor";
 }
 
 function sanitizeRoots(roots: unknown): RootConfig[] {

--- a/src/lib/server/conversations.ts
+++ b/src/lib/server/conversations.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import type { ConversationFile, RootConfig, RootHealth, RootHealthStatus, Source } from "@/lib/types";
 import { expandHome } from "@/lib/server/paths";
 import { collectJsonlFiles } from "@/lib/server/codex";
+import { listCursorConversationFiles } from "@/lib/server/cursor";
 
 /* ---------- helpers ---------- */
 
@@ -240,6 +241,21 @@ async function scanRoot(root: RootConfig, source: Source): Promise<ConversationF
     return scanCodexRoot(root, rootPath, rootMtimeMs);
   }
 
+  if (source === "cursor") {
+    const cached = _dirCache.get(root.id);
+    if (cached && cached.rootPath === rootPath && isCacheValid(cached, rootMtimeMs)) {
+      return cached.entries;
+    }
+    const entries = await listCursorConversationFiles(root);
+    _dirCache.set(root.id, {
+      rootPath,
+      dirMtimeMs: rootMtimeMs,
+      entries,
+      cachedAtMs: Date.now()
+    });
+    return entries;
+  }
+
   /* check cache */
   const cached = _dirCache.get(root.id);
   if (cached && cached.rootPath === rootPath && isCacheValid(cached, rootMtimeMs)) {
@@ -264,13 +280,20 @@ async function scanRoot(root: RootConfig, source: Source): Promise<ConversationF
       try {
         const st = await safeStat(fullPath);
         if (!st) return null;
+        
+        // For Windsurf sessions, use birth time (creation time) instead of modification time
+        // This ensures sessions are ordered by actual session start date, not file modification date
+        const effectiveTimeMs = (source === "windsurf" && typeof st.birthtimeMs === "number")
+          ? Number(st.birthtimeMs)
+          : Number(st.mtimeMs);
+        
         return {
           id: dirent.name.slice(0, -3),
           source,
           rootId: root.id,
           path: fullPath,
           sizeBytes: Number(st.size),
-          mtimeMs: Number(st.mtimeMs)
+          mtimeMs: effectiveTimeMs
         } satisfies ConversationFile;
       } finally {
         release();
@@ -394,6 +417,19 @@ export async function probeRootHealth(root: RootConfig): Promise<RootHealth> {
         fileCount,
         scanMs: Date.now() - start,
         error: `Cannot read some subdirectories: ${partialErrors.join("; ")}`
+      };
+    }
+  } else if (root.source === "cursor") {
+    try {
+      fileCount = (await listCursorConversationFiles(root)).length;
+    } catch (err) {
+      return {
+        rootId: root.id,
+        path: rootPath,
+        status: "unreadable",
+        fileCount: 0,
+        scanMs: Date.now() - start,
+        error: err instanceof Error ? err.message : String(err)
       };
     }
   } else {

--- a/src/lib/server/cursor.ts
+++ b/src/lib/server/cursor.ts
@@ -1,0 +1,622 @@
+import "server-only";
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+
+import type { AppConfig, ConversationFile, ConversationMeta, SourcesStatus, TrajectoryEvent, TrajectorySummary } from "@/lib/types";
+import { expandHome } from "@/lib/server/paths";
+import { abbreviateHome, fileUriToPath } from "@/lib/server/trajectoryMeta";
+
+const CURSOR_DEFAULT_USER_ROOT = "~/Library/Application Support/Cursor/User";
+const CURSOR_COMPOSER_KEY_PREFIX = "composerData:";
+const CURSOR_WORKSPACE_USER_KEY = "src.vs.platform.reactivestorage.browser.reactiveStorageServiceImpl.persistentStorage.workspaceUser";
+
+type CursorComposerHeader = {
+  bubbleId?: string;
+  type?: number;
+  serverBubbleId?: string;
+};
+
+type CursorBubble = {
+  bubbleId: string;
+  type: number; // 1 = user, 2 = assistant
+  text: string;
+  isThought?: boolean;
+  capabilityType?: number;
+};
+
+type CursorTodo = {
+  text?: string;
+  done?: boolean;
+  status?: string;
+};
+
+type CursorSummaryEnvelope = {
+  summary?: {
+    summary?: string;
+  };
+};
+
+type CursorContext = {
+  cursorRules?: Array<{ filename?: string; addedWithoutMention?: boolean }>;
+  cursorCommands?: Array<{ command?: string }>;
+  fileSelections?: Array<{ uri?: { external?: string; path?: string; fsPath?: string } }>;
+  folderSelections?: Array<{ uri?: { external?: string; path?: string; fsPath?: string } }>;
+  externalLinks?: string[];
+};
+
+type CursorComposerRecord = {
+  _v?: number;
+  composerId: string;
+  name?: string;
+  subtitle?: string;
+  text?: string;
+  status?: string;
+  createdAt?: number;
+  lastUpdatedAt?: number;
+  latestConversationSummary?: CursorSummaryEnvelope;
+  fullConversationHeadersOnly?: CursorComposerHeader[];
+  todos?: CursorTodo[];
+  context?: CursorContext;
+};
+
+type CursorWorkspaceEntry = {
+  workspaceId: string;
+  workspacePath?: string;
+  userStatePath: string;
+};
+
+type CursorComposerListEntry = {
+  key: string;
+  record: CursorComposerRecord;
+  sizeBytes: number;
+};
+
+type CursorRootResolution = {
+  rootPath: string;
+  globalStateDbPath: string;
+  workspaceStoragePath: string;
+};
+
+function resolveCursorRoot(rootPathInput: string): CursorRootResolution {
+  const rootPath = expandHome(rootPathInput);
+  if (rootPath.endsWith(`${path.sep}workspaceStorage`)) {
+    const userRoot = path.dirname(rootPath);
+    return {
+      rootPath,
+      globalStateDbPath: path.join(userRoot, "globalStorage", "state.vscdb"),
+      workspaceStoragePath: rootPath,
+    };
+  }
+
+  if (rootPath.endsWith(`${path.sep}globalStorage`)) {
+    const userRoot = path.dirname(rootPath);
+    return {
+      rootPath,
+      globalStateDbPath: path.join(rootPath, "state.vscdb"),
+      workspaceStoragePath: path.join(userRoot, "workspaceStorage"),
+    };
+  }
+
+  if (rootPath.endsWith("state.vscdb")) {
+    const globalStoragePath = path.dirname(rootPath);
+    const userRoot = path.dirname(globalStoragePath);
+    return {
+      rootPath,
+      globalStateDbPath: rootPath,
+      workspaceStoragePath: path.join(userRoot, "workspaceStorage"),
+    };
+  }
+
+  return {
+    rootPath,
+    globalStateDbPath: path.join(rootPath, "globalStorage", "state.vscdb"),
+    workspaceStoragePath: path.join(rootPath, "workspaceStorage"),
+  };
+}
+
+function openReadonlySqlite(dbPath: string): Database.Database {
+  return new Database(dbPath, { readonly: true, fileMustExist: true });
+}
+
+function normalizeTimestamp(value?: number): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  try {
+    return new Date(value).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeCursorComposerRecord(value: unknown): CursorComposerRecord | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.composerId !== "string" || raw.composerId.trim() === "") return null;
+  return {
+    _v: typeof raw._v === "number" ? raw._v : undefined,
+    composerId: raw.composerId,
+    name: typeof raw.name === "string" ? raw.name.trim() || undefined : undefined,
+    subtitle: typeof raw.subtitle === "string" ? raw.subtitle.trim() || undefined : undefined,
+    text: typeof raw.text === "string" ? raw.text : undefined,
+    status: typeof raw.status === "string" ? raw.status : undefined,
+    createdAt: typeof raw.createdAt === "number" ? raw.createdAt : undefined,
+    lastUpdatedAt: typeof raw.lastUpdatedAt === "number" ? raw.lastUpdatedAt : undefined,
+    latestConversationSummary: typeof raw.latestConversationSummary === "object" && raw.latestConversationSummary
+      ? (raw.latestConversationSummary as CursorSummaryEnvelope)
+      : undefined,
+    fullConversationHeadersOnly: Array.isArray(raw.fullConversationHeadersOnly)
+      ? raw.fullConversationHeadersOnly as CursorComposerHeader[]
+      : undefined,
+    todos: Array.isArray(raw.todos) ? raw.todos as CursorTodo[] : undefined,
+    context: typeof raw.context === "object" && raw.context ? raw.context as CursorContext : undefined,
+  };
+}
+
+function readCursorComposerRows(globalStateDbPath: string): CursorComposerListEntry[] {
+  let db: Database.Database | null = null;
+  try {
+    db = openReadonlySqlite(globalStateDbPath);
+    const rows = db.prepare(
+      "SELECT key, CAST(value AS TEXT) AS value_text, length(value) AS size_bytes FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+    ).all() as Array<{ key: string; value_text: string; size_bytes: number }>;
+
+    return rows
+      .map((row) => {
+        try {
+          const parsed = JSON.parse(row.value_text);
+          const record = normalizeCursorComposerRecord(parsed);
+          if (!record) return null;
+          return {
+            key: row.key,
+            record,
+            sizeBytes: Number(row.size_bytes) || row.value_text.length,
+          } satisfies CursorComposerListEntry;
+        } catch {
+          return null;
+        }
+      })
+      .filter((row): row is CursorComposerListEntry => row !== null);
+  } finally {
+    db?.close();
+  }
+}
+
+function readCursorBubbles(dbPath: string, composerId: string, headers: CursorComposerHeader[]): CursorBubble[] {
+  if (headers.length === 0) return [];
+  let db: Database.Database | null = null;
+  try {
+    db = openReadonlySqlite(dbPath);
+    const bubbles: CursorBubble[] = [];
+    for (const header of headers) {
+      const bid = header.bubbleId;
+      if (!bid) continue;
+      const rows = db.prepare(
+        "SELECT CAST(value AS TEXT) AS value_text FROM cursorDiskKV WHERE key = ?"
+      ).all(`bubbleId:${composerId}:${bid}`) as Array<{ value_text: string }>;
+      if (rows.length === 0) continue;
+      try {
+        const raw = JSON.parse(rows[0].value_text);
+        const btype = typeof raw.type === "number" ? raw.type : 0;
+        const text = typeof raw.text === "string" ? raw.text.trim() : "";
+        const isThought = Boolean(raw.isThought);
+        const capabilityType = typeof raw.capabilityType === "number" ? raw.capabilityType : undefined;
+        // Skip tool-call infrastructure bubbles (empty assistant turns used for tool dispatch)
+        if (btype === 2 && !text && !isThought) continue;
+        bubbles.push({ bubbleId: bid, type: btype, text, isThought, capabilityType });
+      } catch {
+        // skip unparseable bubble
+      }
+    }
+    return bubbles;
+  } finally {
+    db?.close();
+  }
+}
+
+async function readWorkspaceEntries(workspaceStoragePath: string): Promise<CursorWorkspaceEntry[]> {
+  let dirents: Array<{ name: string; isDirectory(): boolean }> = [];
+  try {
+    dirents = await fs.readdir(workspaceStoragePath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: CursorWorkspaceEntry[] = [];
+  for (const dirent of dirents) {
+    if (!dirent.isDirectory()) continue;
+    const workspaceId = dirent.name;
+    const workspaceDir = path.join(workspaceStoragePath, workspaceId);
+    const workspaceJsonPath = path.join(workspaceDir, "workspace.json");
+    let workspacePath: string | undefined;
+    try {
+      const raw = JSON.parse(await fs.readFile(workspaceJsonPath, "utf-8")) as { folder?: string };
+      const filePath = typeof raw.folder === "string" ? fileUriToPath(raw.folder) : null;
+      workspacePath = filePath ? abbreviateHome(filePath) : undefined;
+    } catch {
+      workspacePath = undefined;
+    }
+    results.push({
+      workspaceId,
+      workspacePath,
+      userStatePath: path.join(workspaceDir, "state.vscdb"),
+    });
+  }
+
+  return results;
+}
+
+function inferWorkspacePathFromContext(context?: CursorContext): string | undefined {
+  const fileCandidates = [
+    ...(context?.fileSelections ?? []),
+    ...(context?.folderSelections ?? []),
+  ];
+  for (const item of fileCandidates) {
+    const uri = item?.uri;
+    const p = typeof uri?.external === "string"
+      ? fileUriToPath(uri.external)
+      : typeof uri?.fsPath === "string"
+        ? uri.fsPath
+        : typeof uri?.path === "string"
+          ? uri.path
+          : null;
+    if (!p) continue;
+    const statPath = p.includes(".") ? path.dirname(p) : p;
+    return abbreviateHome(statPath);
+  }
+  return undefined;
+}
+
+function extractSummaryText(record: CursorComposerRecord): string | undefined {
+  const raw = record.latestConversationSummary?.summary?.summary?.trim();
+  if (!raw) return undefined;
+
+  // Format 1: Cursor AI conversation-context format
+  //   "Summary of the conversation so far:\n...\n<previous_user_message>...\n<previous_assistant_message>..."
+  // Extract the last assistant message text as the most useful human-readable snippet.
+  if (raw.startsWith("Summary of the conversation")) {
+    const assistantMatches = [...raw.matchAll(/<previous_assistant_message>([\s\S]*?)<\/previous_assistant_message>/gi)];
+    if (assistantMatches.length > 0) {
+      return assistantMatches[assistantMatches.length - 1][1].trim();
+    }
+    // No closed tags — grab everything after the last <previous_assistant_message>
+    const lastOpen = raw.lastIndexOf("<previous_assistant_message>");
+    if (lastOpen !== -1) {
+      return raw.slice(lastOpen + "<previous_assistant_message>".length).trim();
+    }
+    return undefined;
+  }
+
+  // Format 2: <summary>...</summary> wrapper (may be truncated — closing tag absent)
+  const withClose = /^<summary>\s*([\s\S]*?)\s*<\/summary>$/i.exec(raw);
+  if (withClose) return withClose[1].trim();
+  const openOnly = /^<summary>\s*([\s\S]+)/i.exec(raw);
+  if (openOnly) return openOnly[1].trim();
+
+  return raw;
+}
+
+function buildTitle(record: CursorComposerRecord): string {
+  return record.name?.trim() || record.subtitle?.trim() || record.composerId;
+}
+
+function buildCursorEvents(
+  record: CursorComposerRecord,
+  workspacePath: string | undefined,
+  bubbles: CursorBubble[]
+): TrajectoryEvent[] {
+  const createdAt = normalizeTimestamp(record.createdAt);
+  const updatedAt = normalizeTimestamp(record.lastUpdatedAt) ?? createdAt;
+  const events: TrajectoryEvent[] = [];
+  let index = 0;
+
+  if (bubbles.length > 0) {
+    // Full transcript from bubble store
+    for (const bubble of bubbles) {
+      if (!bubble.text) continue;
+      const role = bubble.type === 1 ? "user" : "assistant";
+      events.push({
+        id: `${record.composerId}:bubble:${bubble.bubbleId}`,
+        index: index++,
+        source: "cursor",
+        kind: role,
+        stepType: `cursor.${role}`,
+        title: role === "user" ? "User" : "Assistant",
+        text: bubble.text,
+        createdAt,
+        completedAt: updatedAt,
+        cwd: workspacePath,
+      });
+    }
+  } else {
+    // Fallback: summary only
+    const summaryText = extractSummaryText(record);
+    if (summaryText) {
+      events.push({
+        id: `${record.composerId}:summary`,
+        index: index++,
+        source: "cursor",
+        kind: "assistant",
+        stepType: "cursor.summary",
+        title: "Conversation summary",
+        text: summaryText,
+        createdAt,
+        completedAt: updatedAt,
+        cwd: workspacePath,
+      });
+    }
+  }
+
+  if (events.length === 0) {
+    events.push({
+      id: `${record.composerId}:placeholder`,
+      index: 0,
+      source: "cursor",
+      kind: "status",
+      stepType: "cursor.placeholder",
+      title: buildTitle(record),
+      text: "Cursor session metadata is present, but no detailed transcript content was recoverable from the validated local store.",
+      createdAt,
+      completedAt: updatedAt,
+      cwd: workspacePath,
+      status: record.status,
+    });
+  }
+
+  return events;
+}
+
+function buildCursorSummary(events: TrajectoryEvent[]): TrajectorySummary {
+  return {
+    totalSteps: events.length,
+    renderedEvents: events.length,
+    userCount: events.filter((event) => event.kind === "user").length,
+    assistantCount: events.filter((event) => event.kind === "assistant").length,
+    thoughtCount: events.filter((event) => event.kind === "thought").length,
+    toolCount: events.filter((event) => event.kind === "tool").length,
+    commandCount: events.filter((event) => event.kind === "command").length,
+    subagentCount: events.filter((event) => event.kind === "subagent").length,
+    errorCount: events.filter((event) => event.status?.toUpperCase().includes("ERROR")).length,
+  };
+}
+
+function buildCursorMarkdown(
+  record: CursorComposerRecord,
+  workspacePath: string | undefined,
+  bubbles: CursorBubble[]
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${buildTitle(record)}`);
+  lines.push("");
+
+  const createdAt = normalizeTimestamp(record.createdAt);
+  const updatedAt = normalizeTimestamp(record.lastUpdatedAt);
+  const context = record.context;
+  const metaLines: string[] = [];
+  metaLines.push(`- **Source:** Cursor`);
+  metaLines.push(`- **Session ID:** ${record.composerId}`);
+  metaLines.push(`- **Status:** ${record.status ?? "unknown"}`);
+  if (workspacePath) metaLines.push(`- **Workspace:** ${workspacePath}`);
+  if (createdAt) metaLines.push(`- **Created:** ${createdAt}`);
+  if (updatedAt) metaLines.push(`- **Updated:** ${updatedAt}`);
+  if (context) {
+    const cursorRules = (context.cursorRules ?? []).map((item) => item.filename).filter((value): value is string => Boolean(value));
+    if (cursorRules.length > 0) metaLines.push(`- **Cursor rules:** ${cursorRules.join(", ")}`);
+  }
+  lines.push("## Session metadata");
+  lines.push("");
+  lines.push(...metaLines);
+  lines.push("");
+
+  if (bubbles.length > 0) {
+    lines.push("## Conversation");
+    lines.push("");
+    for (const bubble of bubbles) {
+      if (!bubble.text) continue;
+      const label = bubble.type === 1 ? "**User**" : "**Assistant**";
+      lines.push(`### ${label}`);
+      lines.push("");
+      lines.push(bubble.text);
+      lines.push("");
+    }
+  } else {
+    const summary = extractSummaryText(record);
+    if (summary) {
+      lines.push("## Conversation summary");
+      lines.push("");
+      lines.push(summary);
+      lines.push("");
+    } else {
+      lines.push("> *No conversation content was recoverable from the validated local store.*");
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function buildWorkspacePathByComposerId(workspaceStoragePath: string): Promise<Map<string, string>> {
+  const workspaceEntries = await readWorkspaceEntries(workspaceStoragePath);
+  const out = new Map<string, string>();
+
+  for (const entry of workspaceEntries) {
+    let db: Database.Database | null = null;
+    try {
+      db = openReadonlySqlite(entry.userStatePath);
+      const rows = db.prepare(
+        "SELECT CAST(value AS TEXT) AS value_text FROM ItemTable WHERE key = 'composer.composerData'"
+      ).all() as Array<{ value_text: string }>;
+      for (const row of rows) {
+        try {
+          const parsed = JSON.parse(row.value_text) as {
+            selectedComposerIds?: string[];
+            lastFocusedComposerIds?: string[];
+            allComposers?: Array<{ composerId?: string }>;
+          };
+          const ids = [
+            ...(Array.isArray(parsed.selectedComposerIds) ? parsed.selectedComposerIds : []),
+            ...(Array.isArray(parsed.lastFocusedComposerIds) ? parsed.lastFocusedComposerIds : []),
+            // newer Cursor schema stores full list in allComposers
+            ...(Array.isArray(parsed.allComposers)
+              ? parsed.allComposers.map((c) => (typeof c?.composerId === "string" ? c.composerId : null)).filter((id): id is string => Boolean(id))
+              : []),
+          ];
+          for (const id of ids) {
+            if (typeof id === "string" && id && entry.workspacePath && !out.has(id)) {
+              out.set(id, entry.workspacePath);
+            }
+          }
+        } catch {
+          // ignore malformed workspace row
+        }
+      }
+    } catch {
+      // ignore unreadable workspace state db
+    } finally {
+      db?.close();
+    }
+  }
+
+  return out;
+}
+
+function firstAvailableCursorRoot(config: AppConfig): string {
+  const configured = config.roots.find((root) => root.source === "cursor")?.path;
+  return configured ?? CURSOR_DEFAULT_USER_ROOT;
+}
+
+function hasComposerContent(record: CursorComposerRecord): boolean {
+  if (record.name?.trim()) return true;
+  if (record.latestConversationSummary) return true;
+  if (record.fullConversationHeadersOnly && record.fullConversationHeadersOnly.length > 0) return true;
+  return false;
+}
+
+export async function listCursorConversationFiles(root: { id: string; path: string; enabled: boolean }): Promise<ConversationFile[]> {
+  const resolved = resolveCursorRoot(root.path);
+  const entries = readCursorComposerRows(resolved.globalStateDbPath);
+  return entries
+    .filter((entry) => hasComposerContent(entry.record))
+    .map((entry) => ({
+      id: entry.record.composerId,
+      source: "cursor",
+      rootId: root.id,
+      path: `${resolved.globalStateDbPath}#${entry.key}`,
+      sizeBytes: entry.sizeBytes,
+      mtimeMs: entry.record.lastUpdatedAt ?? entry.record.createdAt ?? 0,
+    } satisfies ConversationFile));
+}
+
+export async function getCursorTrajectoryMetaMap(config: AppConfig): Promise<Record<string, ConversationMeta>> {
+  const rootPath = firstAvailableCursorRoot(config);
+  const resolved = resolveCursorRoot(rootPath);
+  const workspacePathByComposerId = await buildWorkspacePathByComposerId(resolved.workspaceStoragePath);
+  const entries = readCursorComposerRows(resolved.globalStateDbPath);
+  const out: Record<string, ConversationMeta> = {};
+
+  for (const entry of entries) {
+    const record = entry.record;
+    const inferredWorkspace = workspacePathByComposerId.get(record.composerId) ?? inferWorkspacePathFromContext(record.context);
+    out[record.composerId] = {
+      title: buildTitle(record),
+      ...(inferredWorkspace ? { cwd: inferredWorkspace } : {}),
+    };
+  }
+
+  return out;
+}
+
+export async function getCursorConversation(id: string, config: AppConfig): Promise<{
+  markdown: string;
+  events: TrajectoryEvent[];
+  summary: TrajectorySummary;
+  locator: string;
+  workspacePath?: string;
+}> {
+  const rootPath = firstAvailableCursorRoot(config);
+  const resolved = resolveCursorRoot(rootPath);
+  const workspacePathByComposerId = await buildWorkspacePathByComposerId(resolved.workspaceStoragePath);
+  const entries = readCursorComposerRows(resolved.globalStateDbPath);
+  const match = entries.find((entry) => entry.record.composerId === id);
+  if (!match) {
+    throw new Error(`Cursor session not found: ${id}. The session may have been deleted or the configured Cursor root is incomplete.`);
+  }
+
+  const workspacePath = workspacePathByComposerId.get(id) ?? inferWorkspacePathFromContext(match.record.context);
+  const bubbles = readCursorBubbles(
+    resolved.globalStateDbPath,
+    match.record.composerId,
+    match.record.fullConversationHeadersOnly ?? []
+  );
+  const events = buildCursorEvents(match.record, workspacePath, bubbles);
+  return {
+    markdown: buildCursorMarkdown(match.record, workspacePath, bubbles),
+    events,
+    summary: buildCursorSummary(events),
+    locator: `${resolved.globalStateDbPath}#${match.key}`,
+    ...(workspacePath ? { workspacePath } : {}),
+  };
+}
+
+export async function getCursorRawContent(id: string, config: AppConfig): Promise<{
+  dbPath: string;
+  key: string;
+  workspacePath?: string;
+  record: CursorComposerRecord;
+}> {
+  const rootPath = firstAvailableCursorRoot(config);
+  const resolved = resolveCursorRoot(rootPath);
+  const workspacePathByComposerId = await buildWorkspacePathByComposerId(resolved.workspaceStoragePath);
+  const entries = readCursorComposerRows(resolved.globalStateDbPath);
+  const match = entries.find((entry) => entry.record.composerId === id);
+  if (!match) throw new Error(`Cursor session not found: ${id}`);
+
+  const workspacePath = workspacePathByComposerId.get(id) ?? inferWorkspacePathFromContext(match.record.context);
+  return {
+    dbPath: resolved.globalStateDbPath,
+    key: match.key,
+    ...(workspacePath ? { workspacePath } : {}),
+    record: match.record,
+  };
+}
+
+export async function getCursorStatus(config: AppConfig): Promise<SourcesStatus["cursor"]> {
+  const cursorRoots = config.roots.filter((root) => root.source === "cursor");
+  const enabledRoots = cursorRoots.filter((root) => root.enabled);
+  if (enabledRoots.length === 0) {
+    return {
+      sessionsFound: false,
+      error: cursorRoots.length === 0
+        ? "No Cursor roots configured. Add a root pointing to ~/Library/Application Support/Cursor/User in Settings."
+        : "No Cursor roots are enabled. Enable a Cursor root in Settings.",
+      recommendedAction: "Configure and enable a Cursor root in Settings.",
+    };
+  }
+
+  let lastError: string | undefined;
+  for (const root of enabledRoots) {
+    const resolved = resolveCursorRoot(root.path);
+    try {
+      await fs.stat(resolved.globalStateDbPath);
+      const entries = readCursorComposerRows(resolved.globalStateDbPath);
+      if (entries.length > 0) {
+        return {
+          sessionsFound: true,
+          storagePath: resolved.globalStateDbPath,
+          sessionCount: entries.length,
+        };
+      }
+      lastError = `No Cursor composer sessions found in ${resolved.globalStateDbPath}. Open Cursor composer/agent chats to create local session state.`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  return {
+    sessionsFound: false,
+    storagePath: enabledRoots[0] ? resolveCursorRoot(enabledRoots[0].path).globalStateDbPath : undefined,
+    error: lastError,
+    recommendedAction: "Open Cursor and start or revisit a composer/agent chat so local session state is written, then refresh.",
+  };
+}

--- a/src/lib/server/diagnosticExport.ts
+++ b/src/lib/server/diagnosticExport.ts
@@ -6,6 +6,7 @@ import { findLatestAntigravityDiscovery, resolveAntigravityRpcTarget } from "@/l
 import { getAntigravityTrajectoryMetaMapFromVscdb } from "@/lib/server/antigravityGlobalState";
 import { getWindsurfDiagnosticBundle } from "@/lib/server/windsurf";
 import { getCodexRawContent } from "@/lib/server/codex";
+import { getCursorRawContent } from "@/lib/server/cursor";
 
 const SERVICE = "exa.language_server_pb.LanguageServerService";
 
@@ -26,6 +27,7 @@ export type DiagnosticExport = {
   };
   windsurf?: Awaited<ReturnType<typeof getWindsurfDiagnosticBundle>>;
   codex?: Awaited<ReturnType<typeof getCodexRawContent>>;
+  cursor?: Awaited<ReturnType<typeof getCursorRawContent>>;
 };
 
 export async function buildDiagnosticExport(params: {
@@ -120,6 +122,17 @@ export async function buildDiagnosticExport(params: {
       source,
       cascadeId,
       codex
+    };
+  }
+
+  if (source === "cursor") {
+    const cursor = await getCursorRawContent(cascadeId, config);
+    return {
+      schemaVersion: 1,
+      generatedAt,
+      source,
+      cascadeId,
+      cursor
     };
   }
 

--- a/src/lib/server/metaCache.ts
+++ b/src/lib/server/metaCache.ts
@@ -4,6 +4,7 @@ import type { AppConfig, ConversationMeta, Source } from "@/lib/types";
 import { getAntigravityTrajectoryMetaMap } from "@/lib/server/antigravity";
 import { getWindsurfTrajectoryMetaMap } from "@/lib/server/windsurf";
 import { getCodexTrajectoryMetaMap } from "@/lib/server/codex";
+import { getCursorTrajectoryMetaMap } from "@/lib/server/cursor";
 
 type CacheEntry = {
   expiresAtMs: number;
@@ -16,7 +17,8 @@ const CACHE_TTL_MS = 5_000;
 const cache: Record<Source, CacheEntry> = {
   antigravity: { expiresAtMs: 0 },
   windsurf: { expiresAtMs: 0 },
-  codex: { expiresAtMs: 0 }
+  codex: { expiresAtMs: 0 },
+  cursor: { expiresAtMs: 0 }
 };
 
 export async function getTrajectoryMetaMapCached(params: {
@@ -35,8 +37,10 @@ export async function getTrajectoryMetaMapCached(params: {
         value = await getAntigravityTrajectoryMetaMap();
       } else if (params.source === "windsurf") {
         value = await getWindsurfTrajectoryMetaMap(params.config);
-      } else {
+      } else if (params.source === "codex") {
         value = await getCodexTrajectoryMetaMap(params.config);
+      } else {
+        value = await getCursorTrajectoryMetaMap(params.config);
       }
       entry.value = value;
       entry.expiresAtMs = Date.now() + CACHE_TTL_MS;

--- a/src/lib/server/projectEvidenceProvider.ts
+++ b/src/lib/server/projectEvidenceProvider.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { discoverProjectEvidence, type ProjectEvidenceFileSystem, type ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
+
+function safeRepoPath(rootDir: string, relativePath: string): string | null {
+  const normalized = relativePath.replaceAll("\\", "/").replace(/^\/+/, "");
+  if (!normalized || normalized.startsWith("../") || normalized.includes("/../")) return null;
+  const absolutePath = path.resolve(rootDir, normalized);
+  const relativeToRoot = path.relative(rootDir, absolutePath);
+  if (relativeToRoot.startsWith("..") || path.isAbsolute(relativeToRoot)) return null;
+  return absolutePath;
+}
+
+function createRepoFileSystem(rootDir: string): ProjectEvidenceFileSystem {
+  return {
+    exists(relativePath) {
+      const absolutePath = safeRepoPath(rootDir, relativePath);
+      return absolutePath ? fs.existsSync(absolutePath) : false;
+    },
+    isFile(relativePath) {
+      const absolutePath = safeRepoPath(rootDir, relativePath);
+      return absolutePath ? fs.statSync(absolutePath).isFile() : false;
+    },
+    isDirectory(relativePath) {
+      const absolutePath = safeRepoPath(rootDir, relativePath);
+      return absolutePath ? fs.statSync(absolutePath).isDirectory() : false;
+    },
+    listDirectory(relativePath) {
+      const absolutePath = safeRepoPath(rootDir, relativePath);
+      if (!absolutePath) return [];
+      return fs.readdirSync(absolutePath);
+    },
+    readFile(relativePath) {
+      const absolutePath = safeRepoPath(rootDir, relativePath);
+      if (!absolutePath) throw new Error("Path is outside the repository root.");
+      return fs.readFileSync(absolutePath, "utf8");
+    },
+  };
+}
+
+export function getProjectEvidenceProviderResult(rootDir = process.cwd()): ProjectEvidenceProviderResult {
+  return discoverProjectEvidence({
+    fileSystem: createRepoFileSystem(rootDir),
+    rootLabel: "repository root",
+  });
+}

--- a/src/lib/server/trajectoryMeta.ts
+++ b/src/lib/server/trajectoryMeta.ts
@@ -38,7 +38,37 @@ export function extractMetaFromTrajectorySummary(summary: any): ConversationMeta
   const p = uri ? fileUriToPath(uri) : null;
   const cwd = p ? abbreviateHome(p) : undefined;
 
-  return { ...(title ? { title } : {}), ...(cwd ? { cwd } : {}) };
+  // Extract timestamp from trajectory summary for proper session ordering
+  // Try multiple possible timestamp field names
+  let timestampMs: number | undefined;
+  
+  if (typeof summary?.startTimestampMs === "number") {
+    timestampMs = summary.startTimestampMs;
+  } else if (typeof summary?.start_timestamp_ms === "number") {
+    timestampMs = summary.start_timestamp_ms;
+  } else if (typeof summary?.createdMs === "number") {
+    timestampMs = summary.createdMs;
+  } else if (typeof summary?.created_ms === "number") {
+    timestampMs = summary.created_ms;
+  } else if (typeof summary?.timestampMs === "number") {
+    timestampMs = summary.timestampMs;
+  } else if (typeof summary?.timestamp_ms === "number") {
+    timestampMs = summary.timestamp_ms;
+  } else if (typeof summary?.startTimeMs === "number") {
+    timestampMs = summary.startTimeMs;
+  } else if (typeof summary?.start_time_ms === "number") {
+    timestampMs = summary.start_time_ms;
+  } else if (typeof summary?.creationTimeMs === "number") {
+    timestampMs = summary.creationTimeMs;
+  } else if (typeof summary?.creation_time_ms === "number") {
+    timestampMs = summary.creation_time_ms;
+  }
+
+  return { 
+    ...(title ? { title } : {}), 
+    ...(cwd ? { cwd } : {}),
+    ...(timestampMs ? { timestampMs } : {})
+  };
 }
 
 export function buildMetaMapFromTrajectorySummaries(

--- a/src/lib/server/trajectoryMeta.ts
+++ b/src/lib/server/trajectoryMeta.ts
@@ -67,7 +67,7 @@ export function extractMetaFromTrajectorySummary(summary: any): ConversationMeta
   return { 
     ...(title ? { title } : {}), 
     ...(cwd ? { cwd } : {}),
-    ...(timestampMs ? { timestampMs } : {})
+    ...(typeof timestampMs === "number" ? { timestampMs } : {})
   };
 }
 

--- a/src/lib/server/windsurf.ts
+++ b/src/lib/server/windsurf.ts
@@ -53,7 +53,7 @@ function toWindsurfRpcError(err: unknown, cascadeId: string): Error {
   const bodyText = err.bodyText?.trim() ?? "";
   if (/trajectory not found/i.test(bodyText)) {
     return new Error(
-      `Windsurf LS returned "trajectory not found" for session ${cascadeId}. The local .pb file was discovered, but the running Windsurf LS database does not have this trajectory anymore.`
+      `Windsurf LS returned "trajectory not found" for session ${cascadeId}. The trajectory may not exist in the running Windsurf LS database (session could be legacy or from a different Windsurf installation).`
     );
   }
 

--- a/src/lib/server/windsurf.ts
+++ b/src/lib/server/windsurf.ts
@@ -6,15 +6,17 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import type { AppConfig, ChatMessage, SourcesStatus, TrajectoryEvent, TrajectorySummary } from "@/lib/types";
-import { extractCsrfTokenFromCommand } from "@/lib/parse/commandLine";
+import { extractCsrfTokenFromCommand, extractCsrfTokenMatchFromCommand } from "@/lib/parse/commandLine";
 import { classifyCsrfTokenSource } from "@/lib/parse/tokenSource";
 import { getHeartbeatFailureSummary, getSessionRestartAction } from "@/lib/parse/connectionDiagnostics";
+import { inferWindsurfRecoverability } from "@/lib/parse/windsurfRecoverability";
 import { getWindsurfRecommendedAction, inferWindsurfTokenRequired } from "@/lib/parse/windsurfStatus";
 import { summarizeTrajectoryEvents } from "@/lib/parse/trajectory";
 import { extractLatestWindsurfStartInfoFromLog } from "@/lib/parse/windsurfLog";
 import { normalizeWindsurfStepsToMessages, normalizeWindsurfStepsToTrajectoryEvents } from "@/lib/parse/windsurfSteps";
 import { ConnectUnaryError, connectUnaryJson } from "@/lib/server/connect";
 import { platformPaths } from "@/lib/server/platform";
+import { expandHome } from "@/lib/server/paths";
 import { buildMetaMapFromTrajectorySummaries } from "@/lib/server/trajectoryMeta";
 
 const execFileAsync = promisify(execFile);
@@ -43,12 +45,73 @@ function extractErrCodeMessage(err: unknown): { code?: string; message?: string 
   return { ...(code ? { code } : {}), ...(message ? { message } : {}) };
 }
 
+function toWindsurfRpcError(err: unknown, cascadeId: string): Error {
+  if (!(err instanceof ConnectUnaryError)) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+
+  const bodyText = err.bodyText?.trim() ?? "";
+  if (/trajectory not found/i.test(bodyText)) {
+    return new Error(
+      `Windsurf LS returned "trajectory not found" for session ${cascadeId}. The local .pb file was discovered, but the running Windsurf LS database does not have this trajectory anymore.`
+    );
+  }
+
+  if (bodyText.length > 0) {
+    return new Error(`${err.message}: ${bodyText}`);
+  }
+
+  return new Error(err.message);
+}
+
 function isInvalidCsrfToken(res: HeartbeatProbeResult | null | undefined): boolean {
   return res?.httpStatus === 401 && /invalid csrf token/i.test(res.errorMessage ?? "");
 }
 
 function isMissingCsrfToken(res: HeartbeatProbeResult | null | undefined): boolean {
   return res?.httpStatus === 401 && /missing csrf token/i.test(res.errorMessage ?? "");
+}
+
+async function getLegacyWindsurfRecoveryEvidence(cascadeId: string) {
+  const pbPath = expandHome(`~/.codeium/cascade/${cascadeId}.pb`);
+  const brainDir = expandHome(`~/.codeium/brain/${cascadeId}`);
+
+  const pbStat = await fs.stat(pbPath).catch(() => null);
+  const planText = await fs.readFile(path.join(brainDir, "plan.md"), "utf-8").catch(() => null);
+  const planMetadataText = await fs.readFile(path.join(brainDir, "plan_metadata.pbtxt"), "utf-8").catch(() => null);
+
+  let recoveredTitle: string | undefined;
+  let recoveredCurrentGoal: string | undefined;
+  if (planText) {
+    const lines = planText.split(/\r?\n/);
+    const headingLine = lines.find((line) => line.startsWith("# "));
+    if (headingLine) recoveredTitle = headingLine.slice(2).trim() || undefined;
+
+    const goalIndex = lines.findIndex((line) => /^##\s+Current Goal\s*$/i.test(line.trim()));
+    if (goalIndex >= 0) {
+      const goalLine = lines.slice(goalIndex + 1).find((line) => line.trim().length > 0);
+      if (goalLine) recoveredCurrentGoal = goalLine.trim();
+    }
+  }
+
+  return {
+    localPb: pbStat
+      ? {
+          path: pbPath,
+          sizeBytes: Number(pbStat.size),
+          mtimeMs: Number(pbStat.mtimeMs)
+        }
+      : undefined,
+    brainSidecar: planText || planMetadataText
+      ? {
+          path: brainDir,
+          hasPlanMd: Boolean(planText),
+          hasPlanMetadata: Boolean(planMetadataText),
+          ...(recoveredTitle ? { recoveredTitle } : {}),
+          ...(recoveredCurrentGoal ? { recoveredCurrentGoal } : {})
+        }
+      : undefined
+  };
 }
 
 async function probeWindsurfHeartbeat(params: { baseUrl: string; csrfToken?: string }): Promise<HeartbeatProbeResult> {
@@ -184,9 +247,10 @@ async function resolveWindsurfConnection(config: AppConfig): Promise<WindsurfCon
   }
 
   const cmd = await readProcessCommandLine(startInfo.pid);
-  const tokenFromPs = cmd ? extractCsrfTokenFromCommand(cmd) : null;
+  const psTokenMatch = cmd ? extractCsrfTokenMatchFromCommand(cmd) : { token: null, source: "none" as const };
+  const tokenFromPs = psTokenMatch.token;
   const overrideToken = config.windsurf.csrfTokenOverride?.trim() || null;
-  const tokenInfo = classifyCsrfTokenSource({ tokenFromPs, overrideToken });
+  const tokenInfo = classifyCsrfTokenSource({ tokenFromPs, tokenFromPsSource: psTokenMatch.source, overrideToken });
   const csrfToken = tokenInfo.token ?? "";
 
   const baseUrl = `http://127.0.0.1:${startInfo.port}`;
@@ -210,9 +274,9 @@ async function resolveWindsurfConnection(config: AppConfig): Promise<WindsurfCon
     throw new Error("Windsurf heartbeat probe failed with the Settings override token. Refresh the override token, then retry.");
   }
   if (isInvalidCsrfToken(resWithToken)) {
-    throw new Error("Windsurf rejected the process-args CSRF token (401 invalid CSRF token). Restart a Cascade session, then refresh.");
+    throw new Error(`Windsurf rejected the ${tokenInfo.source === "ps_env" ? "running-process env" : "process-args"} CSRF token (401 invalid CSRF token). Restart a Cascade session, then refresh.`);
   }
-  throw new Error("Windsurf heartbeat probe failed with the process-args CSRF token. Restart a Cascade session, then refresh.");
+  throw new Error(`Windsurf heartbeat probe failed with the ${tokenInfo.source === "ps_env" ? "running-process env" : "process-args"} CSRF token. Restart a Cascade session, then refresh.`);
 
   // unreachable
 }
@@ -268,9 +332,10 @@ export async function getWindsurfStatus(config: AppConfig): Promise<SourcesStatu
   }
 
   const cmd = await readProcessCommandLine(startInfo.pid);
-  const tokenFromPs = cmd ? extractCsrfTokenFromCommand(cmd) : null;
+  const psTokenMatch = cmd ? extractCsrfTokenMatchFromCommand(cmd) : { token: null, source: "none" as const };
+  const tokenFromPs = psTokenMatch.token;
   const overrideToken = config.windsurf.csrfTokenOverride?.trim() || null;
-  const tokenInfo = classifyCsrfTokenSource({ tokenFromPs, overrideToken });
+  const tokenInfo = classifyCsrfTokenSource({ tokenFromPs, tokenFromPsSource: psTokenMatch.source, overrideToken });
   const csrfToken = tokenInfo.token;
   const csrfTokenSource = tokenInfo.source;
 
@@ -396,17 +461,25 @@ async function getWindsurfStepChunk(params: {
       body: { cascadeId }
     });
     if (typeof t?.numTotalSteps === "number") numTotalSteps = t.numTotalSteps;
-  } catch {
+  } catch (err) {
+    if (err instanceof ConnectUnaryError && /trajectory not found/i.test(err.bodyText ?? "")) {
+      throw toWindsurfRpcError(err, cascadeId);
+    }
     // Optional
   }
 
-  const stepsRes = await connectUnaryJson<any>({
-    baseUrl,
-    serviceTypeName: SERVICE,
-    methodName: "GetCascadeTrajectorySteps",
-    csrfToken,
-    body: { cascadeId, stepOffset, verbosity: "CLIENT_TRAJECTORY_VERBOSITY_PROD_UI" }
-  });
+  let stepsRes: any;
+  try {
+    stepsRes = await connectUnaryJson<any>({
+      baseUrl,
+      serviceTypeName: SERVICE,
+      methodName: "GetCascadeTrajectorySteps",
+      csrfToken,
+      body: { cascadeId, stepOffset, verbosity: "CLIENT_TRAJECTORY_VERBOSITY_PROD_UI" }
+    });
+  } catch (err) {
+    throw toWindsurfRpcError(err, cascadeId);
+  }
 
   const steps: unknown[] = Array.isArray(stepsRes?.steps) ? stepsRes.steps : [];
   return {
@@ -449,6 +522,19 @@ export async function getWindsurfDiagnosticBundle(params: {
   pid: number;
   port: number;
   csrfTokenPresent: boolean;
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  localPb?: {
+    path: string;
+    sizeBytes: number;
+    mtimeMs: number;
+  };
+  brainSidecar?: {
+    path: string;
+    hasPlanMd: boolean;
+    hasPlanMetadata: boolean;
+    recoveredTitle?: string;
+    recoveredCurrentGoal?: string;
+  };
   getCascadeTrajectoryResponse: unknown;
   getCascadeTrajectoryStepsPages: Array<{ stepOffset: number; response: unknown }>;
   numTotalSteps?: number;
@@ -460,13 +546,50 @@ export async function getWindsurfDiagnosticBundle(params: {
   const conn = await resolveWindsurfConnection(config);
   const baseUrl = `http://127.0.0.1:${conn.port}`;
 
-  const getCascadeTrajectoryResponse = await connectUnaryJson<any>({
-    baseUrl,
-    serviceTypeName: SERVICE,
-    methodName: "GetCascadeTrajectory",
-    csrfToken: conn.csrfToken,
-    body: { cascadeId }
+  let getCascadeTrajectoryResponse: any;
+  let trajectoryMissing = false;
+  try {
+    getCascadeTrajectoryResponse = await connectUnaryJson<any>({
+      baseUrl,
+      serviceTypeName: SERVICE,
+      methodName: "GetCascadeTrajectory",
+      csrfToken: conn.csrfToken,
+      body: { cascadeId }
+    });
+  } catch (err) {
+    if (err instanceof ConnectUnaryError && /trajectory not found/i.test(err.bodyText ?? "")) {
+      trajectoryMissing = true;
+      getCascadeTrajectoryResponse = {
+        error: toWindsurfRpcError(err, cascadeId).message,
+        bodyText: err.bodyText,
+        status: err.status
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  const recoveryEvidence = trajectoryMissing ? await getLegacyWindsurfRecoveryEvidence(cascadeId) : { localPb: undefined, brainSidecar: undefined };
+  const recoverability = inferWindsurfRecoverability({
+    trajectoryReadable: !trajectoryMissing,
+    trajectoryMissing,
+    hasSidecarEvidence: Boolean(recoveryEvidence.brainSidecar)
   });
+
+  if (trajectoryMissing) {
+    return {
+      logPath: conn.logPath,
+      pid: conn.pid,
+      port: conn.port,
+      csrfTokenPresent: Boolean(conn.csrfToken),
+      ...(recoverability ? { recoverability } : {}),
+      ...(recoveryEvidence.localPb ? { localPb: recoveryEvidence.localPb } : {}),
+      ...(recoveryEvidence.brainSidecar ? { brainSidecar: recoveryEvidence.brainSidecar } : {}),
+      getCascadeTrajectoryResponse,
+      getCascadeTrajectoryStepsPages: [],
+      truncated: false
+    };
+  }
 
   const numTotalSteps = typeof getCascadeTrajectoryResponse?.numTotalSteps === "number" ? getCascadeTrajectoryResponse.numTotalSteps : undefined;
 
@@ -524,6 +647,7 @@ export async function getWindsurfDiagnosticBundle(params: {
     pid: conn.pid,
     port: conn.port,
     csrfTokenPresent: Boolean(conn.csrfToken),
+    ...(recoverability ? { recoverability } : {}),
     getCascadeTrajectoryResponse,
     getCascadeTrajectoryStepsPages,
     ...(typeof numTotalSteps === "number" ? { numTotalSteps } : {}),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,12 @@ export type ConversationListItem = ConversationFile & {
   gitBranch?: string;
   /** Model used in the session, e.g. "gpt-5.4" (Codex only). */
   model?: string;
+  /** Bounded Windsurf recoverability state for locally discovered sessions. */
+  recoverability?: "ls_readable" | "partial" | "unavailable";
+  /** Whether bounded brain-sidecar evidence was discovered for this session. */
+  hasRecoveryEvidence?: boolean;
+  /** Compact recoverability note for viewer / workflow handoff surfaces. */
+  recoverabilityNote?: string;
   /** Root IDs that contain a session with the same id (excluding the item's own rootId). */
   duplicateRootIds?: string[];
 };
@@ -61,7 +67,7 @@ export type SourcesStatus = {
     httpPort?: number;
     httpsPort?: number;
     csrfTokenPresent?: boolean;
-    csrfTokenSource?: "ps_args" | "override" | "discovery_file" | "none";
+    csrfTokenSource?: "ps_args" | "ps_env" | "override" | "discovery_file" | "none";
     tokenRequired?: boolean;
     heartbeatOk?: boolean;
     lastError?: string;
@@ -77,7 +83,7 @@ export type SourcesStatus = {
     pidAlive?: boolean;
     port?: number;
     csrfTokenPresent?: boolean;
-    csrfTokenSource?: "ps_args" | "override" | "discovery_file" | "none";
+    csrfTokenSource?: "ps_args" | "ps_env" | "override" | "discovery_file" | "none";
     tokenRequired?: boolean;
     heartbeatOk?: boolean;
     lastError?: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Source = "antigravity" | "windsurf" | "codex";
+export type Source = "antigravity" | "windsurf" | "codex" | "cursor";
 
 export type RootConfig = {
   id: string;
@@ -93,6 +93,16 @@ export type SourcesStatus = {
      */
     sessionsDir?: string;
     error?: string;
+  };
+  cursor: {
+    /** True if at least one Cursor composer session was found in the validated local state. */
+    sessionsFound: boolean;
+    /** Resolved Cursor SQLite/app-storage path used for the current status probe. */
+    storagePath?: string;
+    /** Number of composer sessions found in the probed local store, when available. */
+    sessionCount?: number;
+    error?: string;
+    recommendedAction?: string;
   };
 };
 
@@ -216,6 +226,8 @@ export type ConversationMeta = {
   gitBranch?: string;
   /** Model used in the session, e.g. "gpt-5.4" (Codex only). */
   model?: string;
+  /** Timestamp from trajectory data for accurate session ordering (Windsurf only). */
+  timestampMs?: number;
 };
 
 export type SearchResult = {

--- a/src/lib/urlState.ts
+++ b/src/lib/urlState.ts
@@ -115,7 +115,7 @@ export function parseUrlState(search: string): Partial<UrlViewerState> {
 
   // source
   const src = p.get("source");
-  if (src === "antigravity" || src === "windsurf" || src === "codex") state.source = src;
+  if (src === "antigravity" || src === "windsurf" || src === "codex" || src === "cursor") state.source = src;
 
   // id
   const id = p.get("id");

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -8,11 +8,13 @@ import {
   resolveAnalysisNavigationHandoff,
 } from "@/components/AnalysisFoundation";
 import { resolveAnalysisSessionRootId, type AnalysisHandoff } from "@/lib/analysisFindings";
+import type { ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
 
-function renderAnalysisFoundation(handoff: AnalysisHandoff | null) {
+function renderAnalysisFoundation(handoff: AnalysisHandoff | null, projectEvidence?: ProjectEvidenceProviderResult | null) {
   return renderToStaticMarkup(
     <AnalysisFoundation
       handoff={handoff}
+      projectEvidence={projectEvidence}
       loadingDelayMs={0}
       onOpenAssets={vi.fn()}
       onOpenBackup={vi.fn()}
@@ -20,6 +22,19 @@ function renderAnalysisFoundation(handoff: AnalysisHandoff | null) {
       onOpenSession={vi.fn()}
     />
   );
+}
+
+function createProviderResult(input: Partial<ProjectEvidenceProviderResult>): ProjectEvidenceProviderResult {
+  return {
+    provider: "project-evidence-provider-v1",
+    status: "available",
+    rootLabel: "repository root",
+    evidenceSource: "repo-local",
+    items: [],
+    assets: [],
+    diagnostics: [],
+    ...input,
+  };
 }
 
 describe("AnalysisFoundation", () => {
@@ -141,4 +156,41 @@ describe("AnalysisFoundation", () => {
     ).toBeNull();
   });
 
+  it("renders provider diagnostics as bounded findings", () => {
+    const html = renderAnalysisFoundation(null, createProviderResult({
+      diagnostics: [
+        {
+          id: "project-evidence-diagnostic-unreadable-agents-md",
+          kind: "unreadable",
+          severity: "warning",
+          path: "AGENTS.md",
+          message: "Provider could not read this repo-local allowlisted evidence file.",
+        },
+      ],
+    }));
+
+    expect(html).toContain("provider diagnostics");
+    expect(html).toContain("Provider unreadable evidence: AGENTS.md");
+    expect(html).toContain("bounded provider diagnostics");
+    expect(html).not.toContain("Preserve session evidence before migration cleanup");
+  });
+
+  it("renders provider-backed no-current-findings without seed issues", () => {
+    const html = renderAnalysisFoundation(null, createProviderResult({
+      assets: [],
+      diagnostics: [],
+    }));
+
+    expect(html).toContain("no current provider findings");
+    expect(html).toContain("0");
+    expect(html).toContain("No findings match the current issue and object context.");
+    expect(html).not.toContain("Stale review preference memory");
+  });
+
+  it("labels seed findings as fallback when provider is unavailable", () => {
+    const html = renderAnalysisFoundation(null, createProviderResult({ status: "unavailable" }));
+
+    expect(html).toContain("provider unavailable fallback");
+    expect(html).toContain("Preserve session evidence before migration cleanup");
+  });
 });

--- a/tests/assetsFoundation.test.tsx
+++ b/tests/assetsFoundation.test.tsx
@@ -3,12 +3,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { AssetsFoundation } from "@/components/AssetsFoundation";
-import type { AssetsHandoff } from "@/lib/contextAssets";
+import { normalizeContextAsset, type AssetsHandoff } from "@/lib/contextAssets";
+import type { ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
 
-function renderAssetsFoundation(handoff: AssetsHandoff | null) {
+function renderAssetsFoundation(handoff: AssetsHandoff | null, projectEvidence?: ProjectEvidenceProviderResult | null) {
   return renderToStaticMarkup(
     <AssetsFoundation
       handoff={handoff}
+      projectEvidence={projectEvidence}
       loadingDelayMs={0}
       onOpenAnalysis={vi.fn()}
       onOpenBackup={vi.fn()}
@@ -16,6 +18,19 @@ function renderAssetsFoundation(handoff: AssetsHandoff | null) {
       onOpenSession={vi.fn()}
     />
   );
+}
+
+function createProviderResult(input: Partial<ProjectEvidenceProviderResult>): ProjectEvidenceProviderResult {
+  return {
+    provider: "project-evidence-provider-v1",
+    status: "available",
+    rootLabel: "repository root",
+    evidenceSource: "repo-local",
+    items: [],
+    assets: [],
+    diagnostics: [],
+    ...input,
+  };
 }
 
 describe("AssetsFoundation", () => {
@@ -127,5 +142,57 @@ describe("AssetsFoundation", () => {
 
     expect(html).toContain("route owner: Project Overview");
     expect(html).toContain("Route to Project Overview: review governance context");
+  });
+
+  it("renders provider-backed inventory instead of seed rows", () => {
+    const html = renderAssetsFoundation(null, createProviderResult({
+      assets: [
+        normalizeContextAsset({
+          id: "asset-project-evidence-agents-md",
+          title: "Agents",
+          subtype: "rule",
+          scope: "project",
+          source: "codex",
+          status: "active",
+          provenance: "AGENTS.md (repo-local)",
+          usage: { state: "in_effect", summary: "Repo-local rule evidence." },
+        }),
+      ],
+    }));
+
+    expect(html).toContain("Repo-local evidence");
+    expect(html).toContain("Agents");
+    expect(html).toContain("AGENTS.md (repo-local)");
+    expect(html).not.toContain("Project coding rules");
+    expect(html).not.toContain("Foundation data cue");
+  });
+
+  it("renders empty provider state without seed fallback rows", () => {
+    const html = renderAssetsFoundation(null, createProviderResult({ status: "empty" }));
+
+    expect(html).toContain("Repo-local evidence zero state");
+    expect(html).toContain("0");
+    expect(html).toContain("No reusable assets match the current subtype and filter context.");
+    expect(html).not.toContain("Project coding rules");
+  });
+
+  it("keeps unavailable provider fallback labeled and diagnostics visible", () => {
+    const html = renderAssetsFoundation(null, createProviderResult({
+      status: "unavailable",
+      diagnostics: [
+        {
+          id: "project-evidence-diagnostic-unreadable-agents-md",
+          kind: "unreadable",
+          severity: "warning",
+          path: "AGENTS.md",
+          message: "Provider could not read this repo-local allowlisted evidence file.",
+        },
+      ],
+    }));
+
+    expect(html).toContain("Provider unavailable fallback");
+    expect(html).toContain("Project coding rules");
+    expect(html).toContain("Provider diagnostics");
+    expect(html).toContain("unreadable: AGENTS.md");
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -28,11 +28,12 @@ describe("readConfig / sanitizeRoots backfill", () => {
     const { config } = await readConfig();
     const sources = config.roots.map((r: RootConfig) => r.source);
     expect(sources).toContain("codex");
+    expect(sources).toContain("cursor");
     expect(sources).toContain("antigravity");
     expect(sources).toContain("windsurf");
   });
 
-  it("backfills default codex root when saved config has no codex entry", async () => {
+  it("backfills default codex and cursor roots when saved config is missing newer sources", async () => {
     const savedConfig = {
       schemaVersion: 1,
       roots: [
@@ -53,6 +54,10 @@ describe("readConfig / sanitizeRoots backfill", () => {
     expect(codexRoots.length).toBeGreaterThan(0);
     expect(codexRoots[0]!.path).toBe("~/.codex/sessions");
     expect(codexRoots[0]!.enabled).toBe(true);
+    const cursorRoots = config.roots.filter((r: RootConfig) => r.source === "cursor");
+    expect(cursorRoots.length).toBeGreaterThan(0);
+    expect(cursorRoots[0]!.path).toBe("~/Library/Application Support/Cursor/User");
+    expect(cursorRoots[0]!.enabled).toBe(true);
     // Existing roots are preserved
     expect(config.roots.filter((r: RootConfig) => r.source === "antigravity").length).toBeGreaterThan(0);
     expect(config.roots.filter((r: RootConfig) => r.source === "windsurf").length).toBeGreaterThan(0);

--- a/tests/cursorServer.test.ts
+++ b/tests/cursorServer.test.ts
@@ -130,7 +130,7 @@ describe("cursor server adapter", () => {
 
     expect(conversation.markdown).toContain("# Cursor support implementation");
     expect(conversation.markdown).toContain("Conversation summary");
-    expect(conversation.markdown).toContain("Retrieval note");
+    expect(conversation.markdown).toContain("Source:** Cursor");
     expect(conversation.events.some((event: { stepType?: string }) => event.stepType === "cursor.summary")).toBe(true);
     expect(conversation.summary.totalSteps).toBeGreaterThan(0);
     expect(conversation.workspacePath).toBe("/Users/test/example-repo");

--- a/tests/cursorServer.test.ts
+++ b/tests/cursorServer.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getCursorConversation, getCursorStatus, getCursorTrajectoryMetaMap, listCursorConversationFiles } from "../src/lib/server/cursor";
+import type { AppConfig, RootConfig } from "../src/lib/types";
+
+let tmpDir: string;
+
+function createCursorFixture(rootDir: string) {
+  const userDir = path.join(rootDir, "CursorUser");
+  const globalStorageDir = path.join(userDir, "globalStorage");
+  const workspaceStorageDir = path.join(userDir, "workspaceStorage", "workspace-1");
+  return { userDir, globalStorageDir, workspaceStorageDir };
+}
+
+async function seedCursorFixture(rootDir: string) {
+  const fixture = createCursorFixture(rootDir);
+  await fs.mkdir(fixture.globalStorageDir, { recursive: true });
+  await fs.mkdir(fixture.workspaceStorageDir, { recursive: true });
+  await fs.writeFile(
+    path.join(fixture.workspaceStorageDir, "workspace.json"),
+    JSON.stringify({ folder: "file:///Users/test/example-repo" }, null, 2),
+    "utf-8"
+  );
+
+  const globalDb = new Database(path.join(fixture.globalStorageDir, "state.vscdb"));
+  globalDb.exec("CREATE TABLE cursorDiskKV (key TEXT, value BLOB);");
+  globalDb.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+    "composerData:test-composer-1",
+    JSON.stringify({
+      _v: 15,
+      composerId: "test-composer-1",
+      name: "Cursor support implementation",
+      subtitle: "Edited src/lib/server/cursor.ts",
+      status: "completed",
+      createdAt: 1752000000000,
+      lastUpdatedAt: 1752000100000,
+      latestConversationSummary: {
+        summary: {
+          summary: "Implemented the bounded Cursor adapter using local SQLite/app-storage facts."
+        }
+      },
+      todos: [
+        { text: "Verify workspace mapping", done: true, status: "done" },
+        { text: "Document bounded transcript support", done: false, status: "open" }
+      ],
+      context: {
+        cursorRules: [{ filename: "always.mdc", addedWithoutMention: true }],
+        fileSelections: [{ uri: { external: "file:///Users/test/example-repo/src/index.ts" } }],
+        externalLinks: ["https://example.com/docs"]
+      },
+      fullConversationHeadersOnly: [
+        { bubbleId: "user-1", type: 1 },
+        { bubbleId: "assistant-1", type: 2 }
+      ],
+      conversationMap: {}
+    })
+  );
+  globalDb.close();
+
+  const workspaceDb = new Database(path.join(fixture.workspaceStorageDir, "state.vscdb"));
+  workspaceDb.exec("CREATE TABLE ItemTable (key TEXT, value BLOB);");
+  workspaceDb.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run(
+    "composer.composerData",
+    JSON.stringify({
+      selectedComposerIds: ["test-composer-1"],
+      lastFocusedComposerIds: ["test-composer-1"]
+    })
+  );
+  workspaceDb.close();
+
+  return fixture.userDir;
+}
+
+function buildConfig(cursorRoot: string): AppConfig {
+  const roots: RootConfig[] = [
+    { id: "cursor-root", source: "cursor", path: cursorRoot, enabled: true }
+  ];
+  return {
+    schemaVersion: 1,
+    roots,
+    windsurf: {},
+    ui: {
+      defaultSource: "cursor",
+      sortOrder: "mtime_desc"
+    }
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "asm-cursor-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("cursor server adapter", () => {
+  it("lists composer sessions from Cursor local state", async () => {
+    const cursorRoot = await seedCursorFixture(tmpDir);
+    const items = await listCursorConversationFiles({
+      id: "cursor-root",
+      source: "cursor",
+      path: cursorRoot,
+      enabled: true
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe("test-composer-1");
+    expect(items[0]?.path).toContain("composerData:test-composer-1");
+  });
+
+  it("builds a Cursor metadata map with inferred workspace path", async () => {
+    const cursorRoot = await seedCursorFixture(tmpDir);
+    const meta = await getCursorTrajectoryMetaMap(buildConfig(cursorRoot));
+
+    expect(meta["test-composer-1"]).toEqual({
+      title: "Cursor support implementation",
+      cwd: "/Users/test/example-repo"
+    });
+  });
+
+  it("renders bounded markdown and synthetic events for a Cursor session", async () => {
+    const cursorRoot = await seedCursorFixture(tmpDir);
+    const conversation = await getCursorConversation("test-composer-1", buildConfig(cursorRoot));
+
+    expect(conversation.markdown).toContain("# Cursor support implementation");
+    expect(conversation.markdown).toContain("Conversation summary");
+    expect(conversation.markdown).toContain("Retrieval note");
+    expect(conversation.events.some((event: { stepType?: string }) => event.stepType === "cursor.summary")).toBe(true);
+    expect(conversation.summary.totalSteps).toBeGreaterThan(0);
+    expect(conversation.workspacePath).toBe("/Users/test/example-repo");
+  });
+
+  it("reports sessionsFound status from validated Cursor local storage", async () => {
+    const cursorRoot = await seedCursorFixture(tmpDir);
+    const status = await getCursorStatus(buildConfig(cursorRoot));
+
+    expect(status.sessionsFound).toBe(true);
+    expect(status.sessionCount).toBe(1);
+    expect(status.storagePath).toContain("state.vscdb");
+  });
+});

--- a/tests/projectEvidenceProvider.test.ts
+++ b/tests/projectEvidenceProvider.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createProjectEvidenceDiagnosticsFindings,
+  discoverProjectEvidence,
+  normalizeProjectEvidenceItem,
+  type ProjectEvidenceFileSystem,
+} from "@/lib/projectEvidenceProvider";
+
+function createMemoryFileSystem(files: Record<string, string | Error>): ProjectEvidenceFileSystem & { attempts: string[] } {
+  const attempts: string[] = [];
+  const normalizedFiles = new Map(Object.entries(files).map(([key, value]) => [key.replaceAll("\\", "/"), value]));
+  const directories = new Set<string>([""]);
+  for (const filePath of normalizedFiles.keys()) {
+    const parts = filePath.split("/");
+    for (let index = 1; index < parts.length; index += 1) {
+      directories.add(parts.slice(0, index).join("/"));
+    }
+  }
+
+  return {
+    attempts,
+    exists(relativePath) {
+      attempts.push(relativePath);
+      return normalizedFiles.has(relativePath) || directories.has(relativePath);
+    },
+    isFile(relativePath) {
+      attempts.push(relativePath);
+      return normalizedFiles.has(relativePath);
+    },
+    isDirectory(relativePath) {
+      attempts.push(relativePath);
+      return directories.has(relativePath);
+    },
+    listDirectory(relativePath) {
+      attempts.push(relativePath);
+      const prefix = relativePath ? `${relativePath}/` : "";
+      const names = new Set<string>();
+      for (const filePath of [...normalizedFiles.keys(), ...directories]) {
+        if (!filePath.startsWith(prefix) || filePath === relativePath) continue;
+        const rest = filePath.slice(prefix.length);
+        if (!rest) continue;
+        names.add(rest.split("/")[0]!);
+      }
+      return [...names];
+    },
+    readFile(relativePath) {
+      attempts.push(relativePath);
+      const value = normalizedFiles.get(relativePath);
+      if (value instanceof Error) throw value;
+      if (typeof value !== "string") throw new Error("missing");
+      return value;
+    },
+  };
+}
+
+describe("discoverProjectEvidence", () => {
+  it("discovers known instruction, skill, workflow, prompt, and hook paths", () => {
+    const fs = createMemoryFileSystem({
+      "AGENTS.md": "# Agent rules",
+      ".github/copilot-instructions.md": "# Copilot rules",
+      ".github/instructions/parser.instructions.md": "# Parser instructions",
+      ".github/prompts/opsx-apply.prompt.md": "# Prompt",
+      ".github/skills/ops/SKILL.md": "# GitHub skill",
+      ".codex/skills/ops/SKILL.md": "# Codex skill",
+      ".codex/agents/reviewer.toml": "name = 'reviewer'",
+      ".codex/hooks.json": "{}",
+      ".agents/skills/release/SKILL.md": "# Release skill",
+      ".agent/skills/release/SKILL.md": "# Release skill",
+      ".windsurf/skills/ops/SKILL.md": "# Windsurf skill",
+      ".windsurf/rules/engineering.md": "# Windsurf rule",
+      ".windsurf/workflows/opsx-apply.md": "# Windsurf workflow",
+      ".windsurf/hooks.json": "{}",
+      ".windsurf/hooks/guard.py": "print('guard')",
+      ".cursor/mcp.json": "{\"mcpServers\":{}}",
+      ".cursorrules": "Always prefer local-first behavior",
+      ".cursor/rules/repo.mdc": "---\ndescription: Repo rule\n---\nUse project conventions",
+    });
+
+    const result = discoverProjectEvidence({ fileSystem: fs });
+    const paths = result.items.map((item) => item.path);
+
+    expect(result.status).toBe("available");
+    expect(paths).toContain("AGENTS.md");
+    expect(paths).toContain(".github/prompts/opsx-apply.prompt.md");
+    expect(paths).toContain(".codex/hooks.json");
+    expect(paths).toContain(".windsurf/workflows/opsx-apply.md");
+    expect(paths).toContain(".windsurf/hooks/guard.py");
+    expect(paths).toContain(".cursor/mcp.json");
+    expect(paths).toContain(".cursorrules");
+    expect(paths).toContain(".cursor/rules/repo.mdc");
+    expect(result.assets.some((asset) => asset.subtype === "rule")).toBe(true);
+    expect(result.assets.some((asset) => asset.subtype === "skill")).toBe(true);
+    expect(result.assets.some((asset) => asset.subtype === "command")).toBe(true);
+    expect(result.assets.every((asset) => !asset.provenance.startsWith("/"))).toBe(true);
+  });
+
+  it("excludes arbitrary source files and session parser inputs instead of keyword scanning", () => {
+    const fs = createMemoryFileSystem({
+      "src/app/agent-skill-command.ts": "agent skill prompt rule",
+      "tests/fixtures/session.jsonl": "{\"type\":\"message\"}",
+      ".codex/sessions/2026/04/19/rollout.jsonl": "{\"role\":\"user\"}",
+      "AGENTS.md": "# Real rule",
+    });
+
+    const result = discoverProjectEvidence({ fileSystem: fs });
+
+    expect(result.items.map((item) => item.path)).toEqual(["AGENTS.md"]);
+    expect(fs.attempts.some((path) => path.startsWith("src/"))).toBe(false);
+    expect(fs.attempts.some((path) => path.includes("sessions"))).toBe(false);
+  });
+
+  it("does not read user-global stores, external paths, cloud sources, or paths outside the repository root", () => {
+    const fs = createMemoryFileSystem({
+      "../outside/AGENTS.md": "# Outside",
+      "/tmp/AGENTS.md": "# External",
+      "~/.codex/skills/global/SKILL.md": "# Global",
+      ".github/workflows/ci.yml": "name: ci",
+      ".codex/hooks/guard.py": "print('guard')",
+    });
+
+    const result = discoverProjectEvidence({ fileSystem: fs });
+
+    expect(result.assets).toEqual([]);
+    expect(result.diagnostics.map((item) => item.kind)).toContain("unsupported");
+    expect(fs.attempts.every((path) => !path.startsWith("../") && !path.startsWith("/") && !path.startsWith("~"))).toBe(true);
+  });
+
+  it("keeps ambiguous evidence unknown during normalization", () => {
+    const item = normalizeProjectEvidenceItem({
+      path: ".github/prompts/custom.txt",
+      kind: "unknown",
+      content: "custom command",
+    });
+
+    expect(item.kind).toBe("unknown");
+    expect(item.status).toBe("ambiguous");
+  });
+
+  it("reports empty, partial, and unavailable status explicitly", () => {
+    expect(discoverProjectEvidence({ fileSystem: createMemoryFileSystem({}) }).status).toBe("empty");
+
+    expect(
+      discoverProjectEvidence({
+        fileSystem: createMemoryFileSystem({
+          "AGENTS.md": "# Rules",
+          ".codex/hooks.json": new Error("denied"),
+        }),
+      }).status
+    ).toBe("partial");
+
+    expect(
+      discoverProjectEvidence({
+        fileSystem: createMemoryFileSystem({
+          "AGENTS.md": new Error("denied"),
+        }),
+      }).status
+    ).toBe("unavailable");
+  });
+
+  it("converts warning diagnostics into bounded analysis findings", () => {
+    const result = discoverProjectEvidence({
+      fileSystem: createMemoryFileSystem({
+        "AGENTS.md": new Error("denied"),
+      }),
+    });
+
+    const findings = createProjectEvidenceDiagnosticsFindings(result);
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        title: "Provider unreadable evidence: AGENTS.md",
+        issueClass: "provenance",
+        affectedObjectType: "project",
+      }),
+    ]);
+    expect(findings[0]!.whyItMatters).toContain("bounded project evidence provider diagnostic");
+  });
+});

--- a/tests/projectOverview.test.ts
+++ b/tests/projectOverview.test.ts
@@ -233,6 +233,43 @@ describe("deriveProjectOverviewSummary", () => {
     ]);
   });
 
+  it("labels provider-backed local evidence without sample data", () => {
+    const summary = deriveProjectOverviewSummary({
+      assets: [
+        normalizeContextAsset({
+          id: "asset-project-evidence-agents-md",
+          title: "Agents",
+          subtype: "rule",
+          scope: "project",
+          source: "codex",
+          status: "active",
+          provenance: "AGENTS.md (repo-local)",
+          usage: { state: "in_effect", summary: "Repo-local project rule." },
+        }),
+      ],
+      findings: [],
+      sessions: [],
+    });
+
+    expect(summary.identity.evidenceKind).toBe("local-evidence");
+    expect(summary.identity.evidenceLabel).toBe("Derived from explicit local project evidence");
+    expect(summary.contextSnapshot).toContainEqual(expect.objectContaining({
+      id: "assets",
+      value: "1 asset",
+    }));
+  });
+
+  it("keeps empty and unavailable provider evidence from fabricating counts", () => {
+    const empty = deriveProjectOverviewSummary({ assets: [], findings: [], sessions: [] });
+    expect(empty.identity.evidenceKind).toBe("none");
+    expect(empty.contextSnapshot).toContainEqual(expect.objectContaining({ id: "assets", value: "0 assets" }));
+    expect(empty.contextSnapshot).toContainEqual(expect.objectContaining({ id: "analysis", value: "0 findings" }));
+
+    const unavailable = deriveProjectOverviewSummary({ assets: null, findings: null, sessions: [] });
+    expect(unavailable.contextSnapshot).toContainEqual(expect.objectContaining({ id: "assets", value: "Unknown" }));
+    expect(unavailable.contextSnapshot).toContainEqual(expect.objectContaining({ id: "analysis", value: "Unknown" }));
+  });
+
   it("keeps module route descriptors compact and scoped to owning pages", () => {
     const summary = deriveProjectOverviewSummary({
       sessions: [

--- a/tests/projectOverviewSurface.test.tsx
+++ b/tests/projectOverviewSurface.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { ProjectOverviewSurface } from "@/components/ProjectShellClient";
+import { normalizeContextAsset } from "@/lib/contextAssets";
 import { deriveProjectOverviewSummary } from "@/lib/projectOverview";
 
 function renderOverview(summary = deriveProjectOverviewSummary()) {
@@ -92,5 +93,29 @@ describe("ProjectOverviewSurface", () => {
     expect(html).not.toContain("sample data");
     expect(html).not.toContain("command center");
     expect(html).not.toContain("dashboard");
+  });
+
+  it("renders provider-backed counts without sample-data badge", () => {
+    const html = renderOverview(deriveProjectOverviewSummary({
+      assets: [
+        normalizeContextAsset({
+          id: "asset-project-evidence-agents-md",
+          title: "Agents",
+          subtype: "rule",
+          scope: "project",
+          source: "codex",
+          status: "active",
+          provenance: "AGENTS.md (repo-local)",
+          usage: { state: "in_effect", summary: "Repo-local project rule." },
+        }),
+      ],
+      findings: [],
+      sessions: [],
+    }));
+
+    expect(html).toContain("Derived from explicit local project evidence");
+    expect(html).toContain("1 asset");
+    expect(html).toContain("Agents");
+    expect(html).not.toContain("sample data");
   });
 });

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -14,10 +14,12 @@ import {
   buildBackupHandoffFromAssets,
   buildBackupHandoffFromOverview,
   buildBackupHandoffFromSessions,
+  deriveProjectEvidenceOverviewSummary,
   buildExternalSessionSelection,
   resolveInitialProjectShellPage,
   stripSessionViewerSearchParams,
 } from "@/components/ProjectShellClient";
+import type { ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
 import { resolveRoutedWorkflowState } from "@/lib/backupMigration";
 
 describe("resolveInitialProjectShellPage", () => {
@@ -31,6 +33,58 @@ describe("resolveInitialProjectShellPage", () => {
 
   it("opens sessions when a source-scoped URL is present", () => {
     expect(resolveInitialProjectShellPage("?source=windsurf")).toBe("sessions");
+  });
+});
+
+describe("deriveProjectEvidenceOverviewSummary", () => {
+  it("uses provider-backed assets and diagnostics without seed counts", () => {
+    const providerResult: ProjectEvidenceProviderResult = {
+      provider: "project-evidence-provider-v1",
+      status: "available",
+      rootLabel: "repository root",
+      evidenceSource: "repo-local",
+      items: [],
+      assets: [
+        {
+          id: "asset-project-evidence-agents-md",
+          title: "Agents",
+          subtype: "rule",
+          scope: "project",
+          source: "codex",
+          status: "active",
+          provenance: "AGENTS.md (repo-local)",
+          usage: { state: "in_effect", summary: "Repo-local project rule." },
+        },
+      ],
+      diagnostics: [],
+    };
+
+    const summary = deriveProjectEvidenceOverviewSummary(providerResult);
+
+    expect(summary?.identity.evidenceKind).toBe("local-evidence");
+    expect(summary?.contextSnapshot).toContainEqual(expect.objectContaining({
+      id: "assets",
+      value: "1 asset",
+    }));
+    expect(summary?.contextSnapshot).toContainEqual(expect.objectContaining({
+      id: "analysis",
+      value: "0 findings",
+    }));
+  });
+
+  it("keeps unavailable provider state explicit", () => {
+    const summary = deriveProjectEvidenceOverviewSummary({
+      provider: "project-evidence-provider-v1",
+      status: "unavailable",
+      rootLabel: "repository root",
+      evidenceSource: "repo-local",
+      items: [],
+      assets: [],
+      diagnostics: [],
+    });
+
+    expect(summary?.contextSnapshot).toContainEqual(expect.objectContaining({ id: "assets", value: "Unknown" }));
+    expect(summary?.identity.evidenceKind).toBe("none");
   });
 });
 

--- a/tests/windsurfRecoverability.test.ts
+++ b/tests/windsurfRecoverability.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { inferWindsurfRecoverability } from "../src/lib/parse/windsurfRecoverability";
+
+describe("inferWindsurfRecoverability", () => {
+  it("classifies readable trajectories as ls_readable", () => {
+    expect(
+      inferWindsurfRecoverability({
+        trajectoryReadable: true,
+        trajectoryMissing: false,
+        hasSidecarEvidence: false
+      })
+    ).toBe("ls_readable");
+  });
+
+  it("classifies missing trajectories with sidecar evidence as partial", () => {
+    expect(
+      inferWindsurfRecoverability({
+        trajectoryReadable: false,
+        trajectoryMissing: true,
+        hasSidecarEvidence: true
+      })
+    ).toBe("partial");
+  });
+
+  it("classifies missing trajectories without sidecar evidence as unavailable", () => {
+    expect(
+      inferWindsurfRecoverability({
+        trajectoryReadable: false,
+        trajectoryMissing: true,
+        hasSidecarEvidence: false
+      })
+    ).toBe("unavailable");
+  });
+
+  it("returns undefined for non-readable non-missing failures", () => {
+    expect(
+      inferWindsurfRecoverability({
+        trajectoryReadable: false,
+        trajectoryMissing: false,
+        hasSidecarEvidence: true
+      })
+    ).toBeUndefined();
+  });
+});

--- a/tests/windsurfStatus.test.ts
+++ b/tests/windsurfStatus.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from "vitest";
 
+import { extractCsrfTokenMatchFromCommand } from "../src/lib/parse/commandLine";
 import { getWindsurfRecommendedAction, inferWindsurfTokenRequired } from "../src/lib/parse/windsurfStatus";
+
+describe("extractCsrfTokenMatchFromCommand", () => {
+  it("classifies flag-based token discovery as ps_args", () => {
+    expect(extractCsrfTokenMatchFromCommand("language_server --csrf_token 11111111-1111-1111-1111-111111111111")).toEqual({
+      token: "11111111-1111-1111-1111-111111111111",
+      source: "ps_args"
+    });
+  });
+
+  it("classifies env-based token discovery as ps_env", () => {
+    expect(extractCsrfTokenMatchFromCommand("WINDSURF_CSRF_TOKEN=22222222-2222-2222-2222-222222222222 language_server")).toEqual({
+      token: "22222222-2222-2222-2222-222222222222",
+      source: "ps_env"
+    });
+  });
+});
 
 describe("inferWindsurfTokenRequired", () => {
   it("returns false when heartbeat succeeds without token", () => {
@@ -49,8 +66,8 @@ describe("getWindsurfRecommendedAction", () => {
     expect(getWindsurfRecommendedAction({ attached: true, tokenRequired: false })).toBe("Connection healthy.");
   });
 
-  it("maps tokenRequired=true to override guidance", () => {
-    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: true })).toContain("token override");
+  it("maps tokenRequired=true to running-process guidance", () => {
+    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: true })).toContain("running process");
   });
 
   it("maps tokenRequired=false to session restart guidance", () => {


### PR DESCRIPTION
## Summary

This PR implements the `windsurf-legacy-recoverability` change.

### What changed

- add a bounded Windsurf legacy recoverability model:
  - `ls_readable`
  - `partial`
  - `unavailable`
- treat Windsurf `trajectory not found` as data absence instead of a generic transport failure
- extend Windsurf diagnostics with bounded recovery evidence:
  - local `.pb` presence
  - optional `~/.codeium/brain/<cascadeId>` sidecar evidence
- refine Windsurf token-source detection to distinguish:
  - `ps_args`
  - `ps_env`
  - override / discovery-file / none
- update Sessions viewer to keep legacy Windsurf sessions selected and show recoverability-aware messaging
- route recoverability context from Sessions into `Backup / Migration`
- block canonical backup for unreadable legacy Windsurf sessions and warn on partial bounded evidence
- sync and archive the `windsurf-legacy-recoverability` OpenSpec change

## Acceptance notes

Validated against real legacy Windsurf sessions discovered from local roots:

- local legacy `.pb` sessions can still appear in the Sessions list
- some legacy sessions are no longer readable from the live Windsurf LS and return `trajectory not found`
- the UI now distinguishes:
  - unreadable with bounded evidence (`partial`)
  - unreadable without additional evidence (`unavailable`)
- Diagnostic JSON now reflects bounded recoverability evidence without implying:
  - offline transcript reconstruction
  - canonical transcript availability
  - vendor-runtime restoration

## Validation

- `pnpm test -- --run tests/windsurfStatus.test.ts tests/windsurfRecoverability.test.ts`
- `pnpm lint`
- targeted UI / workflow validation completed
- docs updated:
  - `docs/storage/local-storage-notes.md`
  - `docs/viewer/agent-ui-ux-optimization.md`
- OpenSpec synced and archived
