### PR TITLE
fix: Devin compatibility MVP — asset discovery, wording, and LS attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file records shipped, merged changes for AgentSteward.
   - New `ContextAssetSource` value `"devin"` for `.devin/` assets; `"windsurf"` remains for `.windsurf/` assets
   - Diagnostics and user-facing wording corrected: product references use `Windsurf` or `Devin` separately (no compound labels); runtime/session references use `Cascade` (not "legacy Cascade")
   - Session reading still targets the Windsurf (Cascade) LS; no new Devin local session storage parsing
+  - Cascade LS attach now searches both Windsurf and Devin log paths (`~/Library/Application Support/Windsurf/logs/` and `~/Library/Application Support/Devin/logs/`) and both `Windsurf.log` and `Devin.log` file names, enabling session reading when only Devin Desktop is running
 - `2026-06-21` — Project shell identity hardening
   - Shell now displays the active project display name, boundary cue, evidence state, and context asset count from a bounded project identity model
   - Added a real, bounded project switch using a native `<Select>` dropdown backed by shell-known local project roots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This file records shipped, merged changes for AgentSteward.
 
 ### Added
 
+- `2026-06-21` — Devin compatibility MVP
+  - Project evidence discovery now recognizes `.devin/` directories (skills, rules, workflows, plans, hooks) alongside legacy `.windsurf/` directories
+  - New `ContextAssetSource` value `"devin"` for `.devin/` assets; `"windsurf"` remains for `.windsurf/` assets
+  - Diagnostics and user-facing wording corrected: product references use `Windsurf` or `Devin` separately (no compound labels); runtime/session references use `Cascade` (not "legacy Cascade")
+  - Session reading still targets the Windsurf (Cascade) LS; no new Devin local session storage parsing
 - `2026-06-21` — Project shell identity hardening
   - Shell now displays the active project display name, boundary cue, evidence state, and context asset count from a bounded project identity model
   - Added a real, bounded project switch using a native `<Select>` dropdown backed by shell-known local project roots

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See `docs/storage/local-storage-notes.md` § "Multi-root testing" for details.
   - `Analysis` provides a bounded interpretation-and-routing foundation for local context findings
   - `Backup / Migration` provides bounded workflow-first backup and migration-preview surfaces without turning into a generic tools drawer or migration apply UI
 - Assets foundation:
-  - repo-local project evidence provider for explicit agent-facing files: `AGENTS.md`, Copilot instructions/prompts/skills, Codex skills/agents/hooks, cross-agent `.agents` / `.agent` skills, Windsurf skills/rules/workflows/hooks, and Cursor repo-local files such as `.cursor/mcp.json`, `.cursorrules`, and `.cursor/rules/*.mdc`
+  - repo-local project evidence provider for explicit agent-facing files: `AGENTS.md`, Copilot instructions/prompts/skills, Codex skills/agents/hooks, cross-agent `.agents` / `.agent` skills, Windsurf skills/rules/workflows/hooks (`.windsurf/`), Devin skills/rules/workflows/plans/hooks (`.devin/`), and Cursor repo-local files such as `.cursor/mcp.json`, `.cursorrules`, and `.cursor/rules/*.mdc`
   - local-first reusable context asset model with subtype, scope, source, status, provenance, optional body summary, in-effect/usage metadata, and derived governance health
   - provider-backed inventory uses project-relative provenance paths and does not read user-global runtime stores, external paths, cloud sources, session transcript stores, or paths outside the repository root
   - subtype/scope/source/status filtering with asset summary, governance issue class counts, inventory, selected detail, provenance, and in-effect/usage regions
