### PR TITLE
feat(project-shell): harden shell identity with bounded real project switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This file records shipped, merged changes for AgentSteward.
 
 ## Unreleased
 
+### Added
+
+- `2026-06-21` — Project shell identity hardening
+  - Shell now displays the active project display name, boundary cue, evidence state, and context asset count from a bounded project identity model
+  - Added a real, bounded project switch using a native `<Select>` dropdown backed by shell-known local project roots
+  - Project list source is `process.cwd()` plus optional `AGENT_STEWARD_PROJECT_ROOTS` environment variable; no separate registry or workspace manager is introduced
+  - On project switch, the shell lands on `Project Overview` and conservatively clears stale routed context (external selection, assets/analysis/backup handoffs, session viewer URL state)
+  - `Sessions` and `GlobalSearch` are now scoped to the active project root via `projectRootPath`; server-side filtering uses session/search `cwd` against the project root
+  - Added `ProjectEvidenceProviderResult.projectName` and canonical `projectKey` for stable project identity equality
+  - Added `src/lib/projectShellProjects.ts`, `src/lib/server/projectShellContext.ts`, `src/lib/server/projectRootFilter.ts`, and test coverage for project normalization, context, and root filtering
+
 ### Changed
 
 - `2026-05-27` — Project renamed from `agent-storage-manager` to `agent-steward`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Optional: override the config file path via env var (useful for local workspace 
 export AGENT_STEWARD_CONFIG_PATH=./.local/config.json
 ```
 
+### Testing multi-project shell switching
+
+To exercise the bounded project switcher with multiple local projects:
+
+```bash
+AGENT_STEWARD_PROJECT_ROOTS="/Users/tr/Workspace/project-a:/Users/tr/Workspace/project-b" pnpm dev
+```
+
+The shell header will display the active project name and boundary, and the project switcher will list the current working directory plus the configured roots. `Sessions` and `GlobalSearch` are scoped to the active project root.
+
 ### Testing multi-root features
 
 To exercise health indicators, duplicate detection, and multi-root listing without real sessions:

--- a/openspec/changes/project-shell-identity-hardening/.openspec.yaml
+++ b/openspec/changes/project-shell-identity-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/project-shell-identity-hardening/conclusion.md
+++ b/openspec/changes/project-shell-identity-hardening/conclusion.md
@@ -1,0 +1,133 @@
+## Acceptance Notes
+
+This change is accepted only as a bounded shell-hardening line.
+
+It does not widen the product subject beyond `Project`, and it does not bundle
+provider-level preservation into the same scope.
+
+## 1. Active Project Identity
+
+The shell should expose a compact but explicit active-project cue.
+
+Minimum required project identity fields:
+
+- project display name
+- project boundary cue
+  - for example: repository root, configured workspace root, or equivalent
+- project evidence state cue
+  - enough to tell whether the shell is showing a resolved project context,
+    loading context, or unavailable/empty context
+
+Not required in the always-visible shell cue:
+
+- full root inventory
+- full source-health table
+- workflow detail
+- asset or session counts
+
+Those remain page-level or expandable detail concerns.
+
+Canonical project identity for this change:
+
+- each switchable project must have a canonical `project_key`
+- `project_key` is derived from the normalized root identity that defines the
+  shell's project boundary for that project
+- project equality for active selection, project switch, and stale-context
+  clearing is determined by `project_key`
+- display name or page-local evidence does not define project equality
+
+## 2. Project Switch Behavior
+
+Project switch is a shell-level context action.
+
+It should behave as follows:
+
+- switching project is explicit, not inferred from page-local filters
+- switching project changes the shell-owned active project, not only local page
+  state
+- the post-switch landing target should be `Project Overview`
+- the shell may preserve only compact shell-safe context that still makes sense
+  for the new project
+
+The real switch in this change may rely only on a bounded project list source,
+derived from the shell's known local project roots already available to the
+app. It must not expand into arbitrary directory picking, generic workspace
+management, repository dedupe logic, or a separate derived project registry.
+
+The switch action should not:
+
+- reopen the previous project's selected session
+- preserve a stale selected asset or finding by default
+- continue an in-progress workflow automatically across projects
+
+## 3. Routed Context Degradation Rules
+
+When project context changes, routed context should degrade conservatively.
+
+### Clear on project switch
+
+These should clear by default when they belong to the old project:
+
+- selected session
+- selected asset
+- selected finding
+- backup / migration handoff
+- page-local issue or return context
+
+Belonging to the old project is determined by `project_key`. If the shell
+cannot cheaply prove that routed context still matches the active `project_key`,
+it should clear rather than guess.
+
+### May persist only if still valid and project-agnostic
+
+These may persist only if they remain meaningful after project change:
+
+- top-level page selection if the destination page is still safe
+- broad non-object filter preferences
+- shell display preferences
+
+If validity cannot be proved cheaply, the shell should clear rather than guess.
+
+## 4. Zero / Unavailable Identity State
+
+When project identity is not yet fully resolved, the shell should still remain
+project-first.
+
+Expected degraded states:
+
+- loading project context
+- no project context
+- unavailable project identity
+
+These states should not cause the shell to fall back to a session-first product
+frame.
+
+## 5. Minimal Implementation Contract
+
+This change may introduce a minimal shell-owned active-project model and
+bounded project identity helpers only as needed to support a real project
+switch.
+
+Expected bounded implementation pieces:
+
+- canonical `project_key` as the shell-owned active project selection state
+- concrete project display name and boundary cue derived from the active
+  project
+- bounded project list source for the switch UI, derived from shell-known local
+  project roots
+- project-scoped page inputs that refresh when the active project changes
+
+## 6. Explicit Non-Goals
+
+This change does not decide:
+
+- provider-level preservation workflows
+- provider-first or dual-scope navigation
+- generic workspace management
+- cross-project sync
+- redesign of `Sessions`, `Assets`, `Analysis`, or `Backup / Migration`
+
+## 7. Follow-Up Readiness
+
+This proposal is ready to hand to an implementation/planning thread only for a
+small shell-hardening slice that stays inside these notes.

--- a/openspec/changes/project-shell-identity-hardening/design.md
+++ b/openspec/changes/project-shell-identity-hardening/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The current shell already exposes project-first top-level navigation, but its
+identity frame is still too implicit. The shell header says what the product is,
+not clearly which project the user is currently governing.
+
+The IA already expected a `Global Project Switch / Project Identity` module, so
+this change is best understood as shell completion rather than a new product
+subject.
+
+## Goals
+
+- Make the active project boundary explicit in the shell.
+- Let users intentionally switch project context.
+- Preserve the meaning of `Project Overview` as the default landing page.
+- Keep routed context safe when project context changes.
+
+## Non-Goals
+
+- No dual `project + provider` top-level governance.
+- No provider-level preservation model.
+- No redesign of `Sessions`, `Assets`, `Analysis`, or `Backup / Migration`.
+- No implementation of a generic workspace manager.
+
+## Implementation Constraints
+
+- A real project switch in this change must be backed by a minimal shell-owned
+  active-project model, not by page-local filters.
+- The shell may use only a bounded project list source derived from shell-known
+  local project roots already available to the app.
+- Each switchable project must expose a canonical `project_key` derived from its
+  normalized root identity. Project equality for switch and stale-context
+  clearing is determined by `project_key`, not display name, source presence, or
+  page-local data.
+- This change may introduce minimal project identity helpers or shell context
+  helpers, but it must not expand into generic project discovery or generic
+  local workspace management.
+
+## Decisions
+
+### Decision 1: Treat project identity as shell state, not as a hidden page detail
+
+The active project should be visible from the shell itself, not only inferred
+from page contents or repo-local evidence blocks.
+
+### Decision 2: Project switching is a bounded shell action
+
+Project switching should be explicit and intentional. It is not equivalent to
+changing a local filter inside `Sessions` or `Assets`.
+
+The real switch action in this change should only switch among a bounded set of
+known shell projects. It should not imply arbitrary directory picking,
+cross-project sync, or generic workspace administration.
+
+For this change, the bounded project list source is the shell's known local
+project roots only. The implementation must not invent a separate derived
+project registry, repository dedupe layer, or workspace manager contract.
+
+### Decision 3: Project change invalidates stale routed context
+
+When the active project changes, shell-owned routed context that no longer
+matches the new project should be cleared or degraded explicitly instead of
+being silently reused.
+
+### Decision 4: This change does not widen the product subject
+
+Even if project switching becomes more explicit, the default product subject
+remains `Project`, not `Provider`, `Session`, or generic local storage.
+
+### Decision 5: Active project state is shell-owned and drives page inputs
+
+The active project should be owned by the shell and should drive project-scoped
+inputs for `Project Overview`, `Sessions`, `Assets`, `Analysis`, and
+`Backup / Migration`.
+
+This does not require a provider-level state model. It only requires a bounded
+project identity source and shell-level project selection.
+
+The minimum active project state for this change is:
+
+- `project_key`
+- display name
+- boundary cue
+- root identity used to load project-scoped inputs

--- a/openspec/changes/project-shell-identity-hardening/proposal.md
+++ b/openspec/changes/project-shell-identity-hardening/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The product already has a project-first shell and treats `Project Overview` as
+the default landing surface, but the shell still does not make the active
+project boundary explicit enough. Users cannot clearly answer which project is
+currently active, nor can they treat project switching as a first-class shell
+action.
+
+Recent exploration in `provider-level-preservation-scope` concluded that this
+is a shell / UX hardening gap first, not evidence that the whole product should
+immediately move to dual `project + provider` governance. This change narrows
+scope to the shell identity problem only.
+
+## What Changes
+
+- Define explicit project identity cues for the app shell.
+- Add a bounded real project-switch entry / flow to the shell.
+- Clarify what happens to routed page context when the active project changes.
+- Define the minimum shell-owned active-project model and bounded project list
+  source needed to support a real project switch.
+- Define canonical project identity equality for switch and stale-context
+  clearing.
+- Keep the product subject project-first.
+- Keep provider-level preservation, dual-scope governance, and broader
+  preservation model changes out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `project-shell`: Adds explicit project identity and project-switch behavior to
+  the existing project-first shell contract.
+
+## Impact
+
+- Shell/navigation behavior only.
+- Expected affected implementation areas later would be:
+  - `ProjectShellClient`
+  - shell-owned active project state
+  - bounded project list / project shell context helpers
+  - shell-level route context handling
+  - any project identity / root summary helpers used by the shell
+- No backup schema, bundle schema, provider-preservation semantics, or
+  top-level IA rewrite is intended in this change.

--- a/openspec/changes/project-shell-identity-hardening/specs/project-shell/spec.md
+++ b/openspec/changes/project-shell-identity-hardening/specs/project-shell/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Project-first app shell
+The system SHALL expose explicit project identity and a bounded project-switch
+action as part of the project-first shell.
+
+#### Scenario: Shell shows active project identity
+- **WHEN** the user is inside the app shell
+- **THEN** the shell exposes an explicit cue describing the currently active
+  project context
+- **AND** the cue is visible without requiring the user to infer project
+  identity from page-local inventory or workflow content
+
+#### Scenario: Shell uses canonical project identity
+- **WHEN** the shell represents an active or switchable project
+- **THEN** that project has a canonical identity key derived from the shell's
+  normalized project root identity
+- **AND** the shell uses that canonical key rather than display name or
+  page-local evidence to determine project equality
+
+#### Scenario: Shell offers bounded project switching
+- **WHEN** more than one project context is available to the app
+- **THEN** the shell provides a bounded project-switch action
+- **AND** project switching is treated as shell-level context change rather than
+  as a local page filter
+
+#### Scenario: Project switch list comes from shell-known local project roots
+- **WHEN** the shell offers project switching
+- **THEN** the switch list is derived from shell-known local project roots
+- **AND** it does not require a separate derived project registry, repository
+  dedupe model, or generic workspace manager contract
+
+#### Scenario: Project switch returns to project-level landing context
+- **WHEN** the user switches to a different active project
+- **THEN** the shell lands the user in a valid project-level context for that
+  project
+- **AND** it does not preserve stale page-local object focus when that focus no
+  longer belongs to the new project
+
+### Requirement: Routed context safety on project change
+The system SHALL degrade or clear shell-owned routed context explicitly when the
+active project changes.
+
+#### Scenario: Stale routed context is cleared on project switch
+- **WHEN** a routed session, asset, finding, or workflow context belongs to the
+  previous project and the user switches projects
+- **THEN** the shell clears or degrades that routed context explicitly
+- **AND** it does not silently replay the previous project's object selection or
+  workflow state inside the new project
+
+#### Scenario: Routed context ownership is evaluated by canonical project identity
+- **WHEN** the shell evaluates whether routed session, asset, finding, or
+  workflow context still belongs to the active project
+- **THEN** it compares the routed context against the active project's canonical
+  identity key
+- **AND** if the shell cannot cheaply prove a match, it clears rather than
+  guessing
+
+#### Scenario: Project switch does not redefine the top-level subject
+- **WHEN** the shell adds explicit project identity and project switching
+- **THEN** the product still treats `Project` as the default top-level subject
+- **AND** it does not imply provider-first governance or a dual overview model

--- a/openspec/changes/project-shell-identity-hardening/tasks.md
+++ b/openspec/changes/project-shell-identity-hardening/tasks.md
@@ -1,0 +1,22 @@
+## 1. Shell identity
+
+- [x] 1.1 Wire a concrete active-project identity model into the shell.
+- [x] 1.2 Render project display name, boundary cue, and evidence state from
+  the active project instead of generic placeholders.
+- [x] 1.3 Support zero / unavailable identity states without falling back to a
+  session-first frame.
+
+## 2. Project switch behavior
+
+- [x] 2.1 Implement a bounded real project-switch entry in the shell.
+- [x] 2.2 Back the switch with a bounded project list source and shell-owned
+  active project state.
+- [x] 2.3 On project switch, land on `Project Overview` and conservatively clear
+  stale routed object/filter/workflow context.
+
+## 3. Validation boundary
+
+- [x] 3.1 Keep the change project-first only.
+- [x] 3.2 Explicitly exclude provider-level preservation and dual-scope
+  governance from this change.
+- [x] 3.3 Run `openspec validate project-shell-identity-hardening --strict`.

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -9,6 +9,7 @@ import { readConfig } from "@/lib/server/config";
 import { detectDuplicates, listConversationFiles } from "@/lib/server/conversations";
 import { inferWindsurfRecoverability } from "@/lib/parse/windsurfRecoverability";
 import { getTrajectoryMetaMapCached } from "@/lib/server/metaCache";
+import { belongsToProjectRoot } from "@/lib/server/projectRootFilter";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -31,6 +32,7 @@ function isSource(value: string | null): value is Source {
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const sourceParam = url.searchParams.get("source");
+  const projectRootPath = url.searchParams.get("projectRootPath");
   if (!isSource(sourceParam)) {
     return NextResponse.json({ error: "Missing/invalid source. Use ?source=antigravity|windsurf|codex|cursor" }, { status: 400 });
   }
@@ -131,8 +133,10 @@ export async function GET(req: Request) {
     };
   }));
 
-  // Re-sort by the effective mtimeMs to ensure proper ordering
-  withMeta.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const projectScopedItems = withMeta.filter((item) => belongsToProjectRoot(item.cwd, projectRootPath));
 
-  return NextResponse.json({ items: withMeta, limit, offset });
+  // Re-sort by the effective mtimeMs to ensure proper ordering
+  projectScopedItems.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  return NextResponse.json({ items: projectScopedItems, limit, offset });
 }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import type { Source } from "@/lib/types";
+import { belongsToProjectRoot } from "@/lib/server/projectRootFilter";
 import { searchSessions } from "@/lib/server/searchIndex";
 
 export const runtime = "nodejs";
@@ -14,6 +15,7 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const q = (url.searchParams.get("q") ?? "").trim();
   const sourceParam = url.searchParams.get("source");
+  const projectRootPath = url.searchParams.get("projectRootPath");
   const limitNum = Number(url.searchParams.get("limit") ?? "20");
   const limit = Number.isNaN(limitNum) ? 20 : Math.min(Math.max(limitNum, 1), 100);
 
@@ -26,6 +28,7 @@ export async function GET(req: Request) {
     if (sourceParam && isSource(sourceParam)) {
       results = results.filter((r) => r.source === sourceParam);
     }
+    results = results.filter((r) => belongsToProjectRoot(r.cwd, projectRootPath));
     return NextResponse.json({ results });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 import ProjectShellClient from "@/components/ProjectShellClient";
-import { getProjectEvidenceProviderResult } from "@/lib/server/projectEvidenceProvider";
+import { getProjectShellContext } from "@/lib/server/projectShellContext";
 
 export const dynamic = "force-dynamic";
 
 export default function Page() {
-  const projectEvidence = getProjectEvidenceProviderResult();
-  return <ProjectShellClient projectEvidence={projectEvidence} />;
+  const projectShellContext = getProjectShellContext();
+  return <ProjectShellClient {...projectShellContext} />;
 }

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -52,11 +52,12 @@ function SnippetHtml({ html }: { html: string }) {
 // ---------------------------------------------------------------------------
 
 export type GlobalSearchProps = {
+  projectRootPath?: string;
   /** Called when the user selects a session from results. */
   onSelect(sessionId: string, source: Source, rootId?: string): void;
 };
 
-export function GlobalSearch({ onSelect }: GlobalSearchProps) {
+export function GlobalSearch({ projectRootPath, onSelect }: GlobalSearchProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
@@ -121,7 +122,9 @@ export function GlobalSearch({ onSelect }: GlobalSearchProps) {
     }
     setLoading(true);
     setError(null);
-    fetch(`/api/search?q=${encodeURIComponent(q)}&limit=20`)
+    const params = new URLSearchParams({ q, limit: "20" });
+    if (projectRootPath) params.set("projectRootPath", projectRootPath);
+    fetch(`/api/search?${params.toString()}`)
       .then((r) => r.json() as Promise<ApiResponse>)
       .then((data) => {
         setResults(data.results ?? []);
@@ -130,7 +133,7 @@ export function GlobalSearch({ onSelect }: GlobalSearchProps) {
       })
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
-  }, []);
+  }, [projectRootPath]);
 
   const handleQueryChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -80,6 +80,7 @@ export type HomeClientSessionHandoff = {
 export type HomeClientProps = {
   chrome?: "full" | "embedded";
   externalSelection?: HomeClientExternalSelection | null;
+  projectRootPath?: string;
   onOpenAssetsForSession?(handoff: HomeClientAssetHandoff): void;
   onOpenAnalysisForSession?(handoff: HomeClientSessionHandoff): void;
   onOpenBackupForSession?(handoff: HomeClientSessionHandoff): void;
@@ -1444,6 +1445,7 @@ function fromSelectionKey(key: string | null): { rootId?: string; id: string } |
 export default function HomeClient({
   chrome = "full",
   externalSelection = null,
+  projectRootPath,
   onOpenAssetsForSession,
   onOpenAnalysisForSession,
   onOpenBackupForSession,
@@ -2110,7 +2112,7 @@ export default function HomeClient({
   // Ref to track the current loadList operation for cancellation
   const loadListAbortRef = useRef<AbortController | null>(null);
 
-  async function loadList(nextSource: Source) {
+  const loadList = useCallback(async (nextSource: Source) => {
     // Cancel any in-flight loadList operation
     if (loadListAbortRef.current) {
       loadListAbortRef.current.abort();
@@ -2122,7 +2124,9 @@ export default function HomeClient({
     setError(null);
     setItems([]);
     try {
-      const res = await fetch(`/api/conversations?source=${nextSource}&limit=200&offset=0`, {
+      const params = new URLSearchParams({ source: nextSource, limit: "200", offset: "0" });
+      if (projectRootPath) params.set("projectRootPath", projectRootPath);
+      const res = await fetch(`/api/conversations?${params.toString()}`, {
         signal: abortController.signal
       });
       // Check if this operation was cancelled by a newer one
@@ -2142,7 +2146,7 @@ export default function HomeClient({
         loadListAbortRef.current = null;
       }
     }
-  }
+  }, [projectRootPath]);
 
   async function loadMoreWindsurfChat() {
     if (!selectedId || source !== "windsurf" || content?.kind !== "chat") return;
@@ -2251,7 +2255,7 @@ export default function HomeClient({
     setWindsurfView("chat");
     setCursorView("transcript");
     setCollapsedExecutionGroups({});
-  }, [source]);
+  }, [source, loadList]);
 
   // When items reloads (e.g. after a source-switch triggered by GlobalSearch),
   // re-derive selectedKey from selectedId so the conversation list highlights

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -12,9 +12,11 @@ import { GlobalSearch } from "@/components/GlobalSearch";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Select } from "@/components/ui/select";
 import type { AnalysisFindingStatus, AnalysisHandoff, AnalysisIssueClass, AnalysisObjectType, AnalysisSeverity } from "@/lib/analysisFindings";
 import type { AssetsHandoff, ContextAssetScope, ContextAssetStatus, ContextAssetSubtype } from "@/lib/contextAssets";
 import { createProjectEvidenceDiagnosticsFindings, type ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
+import type { ShellProject } from "@/lib/projectShellProjects";
 import {
   deriveProjectOverviewSummary,
   type ProjectOverviewAssetSummary,
@@ -768,9 +770,42 @@ function PlaceholderSurface(props: {
   );
 }
 
-export type ProjectShellClientProps = {
-  projectEvidence?: ProjectEvidenceProviderResult | null;
+export type ProjectIdentity = {
+  displayName: string;
+  boundaryCue: string;
+  evidenceState: "loading" | "resolved" | "unavailable" | "empty";
+  assetCount: number;
 };
+
+export type ProjectShellClientProps = {
+  projects: ShellProject[];
+  initialActiveProjectKey: string;
+  projectEvidenceByProjectKey: Record<string, ProjectEvidenceProviderResult>;
+};
+
+export function deriveProjectIdentity(projectEvidence: ProjectEvidenceProviderResult | null | undefined): ProjectIdentity {
+  if (!projectEvidence) {
+    return {
+      displayName: "Loading...",
+      boundaryCue: "Resolving project context",
+      evidenceState: "loading",
+      assetCount: 0,
+    };
+  }
+
+  const evidenceState = projectEvidence.status === "unavailable"
+    ? "unavailable"
+    : projectEvidence.status === "empty"
+      ? "empty"
+      : "resolved";
+
+  return {
+    displayName: projectEvidence.projectName,
+    boundaryCue: projectEvidence.rootLabel,
+    evidenceState,
+    assetCount: projectEvidence.assets.length,
+  };
+}
 
 export function deriveProjectEvidenceOverviewSummary(projectEvidence: ProjectEvidenceProviderResult | null | undefined): ProjectOverviewSummary | undefined {
   if (!projectEvidence) return undefined;
@@ -798,12 +833,20 @@ export function deriveProjectEvidenceOverviewSummary(projectEvidence: ProjectEvi
   });
 }
 
-export default function ProjectShellClient({ projectEvidence }: ProjectShellClientProps) {
+export default function ProjectShellClient({
+  projects,
+  initialActiveProjectKey,
+  projectEvidenceByProjectKey,
+}: ProjectShellClientProps) {
   const [activePage, setActivePage] = useState<ProjectShellPage>("overview");
+  const [activeProjectKey, setActiveProjectKey] = useState(initialActiveProjectKey);
   const [externalSelection, setExternalSelection] = useState<HomeClientExternalSelection | null>(null);
   const [assetsHandoff, setAssetsHandoff] = useState<AssetsHandoff | null>(null);
   const [analysisHandoff, setAnalysisHandoff] = useState<AnalysisHandoff | null>(null);
   const [backupHandoff, setBackupHandoff] = useState<BackupMigrationHandoff | null>(null);
+
+  const activeProject = projects.find((project) => project.projectKey === activeProjectKey) ?? projects[0] ?? null;
+  const projectEvidence = activeProject ? projectEvidenceByProjectKey[activeProject.projectKey] ?? null : null;
 
   const leaveSessionsSurface = useCallback(() => {
     clearSessionViewerUrlState();
@@ -836,6 +879,17 @@ export default function ProjectShellClient({ projectEvidence }: ProjectShellClie
     setBackupHandoff(null);
     setActivePage(page);
   }, [leaveSessionsSurface]);
+
+  const handleProjectSwitch = useCallback((nextProjectKey: string) => {
+    if (nextProjectKey === activeProjectKey) return;
+    leaveSessionsSurface();
+    setExternalSelection(null);
+    setAssetsHandoff(null);
+    setAnalysisHandoff(null);
+    setBackupHandoff(null);
+    setActiveProjectKey(nextProjectKey);
+    setActivePage("overview");
+  }, [activeProjectKey, leaveSessionsSurface]);
 
   const handleOpenAssets = useCallback((handoff: AssetsHandoff) => {
     leaveSessionsSurface();
@@ -988,6 +1042,7 @@ export default function ProjectShellClient({ projectEvidence }: ProjectShellClie
 
   const activeNav = NAV_ITEMS.find((item) => item.id === activePage) ?? NAV_ITEMS[0]!;
   const overviewSummary = deriveProjectEvidenceOverviewSummary(projectEvidence);
+  const projectIdentity = deriveProjectIdentity(projectEvidence);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -1005,10 +1060,56 @@ export default function ProjectShellClient({ projectEvidence }: ProjectShellClie
               </p>
             </div>
             <div className="flex shrink-0 flex-wrap items-center gap-2">
-              <GlobalSearch onSelect={handleSearchSelect} />
+              <GlobalSearch projectRootPath={activeProject?.rootPath} onSelect={handleSearchSelect} />
               <Button asChild variant="outline" size="sm">
                 <Link href="/settings">Settings</Link>
               </Button>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-col gap-3 rounded-xl border border-border/60 bg-background/50 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent/15">
+                <svg className="h-5 w-5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                </svg>
+              </div>
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{projectIdentity.displayName}</span>
+                  <Badge
+                    variant={
+                      projectIdentity.evidenceState === "resolved"
+                        ? "ok"
+                        : projectIdentity.evidenceState === "loading"
+                          ? "default"
+                          : "warn"
+                    }
+                  >
+                    {projectIdentity.evidenceState}
+                  </Badge>
+                </div>
+                <div className="text-xs text-muted">{projectIdentity.boundaryCue}</div>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted">
+                {projectIdentity.assetCount} context asset{projectIdentity.assetCount !== 1 ? "s" : ""}
+              </span>
+              <Select
+                aria-label="Switch active project"
+                className="min-w-56"
+                value={activeProject?.projectKey ?? ""}
+                onChange={(event) => handleProjectSwitch(event.target.value)}
+                disabled={projects.length <= 1}
+                title={projects.length <= 1 ? "Add AGENT_STEWARD_PROJECT_ROOTS to provide more local projects" : "Switch active project"}
+              >
+                {projects.map((project) => (
+                  <option key={project.projectKey} value={project.projectKey}>
+                    {project.projectName}
+                  </option>
+                ))}
+              </Select>
             </div>
           </div>
 
@@ -1054,6 +1155,7 @@ export default function ProjectShellClient({ projectEvidence }: ProjectShellClie
             <HomeClient
               chrome="embedded"
               externalSelection={externalSelection}
+              projectRootPath={activeProject?.rootPath}
               onOpenAssetsForSession={handleOpenAssetsFromSession}
               onOpenAnalysisForSession={handleOpenAnalysisFromSession}
               onOpenBackupForSession={(handoff) => handleOpenBackup(buildBackupHandoffFromSessions(handoff))}

--- a/src/lib/projectEvidenceProvider.ts
+++ b/src/lib/projectEvidenceProvider.ts
@@ -34,6 +34,7 @@ export type ProjectEvidenceDiagnostic = {
 export type ProjectEvidenceProviderResult = {
   provider: "project-evidence-provider-v1";
   status: ProjectEvidenceProviderStatus;
+  projectName: string;
   rootLabel: string;
   evidenceSource: ProjectEvidenceSource;
   items: ProjectEvidenceItem[];
@@ -322,6 +323,7 @@ export function discoverProjectEvidence(input: {
     return {
       provider: "project-evidence-provider-v1",
       status: "unavailable",
+      projectName: input.rootLabel ?? "Current Project",
       rootLabel: input.rootLabel ?? "repository root",
       evidenceSource: "repo-local",
       items: [],
@@ -393,6 +395,7 @@ export function discoverProjectEvidence(input: {
   return {
     provider: "project-evidence-provider-v1",
     status,
+    projectName: input.rootLabel ?? "Current Project",
     rootLabel: input.rootLabel ?? "repository root",
     evidenceSource: "repo-local",
     items,

--- a/src/lib/projectShellProjects.ts
+++ b/src/lib/projectShellProjects.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+
+export type ProjectKey = string;
+
+export type ShellProject = {
+  projectKey: ProjectKey;
+  projectName: string;
+  boundaryCue: string;
+  rootPath: string;
+};
+
+export function normalizeProjectRootIdentity(rootPath: string): string {
+  const resolved = path.resolve(rootPath);
+  const normalized = resolved.replaceAll("\\", "/").replace(/\/+$|^$/g, "");
+  return normalized || "/";
+}
+
+export function buildProjectKey(rootPath: string): ProjectKey {
+  return normalizeProjectRootIdentity(rootPath);
+}
+
+export function buildShellProject(rootPath: string): ShellProject {
+  const normalizedRootPath = normalizeProjectRootIdentity(rootPath);
+  return {
+    projectKey: buildProjectKey(normalizedRootPath),
+    projectName: path.basename(normalizedRootPath) || normalizedRootPath,
+    boundaryCue: normalizedRootPath,
+    rootPath: normalizedRootPath,
+  };
+}
+
+export function dedupeShellProjects(rootPaths: string[]): ShellProject[] {
+  const seen = new Set<ProjectKey>();
+  const projects: ShellProject[] = [];
+
+  for (const rootPath of rootPaths) {
+    const project = buildShellProject(rootPath);
+    if (seen.has(project.projectKey)) continue;
+    seen.add(project.projectKey);
+    projects.push(project);
+  }
+
+  return projects;
+}

--- a/src/lib/server/projectEvidenceProvider.ts
+++ b/src/lib/server/projectEvidenceProvider.ts
@@ -44,6 +44,6 @@ function createRepoFileSystem(rootDir: string): ProjectEvidenceFileSystem {
 export function getProjectEvidenceProviderResult(rootDir = process.cwd()): ProjectEvidenceProviderResult {
   return discoverProjectEvidence({
     fileSystem: createRepoFileSystem(rootDir),
-    rootLabel: "repository root",
+    rootLabel: path.basename(rootDir) || "repository root",
   });
 }

--- a/src/lib/server/projectRootFilter.ts
+++ b/src/lib/server/projectRootFilter.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+
+import { expandHome } from "@/lib/server/paths";
+
+export function normalizeComparablePath(input: string): string {
+  return path.resolve(expandHome(input)).replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+export function belongsToProjectRoot(
+  cwd: string | undefined,
+  projectRootPath: string | null | undefined
+): boolean {
+  if (!projectRootPath) return true;
+  if (!cwd) return false;
+  const normalizedProjectRoot = normalizeComparablePath(projectRootPath);
+  const normalizedCwd = normalizeComparablePath(cwd);
+  return normalizedCwd === normalizedProjectRoot || normalizedCwd.startsWith(`${normalizedProjectRoot}/`);
+}

--- a/src/lib/server/projectShellContext.ts
+++ b/src/lib/server/projectShellContext.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { dedupeShellProjects, type ShellProject } from "@/lib/projectShellProjects";
+import { getProjectEvidenceProviderResult } from "@/lib/server/projectEvidenceProvider";
+import type { ProjectEvidenceProviderResult } from "@/lib/projectEvidenceProvider";
+
+export type ProjectShellContext = {
+  projects: ShellProject[];
+  initialActiveProjectKey: string;
+  projectEvidenceByProjectKey: Record<string, ProjectEvidenceProviderResult>;
+};
+
+function readConfiguredProjectRoots(): string[] {
+  const raw = process.env.AGENT_STEWARD_PROJECT_ROOTS;
+  if (!raw?.trim()) return [];
+  return raw
+    .split(pathListSeparator())
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function pathListSeparator(): string {
+  return process.platform === "win32" ? ";" : ":";
+}
+
+export function getProjectShellContext(defaultRootDir = process.cwd()): ProjectShellContext {
+  const rootPaths = [defaultRootDir, ...readConfiguredProjectRoots()].filter(Boolean);
+  const projects = dedupeShellProjects(rootPaths);
+  const projectEvidenceByProjectKey = Object.fromEntries(
+    projects.map((project) => [project.projectKey, getProjectEvidenceProviderResult(project.rootPath)])
+  );
+  const initialActiveProjectKey = projects[0]?.projectKey ?? "";
+
+  return {
+    projects,
+    initialActiveProjectKey,
+    projectEvidenceByProjectKey,
+  };
+}

--- a/tests/analysisFoundation.test.tsx
+++ b/tests/analysisFoundation.test.tsx
@@ -28,6 +28,7 @@ function createProviderResult(input: Partial<ProjectEvidenceProviderResult>): Pr
   return {
     provider: "project-evidence-provider-v1",
     status: "available",
+    projectName: "agent-storage-manager",
     rootLabel: "repository root",
     evidenceSource: "repo-local",
     items: [],

--- a/tests/assetsFoundation.test.tsx
+++ b/tests/assetsFoundation.test.tsx
@@ -24,6 +24,7 @@ function createProviderResult(input: Partial<ProjectEvidenceProviderResult>): Pr
   return {
     provider: "project-evidence-provider-v1",
     status: "available",
+    projectName: "agent-storage-manager",
     rootLabel: "repository root",
     evidenceSource: "repo-local",
     items: [],

--- a/tests/projectRootFilter.test.ts
+++ b/tests/projectRootFilter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { belongsToProjectRoot, normalizeComparablePath } from "@/lib/server/projectRootFilter";
+
+describe("projectRootFilter", () => {
+  describe("normalizeComparablePath", () => {
+    it("removes trailing slashes", () => {
+      expect(normalizeComparablePath("/tmp/demo/")).toBe("/tmp/demo");
+    });
+
+    it("resolves home directory abbreviation", () => {
+      expect(normalizeComparablePath("~/demo").startsWith("/")).toBe(true);
+      expect(normalizeComparablePath("~/demo").endsWith("/demo")).toBe(true);
+    });
+  });
+
+  describe("belongsToProjectRoot", () => {
+    it("returns true when no project root is provided", () => {
+      expect(belongsToProjectRoot("/tmp/demo/session", null)).toBe(true);
+      expect(belongsToProjectRoot("/tmp/demo/session", undefined)).toBe(true);
+    });
+
+    it("returns false when cwd is missing", () => {
+      expect(belongsToProjectRoot(undefined, "/tmp/demo")).toBe(false);
+    });
+
+    it("matches exact project root", () => {
+      expect(belongsToProjectRoot("/tmp/demo", "/tmp/demo")).toBe(true);
+    });
+
+    it("matches a child directory of the project root", () => {
+      expect(belongsToProjectRoot("/tmp/demo/subdir", "/tmp/demo")).toBe(true);
+    });
+
+    it("does not match a sibling directory", () => {
+      expect(belongsToProjectRoot("/tmp/demo-other", "/tmp/demo")).toBe(false);
+    });
+
+    it("does not match a prefix that is not a child path", () => {
+      expect(belongsToProjectRoot("/tmp/demo2", "/tmp/demo")).toBe(false);
+    });
+  });
+});

--- a/tests/projectShellClient.test.ts
+++ b/tests/projectShellClient.test.ts
@@ -15,6 +15,7 @@ import {
   buildBackupHandoffFromOverview,
   buildBackupHandoffFromSessions,
   deriveProjectEvidenceOverviewSummary,
+  deriveProjectIdentity,
   buildExternalSessionSelection,
   resolveInitialProjectShellPage,
   stripSessionViewerSearchParams,
@@ -41,6 +42,7 @@ describe("deriveProjectEvidenceOverviewSummary", () => {
     const providerResult: ProjectEvidenceProviderResult = {
       provider: "project-evidence-provider-v1",
       status: "available",
+      projectName: "agent-storage-manager",
       rootLabel: "repository root",
       evidenceSource: "repo-local",
       items: [],
@@ -76,6 +78,7 @@ describe("deriveProjectEvidenceOverviewSummary", () => {
     const summary = deriveProjectEvidenceOverviewSummary({
       provider: "project-evidence-provider-v1",
       status: "unavailable",
+      projectName: "agent-storage-manager",
       rootLabel: "repository root",
       evidenceSource: "repo-local",
       items: [],
@@ -85,6 +88,26 @@ describe("deriveProjectEvidenceOverviewSummary", () => {
 
     expect(summary?.contextSnapshot).toContainEqual(expect.objectContaining({ id: "assets", value: "Unknown" }));
     expect(summary?.identity.evidenceKind).toBe("none");
+  });
+});
+
+describe("deriveProjectIdentity", () => {
+  it("uses the active project display name and root boundary", () => {
+    expect(deriveProjectIdentity({
+      provider: "project-evidence-provider-v1",
+      status: "available",
+      projectName: "agent-storage-manager",
+      rootLabel: "/Users/tr/Workspace/agent-storage-manager",
+      evidenceSource: "repo-local",
+      items: [],
+      assets: [],
+      diagnostics: [],
+    })).toEqual({
+      displayName: "agent-storage-manager",
+      boundaryCue: "/Users/tr/Workspace/agent-storage-manager",
+      evidenceState: "resolved",
+      assetCount: 0,
+    });
   });
 });
 

--- a/tests/projectShellContext.test.ts
+++ b/tests/projectShellContext.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { getProjectShellContext } from "@/lib/server/projectShellContext";
+
+describe("getProjectShellContext", () => {
+  it("returns empty state when no roots are available", () => {
+    const context = getProjectShellContext("");
+
+    expect(context.projects).toEqual([]);
+    expect(context.initialActiveProjectKey).toBe("");
+    expect(context.projectEvidenceByProjectKey).toEqual({});
+  });
+
+  it("uses the default root as the active project when no extra roots are configured", () => {
+    const context = getProjectShellContext("/tmp/demo-project");
+
+    expect(context.projects).toHaveLength(1);
+    expect(context.projects[0]).toEqual(
+      expect.objectContaining({
+        projectKey: "/tmp/demo-project",
+        projectName: "demo-project",
+        rootPath: "/tmp/demo-project",
+      })
+    );
+    expect(context.initialActiveProjectKey).toBe("/tmp/demo-project");
+    expect(context.projectEvidenceByProjectKey).toHaveProperty("/tmp/demo-project");
+  });
+});

--- a/tests/projectShellProjects.test.ts
+++ b/tests/projectShellProjects.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProjectKey, buildShellProject, dedupeShellProjects, normalizeProjectRootIdentity } from "@/lib/projectShellProjects";
+
+describe("projectShellProjects", () => {
+  it("normalizes root identity into a canonical project key", () => {
+    expect(normalizeProjectRootIdentity("/tmp/demo/")) .toBe("/tmp/demo");
+    expect(buildProjectKey("/tmp/demo")).toBe("/tmp/demo");
+  });
+
+  it("builds shell project identity from a root path", () => {
+    expect(buildShellProject("/tmp/demo-project")).toEqual({
+      projectKey: "/tmp/demo-project",
+      projectName: "demo-project",
+      boundaryCue: "/tmp/demo-project",
+      rootPath: "/tmp/demo-project",
+    });
+  });
+
+  it("dedupes equivalent root paths by canonical project key", () => {
+    expect(dedupeShellProjects(["/tmp/demo", "/tmp/demo/"])).toEqual([
+      {
+        projectKey: "/tmp/demo",
+        projectName: "demo",
+        boundaryCue: "/tmp/demo",
+        rootPath: "/tmp/demo",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens the project shell identity surface:

- Displays the active project display name, boundary cue, evidence state, and asset count.
- Adds a real, bounded project switch using a native `<Select>` dropdown.
- Scopes `Sessions` and `GlobalSearch` to the active project root.
- Clears stale routed context on project switch and lands on `Project Overview`.

## Project roots source

The bounded project list is derived from:

1. `process.cwd()` (default active project)
2. `AGENT_STEWARD_PROJECT_ROOTS` env var (optional additional roots, `:` separated on macOS/Linux)

No separate registry or workspace manager is introduced.

## Scope boundaries

- Project-first only.
- Does not add provider-level preservation or dual-scope governance.
- Does not generalize Backup / Migration into a generic tools drawer.

## Validation

- `pnpm exec tsc --noEmit` ✅
- `pnpm test` ✅ (81 relevant tests)
- `openspec validate project-shell-identity-hardening --strict` ✅
- `pnpm lint` ✅

## Related

- OpenSpec change: `openspec/changes/project-shell-identity-hardening`
- CHANGELOG.md updated under `## Unreleased`.