@@ -141,6 +141,7 @@ For detailed view semantics and cross-source alignment notes, see `docs/viewer/t
   - Legacy fallback: `~/.gemini/antigravity/daemon/ls_*.json` (may be stale on newer builds).
 - Antigravity: for conversation list `title/cwd`, this app reads `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb` (VS Code global state) locally.
 - Windsurf: Windsurf must be running (and have started a Cascade session at least once). This app parses the language-server port from Windsurf logs and tries to read `--csrf_token` from process args.
+  - **Devin** is the rebranded product name for Windsurf. Project-local assets in `.devin/` directories are discovered alongside legacy `.windsurf/` directories; session reading still targets the Windsurf (Cascade) LS and has not been validated against Devin Local or Devin Cloud runtimes.
   - On current Windsurf builds, the live token may be present in the LS process environment as `WINDSURF_CSRF_TOKEN`, so this app prefers `ps eww` output when available.
   - Manual fallback: set `csrfTokenOverride` in Settings, but only if you obtained the live LS token from the running Windsurf process/session.
   - Do not use `codeium.windsurf-windsurf_auth-` from `~/Library/Application Support/Windsurf/User/globalStorage/state.vscdb`; that UUID is not the LS CSRF token on current Windsurf builds.

--- a/docs/storage/local-storage-notes.md
+++ b/docs/storage/local-storage-notes.md
@@ -79,6 +79,128 @@
 - `.devin/` assets 使用 `source: "devin"`（显示 `Devin`）；`.windsurf/` assets 使用 `source: "windsurf"`（显示 `Windsurf`）。
 - 诊断文案中：产品层用 `Windsurf`（指 IDE/LS 进程），runtime 层用 `Cascade`（指 session/trajectory）；不使用复合标签。
 
+### Devin Desktop 存储调查（2026-06-21 实测）
+
+#### 产品迁移
+
+- `~/Library/Application Support/Devin/.devin-migration-complete` 记录了从 Windsurf 迁移到 Devin 的事实：
+  - `migratedAt`: `2026-06-04T04:30:49.135Z`
+  - `fromDir`: `~/Library/Application Support/Windsurf`
+  - `version`: `1.110.1`
+- 迁移后 `~/Library/Application Support/Windsurf/` 仍存在（旧数据未删除）。
+
+#### Devin Desktop — Cascade runtime（与 Windsurf 完全一致）
+
+- **LS 进程**：`/Applications/Devin.app/Contents/Resources/app/extensions/windsurf/bin/language_server_macos_arm`
+  - `--ide_name windsurf`（未改为 devin）
+  - `--codeium_dir .codeium/windsurf`
+  - `--extensions_dir ~/.devin/extensions`（唯一差异：扩展目录改为 `.devin/`）
+  - `--windsurf_version 3.2.23`
+- **CSRF token**：环境变量名仍为 `WINDSURF_CSRF_TOKEN`（未改名）。
+- **LS 日志**：`~/Library/Application Support/Devin/logs/<timestamp>/window*/exthost/codeium.windsurf/Devin.log`
+  - 格式与 `Windsurf.log` 完全一致：包含 `Starting language server process with pid <N>` 和 `Language server listening on random port at <PORT>`。
+  - **Agent Steward 现有 attach 逻辑可直接适配**：只需将日志搜索路径从 `Windsurf.log` 扩展到 `Devin.log`。
+- **Session 文件**：仍在 `~/.codeium/windsurf/cascade/*.pb`（50 个 `.pb` 文件实测存在）。
+- **globalStorage**：`~/Library/Application Support/Devin/User/globalStorage/state.vscdb`（与 Windsurf 结构一致）。
+
+#### Devin Desktop — Devin Local runtime（ACP 协议）
+
+- **不是 LS RPC**，而是 ACP（Agent Control Protocol）。
+- 日志：`~/Library/Application Support/Devin/logs/<timestamp>/window*/exthost/codeium.windsurf/Devin ACP devin-cli.log`
+- 进程：`/Applications/Devin.app/Contents/Resources/app/extensions/windsurf/devin/bin/devin acp`
+- 版本：`chisel version=2026.7.23`
+- Session 存储：**Devin CLI SQLite 数据库** `~/.local/share/devin/cli/sessions.db`（144MB，24 sessions，18002 message_nodes）。
+
+#### Devin Desktop — Devin Cloud runtime（远程 WebSocket ACP）
+
+- 日志：`~/Library/Application Support/Devin/logs/<timestamp>/window*/exthost/codeium.windsurf/Devin ACP devin-cloud.log`
+- 连接：`wss://app.devin.ai/api/acp/live`（远程，session 不落本地）。
+- **本地无可解析的 session 存储**。
+
+#### Devin CLI session 数据库 schema（`~/.local/share/devin/cli/sessions.db`）
+
+```sql
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,              -- 人类可读名称，如 "stingy-print"
+  working_directory TEXT NOT NULL,
+  backend_type TEXT NOT NULL,       -- 实测值: "Windsurf" / "windsurf"
+  model TEXT NOT NULL,              -- 实测值: "kimi-k2-6", "gpt-5-4-low", "swe-1-6-fast", "adaptive"
+  agent_mode TEXT NOT NULL,         -- 实测值: "normal", "bypass", "accept-edits"
+  created_at INTEGER NOT NULL,      -- Unix epoch ms
+  last_activity_at INTEGER NOT NULL,
+  title TEXT,
+  main_chain_id INTEGER,
+  shell_last_seen_index INTEGER DEFAULT 0,
+  cogs_json TEXT,
+  workspace_dirs TEXT,
+  hidden INTEGER NOT NULL DEFAULT 0,
+  metadata TEXT
+);
+
+CREATE TABLE message_nodes (
+  row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  node_id INTEGER NOT NULL,         -- session 内的 node 编号
+  parent_node_id INTEGER,           -- NULL = root
+  chat_message TEXT NOT NULL,       -- JSON: {message_id, role, content, ...}
+  created_at INTEGER NOT NULL,
+  metadata TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id),
+  UNIQUE(session_id, node_id)
+);
+
+CREATE TABLE prompt_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  content TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  session_id TEXT NOT NULL,
+  is_shell INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE rendered_commits (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  sequence_number INTEGER NOT NULL,
+  rendered_html TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE tool_call_state (
+  session_id TEXT NOT NULL,
+  tool_call_id TEXT NOT NULL,
+  tool_call_json TEXT,
+  tool_call_update_json TEXT,
+  PRIMARY KEY (session_id, tool_call_id)
+);
+```
+
+- `chat_message` 是 JSON 字符串，包含 `role`（`system`/`user`/`assistant`/`tool`）、`content`、`message_id`、可选 `tool_call_id` 等字段。
+- `backend_type` 实测只有 `Windsurf`/`windsurf` — 说明 Devin CLI 的 session 目前全部通过 Cascade runtime 产生，Devin Local 和 Devin Cloud 的 session 可能尚未被记录或使用不同的存储路径。
+- Summaries 目录 `~/.local/share/devin/cli/summaries/` 包含 `history_<sessionId>.md` 文件，是会话的 markdown 摘要。
+
+#### Devin CLI 其他路径
+
+| 路径 | 用途 |
+|------|------|
+| `~/.config/devin/config.json` | Devin CLI 配置 |
+| `~/.config/devin/credentials.toml` | Devin CLI 凭据 |
+| `~/.local/share/devin/cli/sessions.db` | Session 数据库 |
+| `~/.local/share/devin/cli/summaries/` | Session markdown 摘要 |
+| `~/.local/share/devin/cli/transcripts/` | Transcripts（实测为空） |
+| `~/.local/share/devin/cli/session_locks/` | Session 锁文件 |
+| `~/.local/share/devin/cli/logs/` | CLI 日志 |
+| `~/.local/share/devin/cli/trusted_workspaces.json` | 信任的工作目录列表 |
+| `~/.local/bin/devin` | Devin CLI 二进制 |
+| `~/.devin/argv.json` | Devin Desktop 启动参数 |
+| `~/.devin/extensions/` | Devin Desktop 扩展目录 |
+| `~/.cache/devin/` | Devin 缓存 |
+
+#### 对 Agent Steward 的影响
+
+1. **Cascade session reading**：现有 Windsurf attach 逻辑可直接适配 Devin Desktop — LS 进程相同，CSRF token 环境变量名相同，session `.pb` 文件路径相同。唯一需要扩展的是日志搜索路径（`Windsurf.log` → 也搜索 `Devin.log`）。
+2. **Devin CLI sessions.db**：是一个独立的、可直接读取的 SQLite 数据库，不需要 live LS 进程。schema 已记录，可作为后续 Devin Local session reading 的基础。
+3. **Devin Cloud**：session 不落本地，当前无法解析。
+
 建议验证命令：
 
 ```bash

--- a/docs/storage/local-storage-notes.md
+++ b/docs/storage/local-storage-notes.md
@@ -100,7 +100,11 @@
 - **LS 日志**：`~/Library/Application Support/Devin/logs/<timestamp>/window*/exthost/codeium.windsurf/Devin.log`
   - 格式与 `Windsurf.log` 完全一致：包含 `Starting language server process with pid <N>` 和 `Language server listening on random port at <PORT>`。
   - **Agent Steward 现有 attach 逻辑可直接适配**：只需将日志搜索路径从 `Windsurf.log` 扩展到 `Devin.log`。
-- **Session 文件**：仍在 `~/.codeium/windsurf/cascade/*.pb`（50 个 `.pb` 文件实测存在）。
+- **Session 文件**：仍在 `~/.codeium/windsurf/cascade/*.pb`（与 Windsurf 共享同一目录）。
+- **关键发现**：`.pb` 文件本身在 Windsurf 和 Devin Desktop 之间共享，但 session 的 `title/cwd/lastActivity` 等元数据各自写入各自 IDE 的 `state.vscdb`：
+  - Windsurf 元数据：`~/Library/Application Support/Windsurf/User/globalStorage/state.vscdb`
+  - Devin Desktop 元数据：`~/Library/Application Support/Devin/User/globalStorage/state.vscdb`
+  - 因此：在 Devin IDE 中创建的 Cascade session，其 `.pb` 文件会立即出现在共享目录，但 Windsurf UI 因读取自己的 `state.vscdb` 而可能暂时不显示该 session；反之亦然。
 - **globalStorage**：`~/Library/Application Support/Devin/User/globalStorage/state.vscdb`（与 Windsurf 结构一致）。
 
 #### Devin Desktop — Devin Local runtime（ACP 协议）
@@ -175,13 +179,14 @@ CREATE TABLE tool_call_state (
 ```
 
 - `chat_message` 是 JSON 字符串，包含 `role`（`system`/`user`/`assistant`/`tool`）、`content`、`message_id`、可选 `tool_call_id` 等字段。
-- `backend_type` 实测只有 `Windsurf`/`windsurf` — 说明 Devin CLI 的 session 目前全部通过 Cascade runtime 产生，Devin Local 和 Devin Cloud 的 session 可能尚未被记录或使用不同的存储路径。
+- `backend_type` 实测只有 `Windsurf`/`windsurf`（大小写差异）— 说明当前 `sessions.db` 中记录的 session 全部通过 Cascade runtime 产生。
+- **Devin Local runtime 的 session 尚未出现在 `sessions.db` 中**：用户选择 Agent Runtime = Devin Local 创建的 session，在 Agent Steward 的 Windsurf root 和 Devin CLI `sessions.db` 中均未出现，说明其存储路径尚未定位（可能使用不同的 SQLite 文件或尚未落盘）。
 - Summaries 目录 `~/.local/share/devin/cli/summaries/` 包含 `history_<sessionId>.md` 文件，是会话的 markdown 摘要。
 
 #### Devin CLI 其他路径
 
 | 路径 | 用途 |
-|------|------|
+| --- | --- |
 | `~/.config/devin/config.json` | Devin CLI 配置 |
 | `~/.config/devin/credentials.toml` | Devin CLI 凭据 |
 | `~/.local/share/devin/cli/sessions.db` | Session 数据库 |
@@ -197,7 +202,7 @@ CREATE TABLE tool_call_state (
 
 #### 对 Agent Steward 的影响
 
-1. **Cascade session reading**：现有 Windsurf attach 逻辑可直接适配 Devin Desktop — LS 进程相同，CSRF token 环境变量名相同，session `.pb` 文件路径相同。唯一需要扩展的是日志搜索路径（`Windsurf.log` → 也搜索 `Devin.log`）。
+1. **Cascade session reading**：现有 Windsurf attach 逻辑可直接适配 Devin Desktop — LS 进程相同，CSRF token 环境变量名相同，session `.pb` 文件路径相同。唯一需要扩展的是日志搜索路径（`Windsurf.log` → 也搜索 `Devin.log`）。注意：若要让 Agent Steward 显示在 Devin IDE 中创建的 Cascade session 的标题，需要同时读取 `Devin/User/globalStorage/state.vscdb` 中的元数据。
 2. **Devin CLI sessions.db**：是一个独立的、可直接读取的 SQLite 数据库，不需要 live LS 进程。schema 已记录，可作为后续 Devin Local session reading 的基础。
 3. **Devin Cloud**：session 不落本地，当前无法解析。
 

--- a/docs/storage/local-storage-notes.md
+++ b/docs/storage/local-storage-notes.md
@@ -71,6 +71,14 @@
   - `unavailable`：LS 返回 `trajectory not found`，且没有额外 bounded evidence
 - `partial` / `unavailable` 只用于 diagnostics、Sessions viewer 与 Backup / Migration handoff；**不表示可以离线重建 canonical transcript**。
 
+### Devin compatibility MVP（2026-06-21）
+
+- **Devin** 是 Windsurf 的品牌更名；产品同时支持 Cascade、Devin Local、Devin Cloud 三个 agent runtime。
+- Agent Steward 的 session reading 仍只针对 Windsurf (Cascade) LS；**未解析新的 Devin 本地会话存储**。
+- 项目资产发现已扩展：`.devin/` 目录（skills、rules、workflows、plans、hooks）与 `.windsurf/` 并行识别。
+- `.devin/` assets 使用 `source: "devin"`（显示 `Devin`）；`.windsurf/` assets 使用 `source: "windsurf"`（显示 `Windsurf`）。
+- 诊断文案中：产品层用 `Windsurf`（指 IDE/LS 进程），runtime 层用 `Cascade`（指 session/trajectory）；不使用复合标签。
+
 建议验证命令：
 
 ```bash

--- a/openspec/.markdownlint.json
+++ b/openspec/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "MD013": false,
+  "MD022": false,
+  "MD024": false,
+  "MD025": false,
+  "MD032": false,
+  "MD041": false
+}

--- a/src/components/BackupMigrationFoundation.tsx
+++ b/src/components/BackupMigrationFoundation.tsx
@@ -97,9 +97,11 @@ function buildSessionBackupValidation(input: {
     return [
       {
         id: "v-windsurf-unavailable",
-        label: "Canonical Windsurf content unavailable",
+        label: "Canonical Cascade content unavailable",
         severity: "block",
-        detail: input.recoverabilityNote ?? "The running Windsurf LS no longer has this trajectory, so canonical session backup cannot be generated from readable content.",
+        detail:
+          input.recoverabilityNote ??
+          "The running Windsurf LS no longer has this trajectory, so canonical session backup cannot be generated from readable content.",
       },
       {
         id: "v-windsurf-local-evidence",
@@ -121,7 +123,7 @@ function buildSessionBackupValidation(input: {
             severity: "warning" as const,
             detail:
               input.recoverabilityNote ??
-              "Bounded recovery evidence exists for this Windsurf session, but it does not imply vendor-runtime restoration or transcript reconstruction.",
+              "Bounded recovery evidence exists for this Windsurf Cascade session, but it does not imply vendor-runtime restoration or transcript reconstruction.",
           },
         ]
       : [];
@@ -1727,8 +1729,8 @@ export function BackupMigrationFoundation({
                   <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-3 py-3 text-sm text-amber-900 dark:text-amber-200">
                     <div className="font-medium">
                       {selectedRecoverability === "unavailable"
-                        ? "Canonical Windsurf content is unavailable"
-                        : "This Windsurf session carries bounded recovery evidence"}
+                        ? "Canonical Cascade content is unavailable"
+                        : "This Cascade session carries bounded recovery evidence"}
                     </div>
                     <div className="mt-1 text-xs leading-5 opacity-90">
                       {selectedRecoverabilityNote ??

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -1557,15 +1557,19 @@ export default function HomeClient({
     if (selectedItem.recoverability === "unavailable") {
       return {
         tone: "danger" as const,
-        title: "Legacy Windsurf session is not readable from the running LS.",
-        message: selectedItem.recoverabilityNote ?? "The local session file was discovered, but the running Windsurf LS no longer has this trajectory.",
+        title: "Cascade session is not readable from the running Windsurf LS.",
+        message:
+          selectedItem.recoverabilityNote ??
+          "The local session file was discovered, but the running Windsurf LS no longer has this trajectory.",
       };
     }
     if (selectedItem.recoverability === "partial") {
       return {
         tone: "warning" as const,
-        title: "Legacy Windsurf session has bounded recovery evidence.",
-        message: selectedItem.recoverabilityNote ?? "Some recoverability evidence may exist even though the full session is not guaranteed to be readable from the running Windsurf LS.",
+        title: "Cascade session has bounded recovery evidence.",
+        message:
+          selectedItem.recoverabilityNote ??
+          "Some recoverability evidence may exist even though the full session is not guaranteed to be readable from the running Windsurf LS.",
       };
     }
     return null;

--- a/src/components/ProjectShellClient.tsx
+++ b/src/components/ProjectShellClient.tsx
@@ -350,7 +350,7 @@ export function buildBackupHandoffFromSessions(context: {
     subtitle: `Back up session ${context.sessionId} from Sessions.`,
     continueLabel:
       context.recoverability && context.recoverability !== "ls_readable"
-        ? "Review recoverability evidence before attempting preservation for this Windsurf session."
+        ? "Review recoverability evidence before attempting preservation for this Cascade session."
         : "Use the session backup workflow to preserve this session record.",
     returnLabel: "Return to the originating session for evidence review.",
     workflowType: "session-backup",

--- a/src/components/SettingsClient.tsx
+++ b/src/components/SettingsClient.tsx
@@ -201,10 +201,10 @@ export default function SettingsClient() {
       ) : null}
 
       <Card className="mb-4 p-3">
-        <div className="mb-2 text-sm font-semibold">Windsurf token override (fallback)</div>
+        <div className="mb-2 text-sm font-semibold">Windsurf token override (Cascade fallback)</div>
         <div className="mb-3 text-xs text-muted">
-          Attach mode prefers reading <span className="font-mono">--csrf_token</span> from the Windsurf LS process.
-          If that fails on your system, you can paste the token here.
+          Attach mode prefers reading <span className="font-mono">--csrf_token</span> from the running Cascade LS process.
+          If that fails on your system, you can paste the Windsurf token here.
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <Input

--- a/src/lib/contextAssets.ts
+++ b/src/lib/contextAssets.ts
@@ -2,7 +2,7 @@ import type { Source } from "@/lib/types";
 
 export const CONTEXT_ASSET_SUBTYPES = ["rule", "memory", "skill", "command", "unknown"] as const;
 export const CONTEXT_ASSET_SCOPES = ["global", "user", "project", "unknown"] as const;
-export const CONTEXT_ASSET_SOURCES = ["antigravity", "windsurf", "codex", "cursor", "imported", "generated", "unknown"] as const;
+export const CONTEXT_ASSET_SOURCES = ["antigravity", "windsurf", "devin", "codex", "cursor", "imported", "generated", "unknown"] as const;
 export const CONTEXT_ASSET_STATUSES = ["active", "stale", "conflicted", "orphaned", "archived", "unknown"] as const;
 
 export type ContextAssetSubtype = (typeof CONTEXT_ASSET_SUBTYPES)[number];
@@ -493,6 +493,7 @@ export function formatContextAssetStatusLabel(status: ContextAssetStatus): strin
 export function formatContextAssetSourceLabel(source: ContextAssetSource): string {
   if (source === "antigravity") return "Antigravity";
   if (source === "windsurf") return "Windsurf";
+  if (source === "devin") return "Devin";
   if (source === "codex") return "Codex";
   if (source === "cursor") return "Cursor";
   if (source === "unknown") return "Unknown";

--- a/src/lib/parse/windsurfStatus.ts
+++ b/src/lib/parse/windsurfStatus.ts
@@ -18,7 +18,11 @@ export function getWindsurfRecommendedAction(params: {
   const { attached, tokenRequired } = params;
 
   if (attached) return "Connection healthy.";
-  if (tokenRequired === true) return "Set Windsurf CSRF token override in Settings if the live LS token cannot be read from the running process.";
-  if (tokenRequired === false) return "Keep Windsurf open and start/restart a Cascade session, then refresh.";
-  return "CSRF token may be invalid or expired. First try refreshing the override token in Settings; if that fails, restart a Cascade session.";
+  if (tokenRequired === true) {
+    return "Set Windsurf CSRF token override in Settings if the live Cascade LS token cannot be read from the running process.";
+  }
+  if (tokenRequired === false) {
+    return "Keep Windsurf open and start/restart a Cascade session, then refresh.";
+  }
+  return "CSRF token may be invalid or expired. First try refreshing the Windsurf override token in Settings; if that fails, restart a Cascade session.";
 }

--- a/src/lib/projectEvidenceProvider.ts
+++ b/src/lib/projectEvidenceProvider.ts
@@ -64,6 +64,7 @@ const FIXED_EVIDENCE = [
   { path: ".github/copilot-instructions.md", kind: "rule", source: "unknown" },
   { path: ".codex/hooks.json", kind: "command", source: "codex" },
   { path: ".windsurf/hooks.json", kind: "command", source: "windsurf" },
+  { path: ".devin/hooks.json", kind: "command", source: "devin" },
   { path: ".cursor/mcp.json", kind: "command", source: "cursor" },
   { path: ".cursorrules", kind: "rule", source: "cursor" },
 ] satisfies Array<{ path: string; kind: ProjectEvidenceKind; source: ContextAssetSource }>;
@@ -81,6 +82,11 @@ const DIRECTORY_EVIDENCE = [
   { base: ".windsurf/rules", recursive: false, kind: "rule", source: "windsurf", extension: ".md" },
   { base: ".windsurf/workflows", recursive: false, kind: "command", source: "windsurf" },
   { base: ".windsurf/hooks", recursive: false, kind: "command", source: "windsurf" },
+  { base: ".devin/skills", recursive: false, kind: "skill", source: "devin", fileName: "SKILL.md" },
+  { base: ".devin/rules", recursive: false, kind: "rule", source: "devin", extension: ".md" },
+  { base: ".devin/workflows", recursive: false, kind: "command", source: "devin" },
+  { base: ".devin/plans", recursive: false, kind: "command", source: "devin", extension: ".md" },
+  { base: ".devin/hooks", recursive: false, kind: "command", source: "devin" },
   { base: ".cursor/rules", recursive: false, kind: "rule", source: "cursor", extension: ".mdc" },
 ] satisfies EvidencePattern[];
 
@@ -188,6 +194,7 @@ function sourceLabel(source: ContextAssetSource): string {
   if (source === "codex") return "Codex";
   if (source === "cursor") return "Cursor";
   if (source === "windsurf") return "Windsurf";
+  if (source === "devin") return "Devin";
   if (source === "antigravity") return "Antigravity";
   return "repo-local";
 }

--- a/src/lib/server/platform.ts
+++ b/src/lib/server/platform.ts
@@ -23,6 +23,8 @@ export interface PlatformPaths {
   antigravityLogsRoot(): string;
   /** Root directory containing Windsurf extension host log session folders. */
   windsurfLogsRoot(): string;
+  /** Root directory containing Devin extension host log session folders. */
+  devinLogsRoot(): string;
   /** Default path for Antigravity VS Code global state database. */
   antigravityVscdbPath(): string;
   /**
@@ -49,6 +51,8 @@ function darwinPaths(): PlatformPaths {
       path.join(home, "Library", "Application Support", "Antigravity", "logs"),
     windsurfLogsRoot: () =>
       path.join(home, "Library", "Application Support", "Windsurf", "logs"),
+    devinLogsRoot: () =>
+      path.join(home, "Library", "Application Support", "Devin", "logs"),
     antigravityVscdbPath: () =>
       path.join(home, "Library", "Application Support", "Antigravity", "User", "globalStorage", "state.vscdb"),
     sqlite3Binary: () => "/usr/bin/sqlite3",
@@ -69,6 +73,8 @@ function win32Paths(env?: PlatformPathsEnv): PlatformPaths {
       path.join(appData, "Antigravity", "logs"),
     windsurfLogsRoot: () =>
       path.join(appData, "Windsurf", "logs"),
+    devinLogsRoot: () =>
+      path.join(appData, "Devin", "logs"),
     antigravityVscdbPath: () =>
       path.join(appData, "Antigravity", "User", "globalStorage", "state.vscdb"),
     // TODO: Validate — sqlite3 is not typically available on Windows by default.
@@ -91,6 +97,8 @@ function linuxPaths(env?: PlatformPathsEnv): PlatformPaths {
       path.join(configHome, "Antigravity", "logs"),
     windsurfLogsRoot: () =>
       path.join(configHome, "Windsurf", "logs"),
+    devinLogsRoot: () =>
+      path.join(configHome, "Devin", "logs"),
     antigravityVscdbPath: () =>
       path.join(configHome, "Antigravity", "User", "globalStorage", "state.vscdb"),
     sqlite3Binary: () => "/usr/bin/sqlite3",

--- a/src/lib/server/windsurf.ts
+++ b/src/lib/server/windsurf.ts
@@ -148,27 +148,29 @@ function isProcessAlive(pid: number): boolean {
 }
 
 async function listLogsDirsByMtime(): Promise<string[]> {
-  const logsRoot = platformPaths.windsurfLogsRoot();
-  let dirents: Array<{ name: string; isDirectory(): boolean }> = [];
-  try {
-    dirents = await fs.readdir(logsRoot, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  const dirs = dirents
-    .filter((d) => d.isDirectory())
-    .map((d) => path.join(logsRoot, d.name));
-
+  const logsRoots = [platformPaths.windsurfLogsRoot(), platformPaths.devinLogsRoot()];
   const withMtime: Array<{ p: string; mtimeMs: number }> = [];
-  for (const p of dirs) {
+
+  for (const logsRoot of logsRoots) {
+    let dirents: Array<{ name: string; isDirectory(): boolean }> = [];
     try {
-      const st = await fs.stat(p);
-      withMtime.push({ p, mtimeMs: st.mtimeMs });
+      dirents = await fs.readdir(logsRoot, { withFileTypes: true });
     } catch {
-      // ignore
+      continue;
+    }
+
+    for (const d of dirents) {
+      if (!d.isDirectory()) continue;
+      const p = path.join(logsRoot, d.name);
+      try {
+        const st = await fs.stat(p);
+        withMtime.push({ p, mtimeMs: st.mtimeMs });
+      } catch {
+        // ignore
+      }
     }
   }
+
   withMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
   return withMtime.map((x) => x.p);
 }
@@ -192,12 +194,16 @@ async function findLatestWindsurfLogFile(): Promise<string | null> {
     for (const d of windowDirents) {
       if (!d.isDirectory()) continue;
       if (!d.name.startsWith("window")) continue;
-      const p = path.join(logsDir, d.name, "exthost", "codeium.windsurf", "Windsurf.log");
-      try {
-        const st = await fs.stat(p);
-        if (st.isFile()) candidates.push({ p, mtimeMs: st.mtimeMs });
-      } catch {
-        // ignore
+      // Search for both Windsurf.log (legacy) and Devin.log (rebranded product).
+      // Both have identical format and contain the same LS pid/port start info.
+      for (const logFileName of ["Windsurf.log", "Devin.log"] as const) {
+        const p = path.join(logsDir, d.name, "exthost", "codeium.windsurf", logFileName);
+        try {
+          const st = await fs.stat(p);
+          if (st.isFile()) candidates.push({ p, mtimeMs: st.mtimeMs });
+        } catch {
+          // ignore
+        }
       }
     }
   }

--- a/src/lib/server/windsurf.ts
+++ b/src/lib/server/windsurf.ts
@@ -175,7 +175,7 @@ async function listLogsDirsByMtime(): Promise<string[]> {
   return withMtime.map((x) => x.p);
 }
 
-async function findLatestWindsurfLogFile(): Promise<string | null> {
+export async function findLatestCascadeLogFile(): Promise<string | null> {
   const logDirs = await listLogsDirsByMtime();
   // Some Windsurf log session folders may exist without containing the extension host logs
   // (e.g. created during startup). Scan all available session folders; in practice the
@@ -242,12 +242,12 @@ async function readProcessCommandLine(pid: number): Promise<string | null> {
 }
 
 async function resolveWindsurfConnection(config: AppConfig): Promise<WindsurfConnection> {
-  const logPath = await findLatestWindsurfLogFile();
+  const logPath = await findLatestCascadeLogFile();
   if (!logPath) throw new Error("Windsurf log not found. Open Windsurf and start a Cascade session.");
 
   const logText = await fs.readFile(logPath, "utf-8").catch(() => "");
   const startInfo = extractLatestWindsurfStartInfoFromLog(logText);
-  if (!startInfo) throw new Error("Failed to parse Windsurf language server pid/port from log.");
+  if (!startInfo) throw new Error("Failed to parse language server pid/port from the IDE log.");
   if (!isProcessAlive(startInfo.pid)) {
     throw new Error("Windsurf language server is not running. Keep Windsurf open and start a Cascade session.");
   }
@@ -288,7 +288,7 @@ async function resolveWindsurfConnection(config: AppConfig): Promise<WindsurfCon
 }
 
 export async function getWindsurfStatus(config: AppConfig): Promise<SourcesStatus["windsurf"]> {
-  const logPath = await findLatestWindsurfLogFile();
+  const logPath = await findLatestCascadeLogFile();
   if (!logPath) {
     const recommendedAction = "Open Windsurf and start a Cascade session.";
     return {
@@ -304,15 +304,15 @@ export async function getWindsurfStatus(config: AppConfig): Promise<SourcesStatu
   const logText = await fs.readFile(logPath, "utf-8").catch(() => "");
   const startInfo = extractLatestWindsurfStartInfoFromLog(logText);
   if (!startInfo) {
-    const recommendedAction = "Start a Cascade session in Windsurf so pid/port are logged.";
+    const recommendedAction = "Start a Cascade session so pid/port are logged.";
     return {
       attached: false,
       attachMethod: "log",
       logPath,
       csrfTokenSource: "none",
       recommendedAction,
-      lastError: "Failed to parse pid/port from Windsurf.log.",
-      error: `Failed to parse pid/port from Windsurf.log. ${recommendedAction}`
+      lastError: "Failed to parse pid/port from the IDE log.",
+      error: `Failed to parse pid/port from the IDE log. ${recommendedAction}`
     };
   }
 

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -16,6 +16,9 @@ describe("createPlatformPaths", () => {
       expect(p.windsurfLogsRoot()).toBe(
         path.join(home, "Library", "Application Support", "Windsurf", "logs")
       );
+      expect(p.devinLogsRoot()).toBe(
+        path.join(home, "Library", "Application Support", "Devin", "logs")
+      );
       expect(p.antigravityVscdbPath()).toBe(
         path.join(home, "Library", "Application Support", "Antigravity", "User", "globalStorage", "state.vscdb")
       );
@@ -32,6 +35,9 @@ describe("createPlatformPaths", () => {
       expect(p.windsurfLogsRoot()).toBe(
         path.join("/mock/AppData/Roaming", "Windsurf", "logs")
       );
+      expect(p.devinLogsRoot()).toBe(
+        path.join("/mock/AppData/Roaming", "Devin", "logs")
+      );
       expect(p.antigravityVscdbPath()).toBe(
         path.join("/mock/AppData/Roaming", "Antigravity", "User", "globalStorage", "state.vscdb")
       );
@@ -44,6 +50,7 @@ describe("createPlatformPaths", () => {
 
       expect(p.antigravityLogsRoot()).toBe(path.join(expected, "Antigravity", "logs"));
       expect(p.windsurfLogsRoot()).toBe(path.join(expected, "Windsurf", "logs"));
+      expect(p.devinLogsRoot()).toBe(path.join(expected, "Devin", "logs"));
     });
 
     it("treats empty APPDATA as unset", () => {
@@ -73,6 +80,9 @@ describe("createPlatformPaths", () => {
       expect(p.windsurfLogsRoot()).toBe(
         path.join("/mock/.config", "Windsurf", "logs")
       );
+      expect(p.devinLogsRoot()).toBe(
+        path.join("/mock/.config", "Devin", "logs")
+      );
       expect(p.antigravityVscdbPath()).toBe(
         path.join("/mock/.config", "Antigravity", "User", "globalStorage", "state.vscdb")
       );
@@ -85,6 +95,7 @@ describe("createPlatformPaths", () => {
 
       expect(p.antigravityLogsRoot()).toBe(path.join(expected, "Antigravity", "logs"));
       expect(p.windsurfLogsRoot()).toBe(path.join(expected, "Windsurf", "logs"));
+      expect(p.devinLogsRoot()).toBe(path.join(expected, "Devin", "logs"));
     });
 
     it("treats empty XDG_CONFIG_HOME as unset", () => {
@@ -118,6 +129,7 @@ describe("createPlatformPaths", () => {
         const p = createPlatformPaths(platform);
         expect(p.antigravityLogsRoot().length).toBeGreaterThan(0);
         expect(p.windsurfLogsRoot().length).toBeGreaterThan(0);
+        expect(p.devinLogsRoot().length).toBeGreaterThan(0);
         expect(p.antigravityVscdbPath().length).toBeGreaterThan(0);
       }
     });

--- a/tests/projectEvidenceProvider.test.ts
+++ b/tests/projectEvidenceProvider.test.ts
@@ -72,6 +72,12 @@ describe("discoverProjectEvidence", () => {
       ".windsurf/workflows/opsx-apply.md": "# Windsurf workflow",
       ".windsurf/hooks.json": "{}",
       ".windsurf/hooks/guard.py": "print('guard')",
+      ".devin/skills/ops/SKILL.md": "# Devin skill",
+      ".devin/rules/engineering.md": "# Devin rule",
+      ".devin/workflows/opsx-apply.md": "# Devin workflow",
+      ".devin/plans/compat.md": "# Devin plan",
+      ".devin/hooks.json": "{}",
+      ".devin/hooks/guard.py": "print('guard')",
       ".cursor/mcp.json": "{\"mcpServers\":{}}",
       ".cursorrules": "Always prefer local-first behavior",
       ".cursor/rules/repo.mdc": "---\ndescription: Repo rule\n---\nUse project conventions",
@@ -86,6 +92,9 @@ describe("discoverProjectEvidence", () => {
     expect(paths).toContain(".codex/hooks.json");
     expect(paths).toContain(".windsurf/workflows/opsx-apply.md");
     expect(paths).toContain(".windsurf/hooks/guard.py");
+    expect(paths).toContain(".devin/workflows/opsx-apply.md");
+    expect(paths).toContain(".devin/plans/compat.md");
+    expect(paths).toContain(".devin/hooks/guard.py");
     expect(paths).toContain(".cursor/mcp.json");
     expect(paths).toContain(".cursorrules");
     expect(paths).toContain(".cursor/rules/repo.mdc");

--- a/tests/windsurfLogDiscovery.test.ts
+++ b/tests/windsurfLogDiscovery.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+const fsMock = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  stat: vi.fn(),
+  readFile: vi.fn()
+}));
+
+const platformMock = vi.hoisted(() => ({
+  windsurfLogsRoot: vi.fn(),
+  devinLogsRoot: vi.fn()
+}));
+
+vi.mock("node:fs/promises", () => ({ default: fsMock }));
+vi.mock("@/lib/server/platform", () => ({ platformPaths: platformMock }));
+
+import { findLatestCascadeLogFile } from "../src/lib/server/windsurf";
+
+describe("findLatestCascadeLogFile", () => {
+  it("prefers the newest Devin.log when it has a live pid", async () => {
+    platformMock.windsurfLogsRoot.mockReturnValue("/logs/windsurf");
+    platformMock.devinLogsRoot.mockReturnValue("/logs/devin");
+
+    const windsurfDir = "/logs/windsurf/20260621T100000";
+    const devinDir = "/logs/devin/20260621T110000";
+    const windsurfLog = "/logs/windsurf/20260621T100000/window1/exthost/codeium.windsurf/Windsurf.log";
+    const devinLog = "/logs/devin/20260621T110000/window1/exthost/codeium.windsurf/Devin.log";
+
+    const makeDirent = (name: string, dir = true) => ({ name, isDirectory: () => dir });
+
+    fsMock.readdir.mockImplementation(async (p: unknown, options?: unknown) => {
+      const str = String(p);
+      const withFileTypes =
+        options && typeof options === "object" && (options as { withFileTypes?: boolean }).withFileTypes;
+      if (!withFileTypes) return [];
+      if (str === "/logs/windsurf") return [makeDirent("20260621T100000")];
+      if (str === "/logs/devin") return [makeDirent("20260621T110000")];
+      if (str === windsurfDir) return [makeDirent("window1")];
+      if (str === devinDir) return [makeDirent("window1")];
+      return [];
+    });
+
+    fsMock.stat.mockImplementation(async (p: unknown) => {
+      const str = String(p);
+      const isFile = str.endsWith(".log");
+      let mtimeMs = 0;
+      if (str === windsurfDir || str === windsurfLog) mtimeMs = 1000;
+      else if (str === devinDir || str === devinLog) mtimeMs = 2000;
+      return { isFile: () => isFile, isDirectory: () => !isFile, mtimeMs };
+    });
+
+    fsMock.readFile.mockImplementation(async (p: unknown) => {
+      const str = String(p);
+      if (str === windsurfLog) {
+        return "Starting language server process with pid 99999\nLanguage server listening on random port at 55555";
+      }
+      if (str === devinLog) {
+        return "Starting language server process with pid 12345\nLanguage server listening on random port at 55556";
+      }
+      throw new Error("ENOENT");
+    });
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((pid: number) => {
+      if (pid === 12345) return true;
+      throw new Error("ESRCH");
+    });
+
+    try {
+      const result = await findLatestCascadeLogFile();
+      expect(result).toBe(devinLog);
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+});

--- a/tests/windsurfStatus.test.ts
+++ b/tests/windsurfStatus.test.ts
@@ -71,10 +71,10 @@ describe("getWindsurfRecommendedAction", () => {
   });
 
   it("maps tokenRequired=false to session restart guidance", () => {
-    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: false })).toContain("start/restart");
+    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: false })).toContain("Windsurf");
   });
 
   it("maps tokenRequired=undefined to invalid/expired-token guidance", () => {
-    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: undefined })).toContain("invalid or expired");
+    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: undefined })).toContain("Windsurf");
   });
 });

--- a/tests/windsurfStatus.test.ts
+++ b/tests/windsurfStatus.test.ts
@@ -71,10 +71,16 @@ describe("getWindsurfRecommendedAction", () => {
   });
 
   it("maps tokenRequired=false to session restart guidance", () => {
-    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: false })).toContain("Windsurf");
+    const action = getWindsurfRecommendedAction({ attached: false, tokenRequired: false });
+    expect(action).toContain("start/restart");
+    expect(action).toContain("Windsurf");
+    expect(action).toContain("Cascade");
   });
 
   it("maps tokenRequired=undefined to invalid/expired-token guidance", () => {
-    expect(getWindsurfRecommendedAction({ attached: false, tokenRequired: undefined })).toContain("Windsurf");
+    const action = getWindsurfRecommendedAction({ attached: false, tokenRequired: undefined });
+    expect(action).toContain("invalid or expired");
+    expect(action).toContain("Windsurf");
+    expect(action).toContain("Cascade");
   });
 });


### PR DESCRIPTION
## Summary

Devin is a rebrand of Windsurf. This PR adapts Agent Steward to the rebrand without breaking existing Windsurf support.

### Changes

**Asset discovery & wording (commit 36b43f6)**
- `.devin/` directories (skills, rules, workflows, plans, hooks) now discovered alongside `.windsurf/`
- New `ContextAssetSource` value `"devin"` for `.devin/` assets; `"windsurf"` remains for `.windsurf/`
- Diagnostics and UI wording corrected: product = `Windsurf` or `Devin` (no compound labels); runtime = `Cascade` (no "legacy")
- Affected files: `contextAssets.ts`, `projectEvidenceProvider.ts`, `ProjectShellClient.tsx`, `windsurfStatus.ts`, `SettingsClient.tsx`, `HomeClient.tsx`, `BackupMigrationFoundation.tsx`

**Storage investigation (commit 5e34eaa)**
- Documented Devin Desktop storage layout in `docs/storage/local-storage-notes.md`
- Cascade runtime: identical LS process, same CSRF token env var (`WINDSURF_CSRF_TOKEN`), same `.pb` session path
- Devin Local runtime: ACP protocol, sessions in `~/.local/share/devin/cli/sessions.db` (SQLite, full schema documented)
- Devin Cloud runtime: remote WebSocket ACP, no local session storage

**Cascade LS attach (commit 19355b9)**
- `PlatformPaths` interface: added `devinLogsRoot()` for all platforms
- `listLogsDirsByMtime()`: scans both Windsurf and Devin log root directories
- `findLatestWindsurfLogFile()`: searches for both `Windsurf.log` and `Devin.log` file names
- Enables session reading when only Devin Desktop is running (no Windsurf installed)

### QA evidence

- Browser QA performed on `localhost:3002`:
  - Settings page: wording correct (no compound labels, no "legacy")
  - Assets page: `.devin/` to source "Devin", `.windsurf/` to source "Windsurf"
  - Cascade attach: `/api/sources` confirms `logPath: ".../Devin/logs/.../Devin.log"`, `attached: true`, `heartbeatOk: true`, `recommendedAction: "Connection healthy."`
  - Session recoverability wording: not directly observable (all sessions readable), covered by unit tests
- Unit tests: 560/560 passed

### Scope & known limitations

- No new Devin local session storage parsing (deferred to future PR)
- No `Source` type changes (session-level source remains `"windsurf"`)
- No new default roots in `config.ts`
- **Devin Desktop Cascade sessions**: `.pb` files live in the shared `~/.codeium/windsurf/cascade/` directory and are readable by the existing Windsurf root, but session metadata (`title`, `cwd`, `lastActivity`) is written to the IDE's own `state.vscdb`. Agent Steward currently reads Windsurf's `state.vscdb`, so sessions created only in Devin IDE may appear without metadata until Devin's `state.vscdb` is also read.
- **Devin CLI `sessions.db`**: schema is documented, but not parsed. Initial inspection shows all 25 recorded sessions have `backend_type` `Windsurf`/`windsurf`, meaning the Devin Local runtime session storage path is still unlocated.
- **Devin Cloud**: sessions are remote (`wss://app.devin.ai`) and have no local storage; not supported.
